### PR TITLE
feat: header layout staging

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -43,6 +43,7 @@ python3 scripts/dump_headers
 - `--category <frameworks|private>`: 対象カテゴリを限定（複数指定可）
 - `--framework <name>`: 指定したフレームワークのみダンプ（複数指定可、`.framework` は省略可）
 - `--filter <substring>`: フレームワーク名の部分一致フィルタ（複数指定可）
+- `--layout <bundle|headers>`: 出力レイアウト（`bundle` は `.framework` を保持、`headers` は `.framework` を外す）
 - `--list-runtimes`: 利用可能な iOS ランタイム一覧を表示して終了
 - `--list-devices`: ランタイム内のデバイス一覧を表示して終了（`--runtime` 併用）
 - `--runtime <version>`: `--list-devices` 用のランタイム指定
@@ -54,7 +55,8 @@ python3 scripts/dump_headers
 - サブモジュールが未初期化なら `git submodule update --init --recursive` を自動実行します。
 - Python 3 が必要です。
 - `simulator` モード時は `xcrun simctl spawn` 経由です。
-- 環境変数で上書き可能: `PH_EXEC_MODE`, `PH_OUT_DIR`, `PH_SKIP_EXISTING=1`
+- ダンプ中の一時出力は `<out>/.tmp` に作成し、最後にレイアウトへ移動します。
+- 環境変数で上書き可能: `PH_EXEC_MODE`, `PH_OUT_DIR`, `PH_SKIP_EXISTING=1`, `PH_LAYOUT`
 
 ## ライセンス
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -38,7 +38,7 @@ python3 scripts/dump_headers
 
 - `--device <udid|name>`: 対象シミュレーターを指定
 - `--out <dir>`: 出力先を指定
-- `--skip-existing`: 既存ヘッダの上書きを避ける
+- `--force`: 既存ヘッダがあっても常に再生成する
 - `--exec-mode <host|simulator>`: 実行モードを強制（デフォルトは host）
 - `--category <frameworks|private>`: 対象カテゴリを限定（複数指定可）
 - `--framework <name>`: 指定したフレームワークのみダンプ（複数指定可、`.framework` は省略可）
@@ -57,7 +57,7 @@ python3 scripts/dump_headers
 - `simulator` モード時は `xcrun simctl spawn` 経由です。
 - ダンプ中の一時出力は `<out>/.tmp-<run-id>` に作成し、最後にレイアウトへ移動します。
 - 実行中は出力ディレクトリをロックして、同時書き込みを防ぎます。
-- 環境変数で上書き可能: `PH_EXEC_MODE`, `PH_OUT_DIR`, `PH_SKIP_EXISTING=1`, `PH_LAYOUT`
+- 環境変数で上書き可能: `PH_EXEC_MODE`, `PH_OUT_DIR`, `PH_FORCE=1|0`, `PH_SKIP_EXISTING=1|0`, `PH_LAYOUT`
 
 ## ライセンス
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -55,7 +55,8 @@ python3 scripts/dump_headers
 - サブモジュールが未初期化なら `git submodule update --init --recursive` を自動実行します。
 - Python 3 が必要です。
 - `simulator` モード時は `xcrun simctl spawn` 経由です。
-- ダンプ中の一時出力は `<out>/.tmp` に作成し、最後にレイアウトへ移動します。
+- ダンプ中の一時出力は `<out>/.tmp-<run-id>` に作成し、最後にレイアウトへ移動します。
+- 実行中は出力ディレクトリをロックして、同時書き込みを防ぎます。
 - 環境変数で上書き可能: `PH_EXEC_MODE`, `PH_OUT_DIR`, `PH_SKIP_EXISTING=1`, `PH_LAYOUT`
 
 ## ライセンス

--- a/README.md
+++ b/README.md
@@ -54,7 +54,8 @@ This dumps both `Frameworks` and `PrivateFrameworks`.
 - If the submodule isn't initialized, the script runs `git submodule update --init --recursive`.
 - Requires Python 3.
 - Simulator mode uses `xcrun simctl spawn`.
-- During dumping, raw output is staged under `<out>/.tmp` and then moved to the final layout.
+- During dumping, raw output is staged under `<out>/.tmp-<run-id>` and then moved to the final layout.
+- The output directory is locked for the duration of a run to avoid concurrent writes.
 - Environment overrides: `PH_EXEC_MODE`, `PH_OUT_DIR`, `PH_SKIP_EXISTING=1`, `PH_LAYOUT`
 
 ## License

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ This dumps both `Frameworks` and `PrivateFrameworks`.
 - `--exec-mode <host|simulator>`: Force execution mode (default: host if available)
 - `--framework <name>`: Dump only the exact framework name (repeatable, `.framework` optional)
 - `--filter <substring>`: Substring filter for framework names (repeatable)
