### PR TITLE
Forward PH_SYMBOL_PROFILE to simulator child environment

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -168,8 +168,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-dependencies",
       "state" : {
-        "revision" : "411297072220a96f1501211afebd3715316907d2",
-        "version" : "1.10.1"
+        "revision" : "c79f72b3e67a1eb64f66f76704c22ed6a5c1ed84",
+        "version" : "1.11.0"
       }
     },
     {
@@ -249,8 +249,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/jpsim/Yams",
       "state" : {
-        "revision" : "51b5127c7fb6ffac106ad6d199aaa33c5024895f",
-        "version" : "6.2.0"
+        "revision" : "deaf82e867fa2cbd3cd865978b079bfcf384ac28",
+        "version" : "6.2.1"
       }
     }
   ],

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "510b380a50ece780468b01d398fd3fe77ee0366df88a4ff589b08165115ddefe",
+  "originHash" : "c3992bea1b70be553882a54339e966047669983f2461f947289b59b2ce0bb7cf",
   "pins" : [
     {
       "identity" : "associatedobject",
@@ -69,8 +69,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/lynnswap/MachOSwiftSection.git",
       "state" : {
-        "revision" : "3d6165d8dd4edd17937be00811a76225c0a947b6",
-        "version" : "0.8.3"
+        "revision" : "61584dcd738df90c348afe2f0aec57403c83596c"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "c3992bea1b70be553882a54339e966047669983f2461f947289b59b2ce0bb7cf",
+  "originHash" : "a76ec9cad0a8cdadac34a4a7d9bba58472fd46ba3d7f4a94143c29783018540e",
   "pins" : [
     {
       "identity" : "associatedobject",
@@ -69,7 +69,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/lynnswap/MachOSwiftSection.git",
       "state" : {
-        "revision" : "61584dcd738df90c348afe2f0aec57403c83596c"
+        "revision" : "5d032fd36443dd060d149c79e1beb945b0f4f2f8"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -23,7 +23,7 @@ let package = Package(
         ),
         .package(
             url: "https://github.com/lynnswap/MachOSwiftSection.git",
-            from: "0.8.3"
+            revision: "61584dcd738df90c348afe2f0aec57403c83596c"
         ),
         .package(
             url: "https://github.com/lynnswap/swift-objc-dump.git",

--- a/Package.swift
+++ b/Package.swift
@@ -23,7 +23,7 @@ let package = Package(
         ),
         .package(
             url: "https://github.com/lynnswap/MachOSwiftSection.git",
-            revision: "61584dcd738df90c348afe2f0aec57403c83596c"
+            revision: "5d032fd36443dd060d149c79e1beb945b0f4f2f8"
         ),
         .package(
             url: "https://github.com/lynnswap/swift-objc-dump.git",

--- a/README.ja.md
+++ b/README.ja.md
@@ -88,7 +88,7 @@ privateheaderkit-dump --list-devices --runtime 26.0.1
 - 実行中は出力ディレクトリをロックして、同時書き込みを防ぎます。
 - `-D` での詳細ログ時も、スキップクラスのログはデフォルトで出さない（`PH_VERBOSE_SKIP=1` で表示）。
 - 自動作成するデバイスタイプは `PH_DEVICE_TYPE` で指定可能（デバイス名または identifier）。
-- 環境変数で上書き可能: `PH_EXEC_MODE`, `PH_OUT_DIR`, `PH_FORCE=1|0`, `PH_SKIP_EXISTING=1|0`, `PH_LAYOUT`, `PH_SHARED_CACHE=1|0`, `PH_VERBOSE=1|0`, `PH_VERBOSE_SKIP=1`, `PH_DEVICE_TYPE`
+- 環境変数で上書き可能: `PH_EXEC_MODE`, `PH_OUT_DIR`, `PH_FORCE=1|0`, `PH_SKIP_EXISTING=1|0`, `PH_LAYOUT`, `PH_SHARED_CACHE=1|0`, `PH_VERBOSE=1|0`, `PH_VERBOSE_SKIP=1`, `PH_DEVICE_TYPE`, `PH_PROFILE=1|0`, `PH_SWIFT_EVENTS=1|0`
 
 ## ライセンス
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ privateheaderkit-dump --list-devices --runtime 26.0.1
 - The output directory is locked for the duration of a run to avoid concurrent writes.
 - Verbose mode suppresses skipped-class logs by default; set `PH_VERBOSE_SKIP=1` to show them.
 - You can override the device type used for auto-creation with `PH_DEVICE_TYPE` (device name or identifier).
-- Environment overrides: `PH_EXEC_MODE`, `PH_OUT_DIR`, `PH_FORCE=1|0`, `PH_SKIP_EXISTING=1|0`, `PH_LAYOUT`, `PH_SHARED_CACHE=1|0`, `PH_VERBOSE=1|0`, `PH_VERBOSE_SKIP=1`, `PH_DEVICE_TYPE`
+- Environment overrides: `PH_EXEC_MODE`, `PH_OUT_DIR`, `PH_FORCE=1|0`, `PH_SKIP_EXISTING=1|0`, `PH_LAYOUT`, `PH_SHARED_CACHE=1|0`, `PH_VERBOSE=1|0`, `PH_VERBOSE_SKIP=1`, `PH_DEVICE_TYPE`, `PH_PROFILE=1|0`, `PH_SWIFT_EVENTS=1|0`
 
 ## License
 

--- a/Sources/PrivateHeaderKitDump/main.swift
+++ b/Sources/PrivateHeaderKitDump/main.swift
@@ -1138,6 +1138,9 @@ private func runHeaderdumpSimulator(
     if parentEnv["SIMCTL_CHILD_PH_SWIFT_EVENTS"] == nil, parentEnv["PH_SWIFT_EVENTS"] == "1" {
         env["SIMCTL_CHILD_PH_SWIFT_EVENTS"] = "1"
     }
+    if parentEnv["SIMCTL_CHILD_PH_SYMBOL_PROFILE"] == nil, parentEnv["PH_SYMBOL_PROFILE"] == "1" {
+        env["SIMCTL_CHILD_PH_SYMBOL_PROFILE"] = "1"
+    }
 
     var result = try runDumpStreaming(cmd, env: env, cwd: nil, streamOutput: streamOutput)
     try throwIfTerminationRequested()

--- a/Tests/HeaderDumpCLITests/HeaderDumpCLITests.swift
+++ b/Tests/HeaderDumpCLITests/HeaderDumpCLITests.swift
@@ -307,6 +307,58 @@ struct HeaderDumpCLITests {
         #expect(disabled == false)
     }
 
+    @Test func shouldProfileFromEnv() {
+        let enabled = withEnvironment([
+            "PH_PROFILE": "1",
+            "SIMCTL_CHILD_PH_PROFILE": nil
+        ]) {
+            shouldProfile()
+        }
+        #expect(enabled == true)
+
+        let enabledSim = withEnvironment([
+            "PH_PROFILE": nil,
+            "SIMCTL_CHILD_PH_PROFILE": "1"
+        ]) {
+            shouldProfile()
+        }
+        #expect(enabledSim == true)
+
+        let disabled = withEnvironment([
+            "PH_PROFILE": "0",
+            "SIMCTL_CHILD_PH_PROFILE": nil
+        ]) {
+            shouldProfile()
+        }
+        #expect(disabled == false)
+    }
+
+    @Test func shouldLogSwiftEventsFromEnv() {
+        let enabled = withEnvironment([
+            "PH_SWIFT_EVENTS": "1",
+            "SIMCTL_CHILD_PH_SWIFT_EVENTS": nil
+        ]) {
+            shouldLogSwiftEvents()
+        }
+        #expect(enabled == true)
+
+        let enabledSim = withEnvironment([
+            "PH_SWIFT_EVENTS": nil,
+            "SIMCTL_CHILD_PH_SWIFT_EVENTS": "1"
+        ]) {
+            shouldLogSwiftEvents()
+        }
+        #expect(enabledSim == true)
+
+        let disabled = withEnvironment([
+            "PH_SWIFT_EVENTS": "0",
+            "SIMCTL_CHILD_PH_SWIFT_EVENTS": nil
+        ]) {
+            shouldLogSwiftEvents()
+        }
+        #expect(disabled == false)
+    }
+
     @Test func resolveRuntimeURLUsesRuntimeRoot() throws {
         let tempDir = try makeTempDir()
         let runtimeRoot = tempDir.appendingPathComponent("Runtime")


### PR DESCRIPTION
## Summary
- Map `PH_SYMBOL_PROFILE=1` to `SIMCTL_CHILD_PH_SYMBOL_PROFILE=1` in simulator mode so `headerdump-sim` receives symbol profiling settings.
- Keep the existing behavior unchanged when the child-prefixed variable is already provided.

## Testing
- `swift test`