### PR TITLE
feat: add macOS dump support and cache fallback fixes

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -2,7 +2,10 @@
 
 [English](README.md)
 
-iOS Simulator のランタイム（dyld shared cache）から private framework のヘッダを生成します。
+iOS / macOS の private framework ヘッダを生成します。
+
+- iOS: Simulator ランタイム（dyld shared cache）から生成
+- macOS: ホストの `/System/Library/{Frameworks,PrivateFrameworks}` から生成
 
 ## インストール
 
@@ -56,7 +59,15 @@ privateheaderkit-dump 26.2
 `Frameworks` と `PrivateFrameworks` をまとめて出力します。  
 （`--out` / `PH_OUT_DIR` に指定した相対パスはカレントディレクトリを基準に解釈されます。従来どおりリポジトリ配下に出したい場合は、リポジトリrootで実行して `--out generated-headers/iOS/<version>` を指定するか `PH_OUT_DIR` を指定してください）
 
-### 3) ランタイム/デバイス一覧
+### 3) macOS ヘッダをダンプ
+
+```
+privateheaderkit-dump --platform macos
+```
+
+デフォルト出力先は `~/PrivateHeaderKit/generated-headers/macOS/<productVersion>` です。
+
+### 4) ランタイム/デバイス一覧（iOS専用）
 
 ```
 privateheaderkit-dump --list-runtimes
@@ -65,6 +76,7 @@ privateheaderkit-dump --list-devices --runtime 26.0.1
 
 #### オプション
 
+- `--platform <ios|macos>`: 対象プラットフォーム（デフォルトは `ios`。`PH_PLATFORM` でも指定可）
 - `--device <udid|name>`: 対象シミュレーターを指定
 - `--out <dir>`: 出力先を指定
 - `--force`: 既存ヘッダがあっても常に再生成する（成功したフレームワークは出力を丸ごと置換。失敗分は既存出力を残し `_failures.txt` に記録）
@@ -80,6 +92,8 @@ privateheaderkit-dump --list-devices --runtime 26.0.1
 - `--shared-cache`: dyld shared cache を使ってダンプ（デフォルト有効。無効化は `PH_SHARED_CACHE=0`）
 - `-D`, `--verbose`: 詳細ログ
 
+`--list-runtimes` / `--list-devices` / `--runtime` / `--device` は iOS 専用オプションです。
+
 ## メモ
 
 - Xcode command line tools（`xcrun`, `xcodebuild`）が必要です。
@@ -88,7 +102,7 @@ privateheaderkit-dump --list-devices --runtime 26.0.1
 - 実行中は出力ディレクトリをロックして、同時書き込みを防ぎます。
 - `-D` での詳細ログ時も、スキップクラスのログはデフォルトで出さない（`PH_VERBOSE_SKIP=1` で表示）。
 - 自動作成するデバイスタイプは `PH_DEVICE_TYPE` で指定可能（デバイス名または identifier）。
-- 環境変数で上書き可能: `PH_EXEC_MODE`, `PH_OUT_DIR`, `PH_FORCE=1|0`, `PH_SKIP_EXISTING=1|0`, `PH_LAYOUT`, `PH_SHARED_CACHE=1|0`, `PH_VERBOSE=1|0`, `PH_VERBOSE_SKIP=1`, `PH_DEVICE_TYPE`, `PH_PROFILE=1|0`, `PH_SWIFT_EVENTS=1|0`
+- 環境変数で上書き可能: `PH_PLATFORM`, `PH_EXEC_MODE`, `PH_OUT_DIR`, `PH_FORCE=1|0`, `PH_SKIP_EXISTING=1|0`, `PH_LAYOUT`, `PH_SHARED_CACHE=1|0`, `PH_VERBOSE=1|0`, `PH_VERBOSE_SKIP=1`, `PH_DEVICE_TYPE`, `PH_PROFILE=1|0`, `PH_SWIFT_EVENTS=1|0`
 
 ## ライセンス
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,10 @@
 
 [日本語](README.ja.md)
 
-Generate iOS private framework headers from simulator runtimes (dyld shared cache).
+Generate private framework headers for iOS and macOS.
+
+- iOS: dump from simulator runtimes (dyld shared cache).
+- macOS: dump from host `/System/Library/{Frameworks,PrivateFrameworks}`.
 
 ## Installation
 
@@ -56,7 +59,15 @@ Default output directory is `~/PrivateHeaderKit/generated-headers/iOS/<version>`
 This dumps both `Frameworks` and `PrivateFrameworks`.
 (Relative paths passed to `--out` / `PH_OUT_DIR` are resolved from the current directory. If you want the old output under this repo, run from the repo root and pass `--out generated-headers/iOS/<version>` or set `PH_OUT_DIR`.)
 
-### 3) List runtimes / devices
+### 3) Dump macOS headers
+
+```
+privateheaderkit-dump --platform macos
+```
+
+Default output directory is `~/PrivateHeaderKit/generated-headers/macOS/<productVersion>`.
+
+### 4) List runtimes / devices (iOS only)
 
 ```
 privateheaderkit-dump --list-runtimes