+- `--layout <bundle|headers>`: Output layout (`bundle` keeps `.framework` dirs, `headers` removes the `.framework` suffix)
 - `--list-runtimes`: List available iOS runtimes and exit
 - `--list-devices`: List devices for a runtime and exit (use `--runtime`)
 - `--runtime <version>`: Runtime version for `--list-devices`
@@ -53,7 +54,8 @@ This dumps both `Frameworks` and `PrivateFrameworks`.
 - If the submodule isn't initialized, the script runs `git submodule update --init --recursive`.
 - Requires Python 3.
 - Simulator mode uses `xcrun simctl spawn`.
-- Environment overrides: `PH_EXEC_MODE`, `PH_OUT_DIR`, `PH_SKIP_EXISTING=1`
+- During dumping, raw output is staged under `<out>/.tmp` and then moved to the final layout.
+- Environment overrides: `PH_EXEC_MODE`, `PH_OUT_DIR`, `PH_SKIP_EXISTING=1`, `PH_LAYOUT`
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ This dumps both `Frameworks` and `PrivateFrameworks`.
 
 - `--device <udid|name>`: Choose a simulator device
 - `--out <dir>`: Output directory
-- `--skip-existing`: Skip headers that already exist
+- `--force`: Always dump headers even if they already exist
 - `--exec-mode <host|simulator>`: Force execution mode (default: host if available)
 - `--framework <name>`: Dump only the exact framework name (repeatable, `.framework` optional)
 - `--filter <substring>`: Substring filter for framework names (repeatable)
@@ -56,7 +56,7 @@ This dumps both `Frameworks` and `PrivateFrameworks`.
 - Simulator mode uses `xcrun simctl spawn`.
 - During dumping, raw output is staged under `<out>/.tmp-<run-id>` and then moved to the final layout.
 - The output directory is locked for the duration of a run to avoid concurrent writes.
-- Environment overrides: `PH_EXEC_MODE`, `PH_OUT_DIR`, `PH_SKIP_EXISTING=1`, `PH_LAYOUT`
+- Environment overrides: `PH_EXEC_MODE`, `PH_OUT_DIR`, `PH_FORCE=1|0`, `PH_SKIP_EXISTING=1|0`, `PH_LAYOUT`
 
 ## License
 

--- a/scripts/dump_headers
+++ b/scripts/dump_headers
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import argparse
 import atexit
+import fcntl
 import json
 import os
 import shutil
@@ -50,6 +51,7 @@ class Context:
 
 _CLEANUP_PATHS: set[Path] = set()
 _CLEANUP_INSTALLED = False
+_ACTIVE_PROC: subprocess.Popen | None = None
 
 
 def register_cleanup(path: Path) -> None:
@@ -64,14 +66,26 @@ def register_cleanup(path: Path) -> None:
 
 def run_cleanup() -> None:
     for path in list(_CLEANUP_PATHS):
-        if path.exists():
+        if not path.exists():
+            continue
+        if path.is_dir():
             shutil.rmtree(path, ignore_errors=True)
+            continue
+        try:
+            path.unlink()
+        except Exception:
+            pass
 
 
 def install_signal_handlers() -> None:
     def handler(_signum, _frame) -> None:
-        run_cleanup()
-        raise SystemExit(130)
+        global _ACTIVE_PROC
+        if _ACTIVE_PROC is not None:
+            try:
+                _ACTIVE_PROC.terminate()
+            except Exception:
+                pass
+        raise KeyboardInterrupt
 
     for sig in (signal.SIGINT, signal.SIGTERM):
         try:
@@ -83,6 +97,28 @@ def install_signal_handlers() -> None:
             signal.signal(signal.SIGHUP, handler)
         except Exception:
             pass
+
+
+def build_stage_dir(out_dir: Path) -> Path:
+    token = f"{os.getpid()}-{datetime.now().strftime('%Y%m%d%H%M%S')}"
+    return out_dir / f".tmp-{token}"
+
+
+def acquire_output_lock(out_dir: Path):
+    lock_path = out_dir / ".dump_headers.lock"
+    lock_file = lock_path.open("a+", encoding="utf-8")
+    try:
+        fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except BlockingIOError as exc:
+        lock_file.close()
+        raise RuntimeError(f"output directory is locked: {out_dir}") from exc
+    lock_file.seek(0)
+    lock_file.truncate()
+    lock_file.write(
+        f"pid={os.getpid()}\nstarted={datetime.now().isoformat(timespec='seconds')}\n"
+    )
+    lock_file.flush()
+    return lock_file
 
 
 def main() -> int:
@@ -118,6 +154,7 @@ def main() -> int:
     args = parser.parse_args()
 
     ctx: Context | None = None
+    lock_file = None
     try:
         if args.list_runtimes:
             list_runtimes_command(args.json)
@@ -186,6 +223,8 @@ def main() -> int:
                 device.state = "Booted"
 
         ctx.out_dir.mkdir(parents=True, exist_ok=True)
+        lock_file = acquire_output_lock(ctx.out_dir)
+        register_cleanup(ctx.out_dir / ".dump_headers.lock")
         register_cleanup(ctx.stage_dir)
         prepare_output_layout(ctx)
 
@@ -204,6 +243,8 @@ def main() -> int:
         print(f"Error: {exc}", file=sys.stderr)
         return 1
     finally:
+        if lock_file is not None:
+            lock_file.close()
         if ctx is not None:
             run_cleanup()
 
@@ -388,7 +429,7 @@ def interactive_setup(
         args.out
         or Path(os.getenv("PH_OUT_DIR")) if os.getenv("PH_OUT_DIR") else None
     ) or default_out
-    stage_dir = out_dir / ".tmp"
+    stage_dir = build_stage_dir(out_dir)
     skip_existing = args.skip_existing or os.getenv("PH_SKIP_EXISTING") == "1"
 
     if device:
