### PR TITLE
fix: dump headers robustness

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "525b66144d76f6dbf5e7c9f465473a17f9010777c09c6b6a7480b591854a3d66",
+  "originHash" : "6182ad954e5c1785cd3a27da04dd01f07b1cd7c17512912c9a585b72a2880dd3",
   "pins" : [
     {
       "identity" : "associatedobject",
@@ -61,7 +61,7 @@
       "location" : "https://github.com/lynnswap/MachOObjCSection.git",
       "state" : {
         "branch" : "main",
-        "revision" : "4ba7e50bfdc4ad4da63693509443bb6ac34c8e29"
+        "revision" : "90d3afbae7412edabbaff1fc4da4ee44d014af9c"
       }
     },
     {

--- a/README.ja.md
+++ b/README.ja.md
@@ -46,17 +46,17 @@
 - `--runtime <version>`: `--list-devices` 用のランタイム指定
 - `--json`: list 系の JSON 出力
 - `--shared-cache`: dyld shared cache を使ってダンプ（デフォルト有効。無効化は `PH_SHARED_CACHE=0`）
+- `--rebuild-classdump`: 既存の `classdump-dyld` があっても再ビルド
 
 ## メモ
 
-- このリポジトリ内の SwiftPM 実行ファイル（`classdump-dyld`）を利用します。
 - Python 3 が必要です。
 - `simulator` モード時は `xcrun simctl spawn` 経由です。
 - ダンプ中の一時出力は `<out>/.tmp-<run-id>` に作成し、最後にレイアウトへ移動します。
 - 実行中は出力ディレクトリをロックして、同時書き込みを防ぎます。
 - `-D` での詳細ログ時も、スキップクラスのログはデフォルトで出さない（`PH_VERBOSE_SKIP=1` で表示）。
 - 自動作成するデバイスタイプは `PH_DEVICE_TYPE` で指定可能（デバイス名または identifier）。
-- 環境変数で上書き可能: `PH_EXEC_MODE`, `PH_OUT_DIR`, `PH_FORCE=1|0`, `PH_SKIP_EXISTING=1|0`, `PH_LAYOUT`, `PH_SHARED_CACHE=1|0`, `PH_VERBOSE_SKIP=1`, `PH_DEVICE_TYPE`
+- 環境変数で上書き可能: `PH_EXEC_MODE`, `PH_OUT_DIR`, `PH_FORCE=1|0`, `PH_SKIP_EXISTING=1|0`, `PH_LAYOUT`, `PH_SHARED_CACHE=1|0`, `PH_VERBOSE_SKIP=1`, `PH_DEVICE_TYPE`, `PH_REBUILD_CLASSDUMP=1`
 
 ## ライセンス
 

--- a/README.md
+++ b/README.md
@@ -45,17 +45,17 @@ This dumps both `Frameworks` and `PrivateFrameworks`.
 - `--runtime <version>`: Runtime version for `--list-devices`
 - `--json`: JSON output for list commands
 - `--shared-cache`: Use dyld shared cache when dumping (enabled by default; set `PH_SHARED_CACHE=0` to disable)
+- `--rebuild-classdump`: Rebuild `classdump-dyld` even if a binary already exists
 
 ## Notes
 
-- Uses the SwiftPM executable built from this repository (`classdump-dyld`).
 - Requires Python 3.
 - Simulator mode uses `xcrun simctl spawn`.
 - During dumping, raw output is staged under `<out>/.tmp-<run-id>` and then moved to the final layout.
 - The output directory is locked for the duration of a run to avoid concurrent writes.
 - Verbose mode suppresses skipped-class logs by default; set `PH_VERBOSE_SKIP=1` to show them.
 - You can override the device type used for auto-creation with `PH_DEVICE_TYPE` (device name or identifier).
-- Environment overrides: `PH_EXEC_MODE`, `PH_OUT_DIR`, `PH_FORCE=1|0`, `PH_SKIP_EXISTING=1|0`, `PH_LAYOUT`, `PH_SHARED_CACHE=1|0`, `PH_VERBOSE_SKIP=1`, `PH_DEVICE_TYPE`
+- Environment overrides: `PH_EXEC_MODE`, `PH_OUT_DIR`, `PH_FORCE=1|0`, `PH_SKIP_EXISTING=1|0`, `PH_LAYOUT`, `PH_SHARED_CACHE=1|0`, `PH_VERBOSE_SKIP=1`, `PH_DEVICE_TYPE`, `PH_REBUILD_CLASSDUMP=1`
 
 ## License
 

--- a/scripts/dump_headers
+++ b/scripts/dump_headers
@@ -106,6 +106,23 @@ def build_stage_dir(out_dir: Path) -> Path:
     return out_dir / f".tmp-{token}"
 
 
+def ensure_device_booted(device: DeviceInfo, *, force: bool = False) -> None:
+    if device.state == "Booted" and not force:
+        return
+    print(f"Booting simulator: {device.name} ({device.udid})")
+    run_simple_command(
+        "xcrun",
+        ["simctl", "boot", device.udid],
+        "failed to boot simulator",
+    )
+    run_simple_command(
+        "xcrun",
+        ["simctl", "bootstatus", device.udid, "-b"],
+        "failed to wait for simulator boot",
+    )
+    device.state = "Booted"
+
+
 def acquire_output_lock(out_dir: Path):
     lock_path = out_dir / ".dump_headers.lock"
     lock_file = lock_path.open("a+", encoding="utf-8")
@@ -165,6 +182,11 @@ def main() -> int:
         "--shared-cache",
         action="store_true",
         help="Use dyld shared cache when dumping",
+    )
+    parser.add_argument(
+        "--rebuild-classdump",
+        action="store_true",
+        help="Rebuild classdump-dyld even if a binary already exists",
     )
     parser.add_argument(
         "-D",
@@ -232,25 +254,18 @@ def main() -> int:
                 verbose,
             )
 
-        ctx.classdump_bin = ensure_classdump_binary(root_dir, ctx)
+        rebuild_classdump = resolve_rebuild_classdump(args)
+        ctx.classdump_bin = ensure_classdump_binary(
+            root_dir,
+            ctx,
+            rebuild_classdump=rebuild_classdump
+        )
 
         if ctx.exec_mode == "simulator":
             device = ctx.device
             if device is None:
                 raise RuntimeError("no simulator device available")
-            if device.state != "Booted":
-                print(f"Booting simulator: {device.name} ({device.udid})")
-                run_simple_command(
-                    "xcrun",
-                    ["simctl", "boot", device.udid],
-                    "failed to boot simulator",
-                )
-                run_simple_command(
-                    "xcrun",
-                    ["simctl", "bootstatus", device.udid, "-b"],
-                    "failed to wait for simulator boot",
-                )
-                device.state = "Booted"
+            ensure_device_booted(device)
 
         ctx.out_dir.mkdir(parents=True, exist_ok=True)
         lock_file = acquire_output_lock(ctx.out_dir)
@@ -284,9 +299,18 @@ def resolve_exec_mode(
 ) -> str:
     if requested in ("host", "simulator"):
         return requested
-    if classdump_simulator.is_file():
+    host_exists = classdump_host.is_file()
+    sim_exists = classdump_simulator.is_file()
+    if host_exists and sim_exists:
+        try:
+            host_mtime = classdump_host.stat().st_mtime
+            sim_mtime = classdump_simulator.stat().st_mtime
+            return "host" if host_mtime >= sim_mtime else "simulator"
+        except Exception:
+            pass
+    if sim_exists:
         return "simulator"
-    if classdump_host.is_file():
+    if host_exists:
         return "host"
     if classdump_sim.is_file():
         return "simulator"
@@ -449,8 +473,18 @@ def build_classdump_simulator(root_dir: Path, device: DeviceInfo) -> Path:
     return bin_path
 
 
-def ensure_classdump_binary(root_dir: Path, ctx: Context) -> Path:
+def ensure_classdump_binary(
+    root_dir: Path,
+    ctx: Context,
+    rebuild_classdump: bool
+) -> Path:
     classdump_host, classdump_simulator, classdump_sim = classdump_paths(root_dir)
+    if rebuild_classdump:
+        if ctx.exec_mode == "host":
+            try_remove_file(classdump_host)
+        else:
+            try_remove_file(classdump_simulator)
+            try_remove_file(classdump_sim)
     if ctx.exec_mode == "host":
         if classdump_host.is_file():
             return classdump_host
@@ -1005,7 +1039,21 @@ def run_classdump_simulator(category: str, ctx: Context) -> tuple[int, bool, lis
     env = os.environ.copy()
     env["SIMCTL_CHILD_PH_RUNTIME_ROOT"] = ctx.runtime_root
     env["SIMCTL_CHILD_DYLD_ROOT_PATH"] = ctx.runtime_root
-    return run_command_stream(cmd, env=env)
+    status, killed, last_lines = run_command_stream(cmd, env=env)
+    if status != 0 and should_retry_simulator_boot(last_lines):
+        ensure_device_booted(device, force=True)
+        status, killed, last_lines = run_command_stream(cmd, env=env)
+    return status, killed, last_lines
+
+
+def should_retry_simulator_boot(last_lines: list[str]) -> bool:
+    for line in last_lines:
+        lowered = line.lower()
+        if "device is not booted" in lowered:
+            return True
+        if "bad or unknown session" in lowered:
+            return True
+    return False
 
 
 def run_command_stream(cmd: list[str], env: dict | None = None) -> tuple[int, bool, list[str]]:
@@ -1179,6 +1227,15 @@ def try_remove_empty(path: Path) -> None:
         return
 
 
+def try_remove_file(path: Path) -> None:
+    try:
+        path.unlink()
+    except FileNotFoundError:
+        return
+    except IsADirectoryError:
+        shutil.rmtree(path, ignore_errors=True)
+
+
 def normalize_framework_name(name: str) -> str:
     trimmed = name.strip()
     if not trimmed:
@@ -1196,6 +1253,13 @@ def resolve_skip_existing(args) -> bool:
     if env_value is not None:
         return env_value == "1"
     return True
+
+
+def resolve_rebuild_classdump(args) -> bool:
+    if getattr(args, "rebuild_classdump", False):
+        return True
+    env_value = os.getenv("PH_REBUILD_CLASSDUMP")
+    return env_value == "1"
 
 
 def resolve_shared_cache(args) -> bool:


### PR DESCRIPTION
Summary:
- Add dump_headers safeguards: simulator boot retry, exec_mode auto selection, and rebuild-classdump option.
- Document rebuild flag and remove the classdump-dyld mention from README files.
- Update Package.resolved to the latest MachOObjCSection revision.

Testing:
- Not run (not requested)