@@ -65,6 +76,7 @@ privateheaderkit-dump --list-devices --runtime 26.0.1
 
 #### Options
 
+- `--platform <ios|macos>`: Target platform (default: `ios`; you can also set `PH_PLATFORM`)
 - `--device <udid|name>`: Choose a simulator device
 - `--out <dir>`: Output directory
 - `--force`: Always dump headers even if they already exist (successful frameworks replace their output directory; failures keep existing output and are recorded in `_failures.txt`)
@@ -80,6 +92,8 @@ privateheaderkit-dump --list-devices --runtime 26.0.1
 - `--shared-cache`: Use dyld shared cache when dumping (enabled by default; set `PH_SHARED_CACHE=0` to disable)
 - `-D`, `--verbose`: Enable verbose logging
 
+`--list-runtimes`, `--list-devices`, `--runtime`, and `--device` are iOS-only options.
+
 ## Notes
 
 - Requires Xcode command line tools (`xcrun`, `xcodebuild`).
@@ -88,7 +102,7 @@ privateheaderkit-dump --list-devices --runtime 26.0.1
 - The output directory is locked for the duration of a run to avoid concurrent writes.
 - Verbose mode suppresses skipped-class logs by default; set `PH_VERBOSE_SKIP=1` to show them.
 - You can override the device type used for auto-creation with `PH_DEVICE_TYPE` (device name or identifier).
-- Environment overrides: `PH_EXEC_MODE`, `PH_OUT_DIR`, `PH_FORCE=1|0`, `PH_SKIP_EXISTING=1|0`, `PH_LAYOUT`, `PH_SHARED_CACHE=1|0`, `PH_VERBOSE=1|0`, `PH_VERBOSE_SKIP=1`, `PH_DEVICE_TYPE`, `PH_PROFILE=1|0`, `PH_SWIFT_EVENTS=1|0`
+- Environment overrides: `PH_PLATFORM`, `PH_EXEC_MODE`, `PH_OUT_DIR`, `PH_FORCE=1|0`, `PH_SKIP_EXISTING=1|0`, `PH_LAYOUT`, `PH_SHARED_CACHE=1|0`, `PH_VERBOSE=1|0`, `PH_VERBOSE_SKIP=1`, `PH_DEVICE_TYPE`, `PH_PROFILE=1|0`, `PH_SWIFT_EVENTS=1|0`
 
 ## License
 


### PR DESCRIPTION
Summary:
- Add `--platform <ios|macos>` and `PH_PLATFORM` with fixed precedence (CLI > env > default), while keeping iOS as the default behavior.
- Add macOS-specific argument validation to reject iOS-only options (`--list-runtimes`, `--list-devices`, `--runtime`, `--device`, simulator exec mode, and positional version).
- Introduce platform-aware dump context fields (`platform`, `systemRoot`, `osVersionLabel`) and macOS context setup using `sw_vers` with default output under `~/PrivateHeaderKit/generated-headers/macOS/<productVersion>`.
- Make dump processing platform-aware by using `systemRoot` for source/staging paths and limiting iOS-specific DYLD environment injection to iOS only.
- Improve shared cache resolution for modern macOS by adding Cryptex shared cache candidates, framework versioned image path normalization (`Versions/Current`, `A/B/C`), and canonical executable path fallback for cache-only bundles.
- Fix `--platform macos --force` UX/reliability by always running macOS dumps per framework (split mode) and passing `-R` for macOS host dumps so runtime-derived ObjC classes (e.g. `AVPlayerView`) are emitted.
- Update metadata/log output to be platform-aware and document macOS usage/options in `README.md` and `README.ja.md`.
- Add/extend tests for versioned cache path normalization, cache-only executable fallback, and runtime fallback target path variants.

Testing:
- `swift test`
- `swift run privateheaderkit-dump --platform macos --framework AppKit --out /tmp/phk-macos-smoke-1770803120`
- `swift run privateheaderkit-dump --platform macos --framework iTunesCloud --out /tmp/phk-macos-private-smoke-1770803206`
- `swift run privateheaderkit-dump --platform ios --list-runtimes`
- `swift run privateheaderkit-dump --platform macos --force --framework AVKit --out /tmp/phk-avkit-force-fix2-1770804174`
- `swift run privateheaderkit-dump --platform macos 26.2` (expected error)
- `swift run privateheaderkit-dump --platform macos --list-runtimes` (expected error)
- `swift run privateheaderkit-dump --platform macos --exec-mode simulator` (expected error)