@@ -442,7 +483,7 @@ def non_interactive_setup(
             device = pick_default_device(devices)
 
     out_dir = args.out or root_dir / "generated-headers/iOS" / version
-    stage_dir = out_dir / ".tmp"
+    stage_dir = build_stage_dir(out_dir)
 
     return Context(
         exec_mode=exec_mode,
@@ -837,6 +878,7 @@ def run_classdump_simulator(category: str, ctx: Context) -> tuple[int, bool, lis
 
 
 def run_command_stream(cmd: list[str], env: dict | None = None) -> tuple[int, bool, list[str]]:
+    global _ACTIVE_PROC
     proc = subprocess.Popen(
         cmd,
         stdout=subprocess.PIPE,
@@ -845,20 +887,41 @@ def run_command_stream(cmd: list[str], env: dict | None = None) -> tuple[int, bo
         env=env,
         bufsize=1,
     )
+    _ACTIVE_PROC = proc
     last_lines: deque[str] = deque(maxlen=8)
     killed = False
-    if proc.stdout:
-        for line in proc.stdout:
-            line = line.rstrip()
-            if line:
-                print(line, flush=True)
-                last_lines.append(line)
-                if "Killed: 9" in line or "killed: 9" in line:
-                    killed = True
-    returncode = proc.wait()
-    if returncode == -9:
-        killed = True
-    return returncode, killed, list(last_lines)
+    try:
+        if proc.stdout:
+            for line in proc.stdout:
+                line = line.rstrip()
+                if line:
+                    print(line, flush=True)
+                    last_lines.append(line)
+                    if "Killed: 9" in line or "killed: 9" in line:
+                        killed = True
+        returncode = proc.wait()
+        if returncode == -9:
+            killed = True
+        return returncode, killed, list(last_lines)
+    except KeyboardInterrupt:
+        try:
+            proc.terminate()
+        except Exception:
+            pass
+        try:
+            proc.wait(timeout=5)
+        except Exception:
+            try:
+                proc.kill()
+            except Exception:
+                pass
+            try:
+                proc.wait(timeout=5)
+            except Exception:
+                pass
+        raise
+    finally:
+        _ACTIVE_PROC = None
 
 
 def report_last_lines(lines: list[str]) -> None:

--- a/scripts/dump_headers
+++ b/scripts/dump_headers
@@ -1034,7 +1034,6 @@ def needs_split(ctx: Context) -> bool:
         ctx.exec_mode == "simulator"
         or ctx.framework_names
         or ctx.framework_filters
-        or ctx.layout == "headers"
     )
 
 

--- a/scripts/dump_headers
+++ b/scripts/dump_headers
@@ -2,9 +2,11 @@
 from __future__ import annotations
 
 import argparse
+import atexit
 import json
 import os
 import shutil
+import signal
 import subprocess
 import sys
 from collections import deque
@@ -38,10 +40,49 @@ class Context:
     runtime_build: str
     device: DeviceInfo | None
     out_dir: Path
+    stage_dir: Path
     skip_existing: bool
+    layout: str
     categories: list[str]
     framework_names: set[str]
     framework_filters: list[str]
+
+
+_CLEANUP_PATHS: set[Path] = set()
+_CLEANUP_INSTALLED = False
+
+
+def register_cleanup(path: Path) -> None:
+    global _CLEANUP_INSTALLED
+    _CLEANUP_PATHS.add(path)
+    if _CLEANUP_INSTALLED:
+        return
+    _CLEANUP_INSTALLED = True
+    atexit.register(run_cleanup)
+    install_signal_handlers()
+
+
+def run_cleanup() -> None:
+    for path in list(_CLEANUP_PATHS):
+        if path.exists():
+            shutil.rmtree(path, ignore_errors=True)
+
+
+def install_signal_handlers() -> None:
+    def handler(_signum, _frame) -> None:
+        run_cleanup()
+        raise SystemExit(130)
+
+    for sig in (signal.SIGINT, signal.SIGTERM):
+        try:
+            signal.signal(sig, handler)
+        except Exception:
+            continue
+    if hasattr(signal, "SIGHUP"):
+        try:
+            signal.signal(signal.SIGHUP, handler)
+        except Exception:
+            pass
 
 
 def main() -> int:
@@ -59,6 +100,11 @@ def main() -> int:
     parser.add_argument("--runtime", help="Runtime version for --list-devices")
     parser.add_argument("--json", action="store_true", help="JSON output for list commands")
     parser.add_argument(
+        "--layout",
+        choices=["bundle", "headers"],
+        help="Output layout (bundle: .framework dirs, headers: plain dirs without suffix)",
+    )
+    parser.add_argument(
         "--framework",
         action="append",
         help="Exact framework name to dump (repeatable)",
@@ -71,6 +117,7 @@ def main() -> int:
 
     args = parser.parse_args()
 
+    ctx: Context | None = None
     try:
         if args.list_runtimes:
             list_runtimes_command(args.json)
@@ -95,6 +142,7 @@ def main() -> int:
         )
 
         categories, framework_names, framework_filters = build_selection(args)
+        layout = resolve_layout(args.layout)
 
         if args.version:
             ctx = non_interactive_setup(
@@ -105,6 +153,7 @@ def main() -> int:
                 categories,
                 framework_names,
                 framework_filters,
+                layout,
             )
         else:
             ctx = interactive_setup(
@@ -115,6 +164,7 @@ def main() -> int:
                 categories,
                 framework_names,
                 framework_filters,
+                layout,
             )
 
         if ctx.exec_mode == "simulator":
@@ -136,17 +186,26 @@ def main() -> int:
                 device.state = "Booted"
 
         ctx.out_dir.mkdir(parents=True, exist_ok=True)
+        register_cleanup(ctx.stage_dir)
+        prepare_output_layout(ctx)
 
         for category in ctx.categories:
+            reset_stage_dir(ctx)
             dump_category(category, ctx)
-            relocate_output(ctx, category)
+            finalize_category_output(ctx, category)
 
         write_metadata(ctx)
         print(f"Done: {ctx.out_dir}")
         return 0
+    except KeyboardInterrupt:
+        print("Interrupted", file=sys.stderr)
+        return 130
     except RuntimeError as exc:
         print(f"Error: {exc}", file=sys.stderr)
         return 1
+    finally:
+        if ctx is not None:
+            run_cleanup()
 
 
 def resolve_exec_mode(
@@ -163,6 +222,13 @@ def resolve_exec_mode(
     raise RuntimeError(
         "classdump-dyld binary not found in macosx, iphonesimulator, or iphoneos directories"
     )
+
+
+def resolve_layout(requested: str | None) -> str:
+    layout = (requested or os.getenv("PH_LAYOUT") or "headers").strip().lower()
+    if layout not in ("bundle", "headers"):
+        raise RuntimeError(f"invalid layout: {layout}")
+    return layout
 
 
 def build_selection(args) -> tuple[list[str], set[str], list[str]]:
@@ -290,6 +356,7 @@ def interactive_setup(
     categories: list[str],
     framework_names: set[str],
     framework_filters: list[str],
+    layout: str,
 ) -> Context:
     print("Interactive mode")
     runtimes = list_runtimes()
@@ -321,6 +388,7 @@ def interactive_setup(
         args.out
         or Path(os.getenv("PH_OUT_DIR")) if os.getenv("PH_OUT_DIR") else None
     ) or default_out
+    stage_dir = out_dir / ".tmp"
     skip_existing = args.skip_existing or os.getenv("PH_SKIP_EXISTING") == "1"
 
     if device:
@@ -336,7 +404,9 @@ def interactive_setup(
         runtime_build=runtime.build,
         device=device,
         out_dir=out_dir.resolve(),
+        stage_dir=stage_dir.resolve(),
         skip_existing=skip_existing,
+        layout=layout,
         categories=categories,
         framework_names=framework_names,
         framework_filters=framework_filters,
@@ -351,6 +421,7 @@ def non_interactive_setup(
     categories: list[str],
     framework_names: set[str],
     framework_filters: list[str],
+    layout: str,
 ) -> Context:
     version = args.version or ""
     runtime = find_runtime(version)
@@ -371,6 +442,7 @@ def non_interactive_setup(
             device = pick_default_device(devices)
 
     out_dir = args.out or root_dir / "generated-headers/iOS" / version
+    stage_dir = out_dir / ".tmp"
 
     return Context(
         exec_mode=exec_mode,
@@ -381,7 +453,9 @@ def non_interactive_setup(
         runtime_build=runtime.build,
         device=device,
         out_dir=out_dir.resolve(),
+        stage_dir=stage_dir.resolve(),
         skip_existing=args.skip_existing,
+        layout=layout,
         categories=categories,
         framework_names=framework_names,
         framework_filters=framework_filters,
@@ -568,21 +642,149 @@ def dump_category_split(category: str, ctx: Context) -> None:
         if killed or status != 0:
             report_last_lines(last_lines)
             failures.append(path)
+        else:
+            relocate_framework_output(ctx, category, item)
+            if ctx.layout == "headers":
+                normalize_framework_dir(ctx, category, item)
     if failures:
         summary = f"classdump-dyld failed for {len(failures)} items under {category}"
         print(summary, file=sys.stderr)
         write_failures(ctx, summary, failures)
 
 
-def relocate_output(ctx: Context, category: str) -> None:
-    src = ctx.out_dir / "System" / "Library" / category
-    if not src.exists():
+def relocate_framework_output(ctx: Context, category: str, framework_name: str) -> None:
+    src = ctx.stage_dir / "System" / "Library" / category / framework_name
+    if not src.exists() or src.is_symlink():
         return
-    dest = ctx.out_dir / category
-    merge_directories(src, dest)
-    try_remove_empty(src)
-    try_remove_empty(src.parent)
-    try_remove_empty(src.parent.parent)
+    dest_dir = ctx.out_dir / category
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    dest = dest_dir / framework_name
+    if dest.exists():
+        merge_directories(src, dest)
+        try_remove_empty(src)
+    else:
+        shutil.move(str(src), str(dest))
+
+
+def relocate_frameworks_in_category(ctx: Context, category: str) -> None:
+    src_dir = ctx.stage_dir / "System" / "Library" / category
+    if not src_dir.is_dir() or src_dir.is_symlink():
+        return
+    dest_dir = ctx.out_dir / category
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    for entry in src_dir.iterdir():
+        if entry.is_symlink():
+            continue
+        dest = dest_dir / entry.name
+        if dest.exists():
+            if entry.is_dir():
+                merge_directories(entry, dest)
+                try_remove_empty(entry)
+            else:
+                entry.unlink()
+        else:
+            shutil.move(str(entry), str(dest))
+
+
+def prepare_output_layout(ctx: Context) -> None:
+    for category in ctx.categories:
+        if ctx.layout == "headers":
+            normalize_framework_dirs(ctx, category)
+        else:
+            denormalize_framework_dirs(ctx, category)
+
+
+def reset_stage_dir(ctx: Context) -> None:
+    if ctx.stage_dir.exists():
+        shutil.rmtree(ctx.stage_dir)
+    ctx.stage_dir.mkdir(parents=True, exist_ok=True)
+
+
+def finalize_category_output(ctx: Context, category: str) -> None:
+    relocate_frameworks_in_category(ctx, category)
+    if ctx.layout == "headers":
+        normalize_framework_dirs(ctx, category)
+
+
+def normalize_framework_dirs(ctx: Context, category: str) -> None:
+    base = ctx.out_dir / category
+    if not base.is_dir():
+        return
+    framework_ext = ".framework"
+    entries = list(base.iterdir())
+    for entry in entries:
+        if entry.is_symlink() and entry.name.endswith(framework_ext):
+            entry.unlink()
+    for entry in entries:
+        if entry.is_symlink():
+            continue
+        if not entry.is_dir():
+            continue
+        if not entry.name.endswith(framework_ext):
+            continue
+        framework_name = entry.name
+        target_name = framework_name[: -len(framework_ext)]
+        target = base / target_name
+        if target.exists():
+            if target.is_symlink():
+                target.unlink()
+            if target.exists():
+                merge_directories(entry, target)
+                try_remove_empty(entry)
+            else:
+                entry.rename(target)
+        else:
+            entry.rename(target)
+
+
+def normalize_framework_dir(ctx: Context, category: str, framework_name: str) -> None:
+    base = ctx.out_dir / category
+    if not base.is_dir():
+        return
+    framework_ext = ".framework"
+    if not framework_name.endswith(framework_ext):
+        return
+    entry = base / framework_name
+    if entry.is_symlink() or not entry.is_dir():
+        return
+    target = base / framework_name[: -len(framework_ext)]
+    if target.exists():
+        if target.is_symlink():
+            target.unlink()
+        if target.exists():
+            merge_directories(entry, target)
+            try_remove_empty(entry)
+        else:
+            entry.rename(target)
+    else:
+        entry.rename(target)
+
+
+def denormalize_framework_dirs(ctx: Context, category: str) -> None:
+    base = ctx.out_dir / category
+    if not base.is_dir():
+        return
+    framework_ext = ".framework"
+    entries = list(base.iterdir())
+    for entry in entries:
+        if entry.is_symlink() and entry.name.endswith(framework_ext):
+            entry.unlink()
+    for entry in list(base.iterdir()):
+        if entry.is_symlink() or not entry.is_dir():
+            continue
+        if entry.name.endswith(framework_ext):
+            continue
+        dest = base / f"{entry.name}{framework_ext}"
+        if dest.exists():
+            if dest.is_symlink():
+                dest.unlink()
+            if dest.exists():
+                merge_directories(entry, dest)
+                try_remove_empty(entry)
+            else:
+                entry.rename(dest)
+        else:
+            entry.rename(dest)
 
 
 def run_classdump(category: str, ctx: Context) -> tuple[int, bool, list[str]]:
@@ -594,7 +796,7 @@ def run_classdump(category: str, ctx: Context) -> tuple[int, bool, list[str]]:
 def run_classdump_host(category: str, ctx: Context) -> tuple[int, bool, list[str]]:
     source_path = Path(ctx.runtime_root) / "System/Library" / category
     is_recursive = "/" not in category
-    cmd = [str(ctx.classdump_bin), "-o", str(ctx.out_dir)]
+    cmd = [str(ctx.classdump_bin), "-o", str(ctx.stage_dir)]
     if is_recursive:
         cmd += ["-r", str(source_path)]
     else:
@@ -618,7 +820,7 @@ def run_classdump_simulator(category: str, ctx: Context) -> tuple[int, bool, lis
         device.udid,
         str(ctx.classdump_bin),
         "-o",
-        str(ctx.out_dir),
+        str(ctx.stage_dir),
     ]
     if is_recursive:
         cmd += ["-r", source_path]
@@ -690,6 +892,7 @@ def write_metadata(ctx: Context) -> None:
         f"RuntimeBuild: {ctx.runtime_build}\n"
         f"iOS: {ctx.version}\n"
         f"HeadersPath: {ctx.out_dir}\n"
+        f"Layout: {ctx.layout}\n"
         f"HeaderCount: {header_count}\n"
         f"Xcode: {xcode_info}\n"
         f"Notes: classdump-dyld output; /System/Library/{{Frameworks,PrivateFrameworks}}; -b -h {skip}\n"
@@ -700,7 +903,11 @@ def write_metadata(ctx: Context) -> None:
 
 def count_headers(dir_path: Path) -> int:
     count = 0
-    for root, _, files in os.walk(dir_path):
+    for root, dirs, files in os.walk(dir_path):
+        if ".tmp" in dirs:
+            dirs.remove(".tmp")
+        if os.path.basename(root) == ".tmp":
+            continue
         for name in files:
             if name.endswith(".h"):
                 count += 1
@@ -764,6 +971,7 @@ def needs_split(ctx: Context) -> bool:
         ctx.exec_mode == "simulator"
         or ctx.framework_names
         or ctx.framework_filters
+        or ctx.layout == "headers"
     )
 
 

--- a/scripts/dump_headers
+++ b/scripts/dump_headers
@@ -968,9 +968,8 @@ def write_metadata(ctx: Context) -> None:
 def count_headers(dir_path: Path) -> int:
     count = 0
     for root, dirs, files in os.walk(dir_path):
-        if ".tmp" in dirs:
-            dirs.remove(".tmp")
-        if os.path.basename(root) == ".tmp":
+        dirs[:] = [name for name in dirs if not name.startswith(".tmp")]
+        if os.path.basename(root).startswith(".tmp"):
             continue
         for name in files:
             if name.endswith(".h"):

--- a/scripts/dump_headers
+++ b/scripts/dump_headers
@@ -129,7 +129,16 @@ def main() -> int:
     parser.add_argument("version", nargs="?", help="iOS runtime version (e.g. 26.0.1)")
     parser.add_argument("--device", help="Simulator device UDID or name")
     parser.add_argument("--out", type=Path, help="Output directory")
-    parser.add_argument("--skip-existing", action="store_true", help="Skip existing headers")
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Always dump headers even if they already exist",
+    )
+    parser.add_argument(
+        "--skip-existing",
+        action="store_true",
+        help=argparse.SUPPRESS,
+    )
     parser.add_argument("--exec-mode", choices=["host", "simulator"], help="Force exec mode")
     parser.add_argument("--list-runtimes", action="store_true", help="List runtimes and exit")
     parser.add_argument("--list-devices", action="store_true", help="List devices and exit")
@@ -430,7 +439,7 @@ def interactive_setup(
         or Path(os.getenv("PH_OUT_DIR")) if os.getenv("PH_OUT_DIR") else None
     ) or default_out
     stage_dir = build_stage_dir(out_dir)
-    skip_existing = args.skip_existing or os.getenv("PH_SKIP_EXISTING") == "1"
+    skip_existing = resolve_skip_existing(args)
 
     if device:
         print(f"Using device: {device.name} ({device.state})")
@@ -484,6 +493,7 @@ def non_interactive_setup(
 
     out_dir = args.out or root_dir / "generated-headers/iOS" / version
     stage_dir = build_stage_dir(out_dir)
+    skip_existing = resolve_skip_existing(args)
 
     return Context(
         exec_mode=exec_mode,
@@ -495,7 +505,7 @@ def non_interactive_setup(
         device=device,
         out_dir=out_dir.resolve(),
         stage_dir=stage_dir.resolve(),
-        skip_existing=args.skip_existing,
+        skip_existing=skip_existing,
         layout=layout,
         categories=categories,
         framework_names=framework_names,
@@ -677,7 +687,13 @@ def dump_category_split(category: str, ctx: Context) -> None:
         return
     failures = []
     total = len(frameworks)
+    existing = set()
+    if ctx.skip_existing:
+        existing = existing_frameworks_in_category(ctx, category, set(frameworks))
     for idx, item in enumerate(frameworks, start=1):
+        if ctx.skip_existing and item in existing:
+            print(f"Skipping existing: {category} ({idx}/{total}) {item}")
+            continue
         print(f"Dumping: {category} ({idx}/{total}) {item}")
         path = f"{category}/{item}"
         status, killed, last_lines = run_classdump(path, ctx)
@@ -987,6 +1003,29 @@ def list_frameworks(category: str, ctx: Context) -> list[str]:
     return frameworks
 
 
+def existing_frameworks_in_category(
+    ctx: Context, category: str, frameworks: set[str]
+) -> set[str]:
+    category_dir = ctx.out_dir / category
+    if not category_dir.is_dir():
+        return set()
+    existing: set[str] = set()
+    for root, dirs, files in os.walk(category_dir):
+        dirs[:] = [name for name in dirs if not name.startswith(".tmp")]
+        if not files:
+            continue
+        if not any(name.endswith(".h") for name in files):
+            continue
+        rel = Path(root).relative_to(category_dir)
+        if not rel.parts:
+            continue
+        top = rel.parts[0]
+        framework_name = normalize_framework_name(top) if ctx.layout == "headers" else top
+        if framework_name in frameworks:
+            existing.add(framework_name)
+    return existing
+
+
 def filter_frameworks(frameworks: list[str], ctx: Context) -> list[str]:
     filtered = frameworks
     if ctx.framework_names:
@@ -1029,11 +1068,24 @@ def normalize_framework_name(name: str) -> str:
     return trimmed if trimmed.endswith(".framework") else f"{trimmed}.framework"
 
 
+def resolve_skip_existing(args) -> bool:
+    if getattr(args, "force", False):
+        return False
+    env_force = os.getenv("PH_FORCE")
+    if env_force is not None:
+        return env_force != "1"
+    env_value = os.getenv("PH_SKIP_EXISTING")
+    if env_value is not None:
+        return env_value == "1"
+    return True
+
+
 def needs_split(ctx: Context) -> bool:
     return bool(
         ctx.exec_mode == "simulator"
         or ctx.framework_names
         or ctx.framework_filters
+        or ctx.skip_existing
     )
 
 

--- a/scripts/dump_headers
+++ b/scripts/dump_headers
@@ -239,8 +239,8 @@ def main() -> int:
 
         for category in ctx.categories:
             reset_stage_dir(ctx)
-            dump_category(category, ctx)
-            finalize_category_output(ctx, category)
+            had_failures = dump_category(category, ctx)
+            finalize_category_output(ctx, category, had_failures)
 
         write_metadata(ctx)
         print(f"Done: {ctx.out_dir}")
@@ -664,27 +664,26 @@ def create_default_device(runtime_id: str, version: str) -> None:
     )
 
 
-def dump_category(category: str, ctx: Context) -> None:
+def dump_category(category: str, ctx: Context) -> bool:
     print(f"Dumping: {category}")
     if needs_split(ctx):
-        dump_category_split(category, ctx)
-        return
+        return dump_category_split(category, ctx)
     status, killed, last_lines = run_classdump(category, ctx)
     if killed:
         print("Retrying per-framework to avoid simulator kill.")
         reset_stage_dir(ctx)
-        dump_category_split(category, ctx)
-        return
+        return dump_category_split(category, ctx)
     if status != 0:
         report_last_lines(last_lines)
         raise RuntimeError(f"classdump-dyld failed for {category}")
+    return False
 
 
-def dump_category_split(category: str, ctx: Context) -> None:
+def dump_category_split(category: str, ctx: Context) -> bool:
     frameworks = list_frameworks(category, ctx)
     if not frameworks:
         print(f"Skipping {category}: no frameworks found under /System/Library/{category}")
-        return
+        return False
     failures = []
     total = len(frameworks)
     existing = set()
@@ -704,10 +703,12 @@ def dump_category_split(category: str, ctx: Context) -> None:
             relocate_framework_output(ctx, category, item)
             if ctx.layout == "headers":
                 normalize_framework_dir(ctx, category, item)
-    if failures:
+    had_failures = bool(failures)
+    if had_failures:
         summary = f"classdump-dyld failed for {len(failures)} items under {category}"
         print(summary, file=sys.stderr)
         write_failures(ctx, summary, failures)
+    return had_failures
 
 
 def relocate_framework_output(ctx: Context, category: str, framework_name: str) -> None:
@@ -758,8 +759,9 @@ def reset_stage_dir(ctx: Context) -> None:
     ctx.stage_dir.mkdir(parents=True, exist_ok=True)
 
 
-def finalize_category_output(ctx: Context, category: str) -> None:
-    relocate_frameworks_in_category(ctx, category)
+def finalize_category_output(ctx: Context, category: str, had_failures: bool = False) -> None:
+    if not had_failures:
+        relocate_frameworks_in_category(ctx, category)
     if ctx.layout == "headers":
         normalize_framework_dirs(ctx, category)
 
@@ -1072,8 +1074,8 @@ def resolve_skip_existing(args) -> bool:
     if getattr(args, "force", False):
         return False
     env_force = os.getenv("PH_FORCE")
-    if env_force is not None:
-        return env_force != "1"
+    if env_force == "1":
+        return False
     env_value = os.getenv("PH_SKIP_EXISTING")
     if env_value is not None:
         return env_value == "1"

--- a/scripts/dump_headers
+++ b/scripts/dump_headers
@@ -621,6 +621,7 @@ def dump_category(category: str, ctx: Context) -> None:
     status, killed, last_lines = run_classdump(category, ctx)
     if killed:
         print("Retrying per-framework to avoid simulator kill.")
+        reset_stage_dir(ctx)
         dump_category_split(category, ctx)
         return
     if status != 0:


### PR DESCRIPTION
Summary:
- Stage classdump output under `<out>/.tmp` and move per-framework into the final layout with cleanup
- Normalize the headers layout by removing the `.framework` suffix per framework during dumping
- Update README notes around output staging and layout behavior

Testing:
- Not run (not requested)