### PR TITLE
feat: add macos option in interactive target list

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -59,15 +59,7 @@ privateheaderkit-dump 26.2
 `Frameworks` と `PrivateFrameworks` をまとめて出力します。  
 （`--out` / `PH_OUT_DIR` に指定した相対パスはカレントディレクトリを基準に解釈されます。従来どおりリポジトリ配下に出したい場合は、リポジトリrootで実行して `--out generated-headers/iOS/<version>` を指定するか `PH_OUT_DIR` を指定してください）
 
-### 3) macOS ヘッダをダンプ
-
-```
-privateheaderkit-dump --platform macos
-```
-
-デフォルト出力先は `~/PrivateHeaderKit/generated-headers/macOS/<productVersion>` です。
-
-### 4) ランタイム/デバイス一覧（iOS専用）
+### 3) ランタイム/デバイス一覧（iOS）
 
 ```
 privateheaderkit-dump --list-runtimes
@@ -76,21 +68,23 @@ privateheaderkit-dump --list-devices --runtime 26.0.1
 
 #### オプション
 
-- `--platform <ios|macos>`: 対象プラットフォーム（デフォルトは `ios`。`PH_PLATFORM` でも指定可）
-- `--device <udid|name>`: 対象シミュレーターを指定
-- `--out <dir>`: 出力先を指定
-- `--force`: 既存ヘッダがあっても常に再生成する（成功したフレームワークは出力を丸ごと置換。失敗分は既存出力を残し `_failures.txt` に記録）
-- `--skip-existing`: 既に出力済みのフレームワークはスキップ（`PH_FORCE=1` を一時的に打ち消したい場合など）
-- `--exec-mode <host|simulator>`: 実行モードを強制
-- `--framework <name>`: 指定したフレームワークのみダンプ（複数指定可、`.framework` は省略可）
-- `--filter <substring>`: フレームワーク名の部分一致フィルタ（複数指定可）
-- `--layout <bundle|headers>`: 出力レイアウト（`bundle` は `.framework` を保持、`headers` は `.framework` を外す）
-- `--list-runtimes`: 利用可能な iOS ランタイム一覧を表示して終了
-- `--list-devices`: ランタイム内のデバイス一覧を表示して終了（`--runtime` 併用）
-- `--runtime <version>`: `--list-devices` 用のランタイム指定
-- `--json`: list 系の JSON 出力
-- `--shared-cache`: dyld shared cache を使ってダンプ（デフォルト有効。無効化は `PH_SHARED_CACHE=0`）
-- `-D`, `--verbose`: 詳細ログ
+| Option | 説明 |
+| --- | --- |
+| `--platform <ios\|macos>` | 対象プラットフォーム（デフォルトは `ios`。`PH_PLATFORM` でも指定可） |
+| `--device <udid\|name>` | 対象シミュレーターを指定 |
+| `--out <dir>` | 出力先を指定 |
+| `--force` | 既存ヘッダがあっても常に再生成する（成功したフレームワークは出力を丸ごと置換。失敗分は既存出力を残し `_failures.txt` に記録） |
+| `--skip-existing` | 既に出力済みのフレームワークはスキップ（`PH_FORCE=1` を一時的に打ち消したい場合など） |
+| `--exec-mode <host\|simulator>` | 実行モードを強制 |
+| `--framework <name>` | 指定したフレームワークのみダンプ（複数指定可、`.framework` は省略可） |
+| `--filter <substring>` | フレームワーク名の部分一致フィルタ（複数指定可） |
+| `--layout <bundle\|headers>` | 出力レイアウト（`bundle` は `.framework` を保持、`headers` は `.framework` を外す） |
+| `--list-runtimes` | 利用可能な iOS ランタイム一覧を表示して終了 |
+| `--list-devices` | ランタイム内のデバイス一覧を表示して終了（`--runtime` 併用） |
+| `--runtime <version>` | `--list-devices` 用のランタイム指定 |
+| `--json` | list 系の JSON 出力 |
+| `--shared-cache` | dyld shared cache を使ってダンプ（デフォルト有効。無効化は `PH_SHARED_CACHE=0`） |
+| `-D`, `--verbose` | 詳細ログ |
 
 `--list-runtimes` / `--list-devices` / `--runtime` / `--device` は iOS 専用オプションです。
 

--- a/README.md
+++ b/README.md
@@ -59,15 +59,7 @@ Default output directory is `~/PrivateHeaderKit/generated-headers/iOS/<version>`
 This dumps both `Frameworks` and `PrivateFrameworks`.
 (Relative paths passed to `--out` / `PH_OUT_DIR` are resolved from the current directory. If you want the old output under this repo, run from the repo root and pass `--out generated-headers/iOS/<version>` or set `PH_OUT_DIR`.)
 
-### 3) Dump macOS headers
-
-```
-privateheaderkit-dump --platform macos
-```
-
-Default output directory is `~/PrivateHeaderKit/generated-headers/macOS/<productVersion>`.
-
-### 4) List runtimes / devices (iOS only)
+### 3) List runtimes / devices (iOS only)
 
 ```
 privateheaderkit-dump --list-runtimes
@@ -76,21 +68,23 @@ privateheaderkit-dump --list-devices --runtime 26.0.1
 
 #### Options
 
-- `--platform <ios|macos>`: Target platform (default: `ios`; you can also set `PH_PLATFORM`)
-- `--device <udid|name>`: Choose a simulator device
-- `--out <dir>`: Output directory
-- `--force`: Always dump headers even if they already exist (successful frameworks replace their output directory; failures keep existing output and are recorded in `_failures.txt`)
-- `--skip-existing`: Skip frameworks that already exist (useful to override `PH_FORCE=1`)
-- `--exec-mode <host|simulator>`: Force execution mode
-- `--framework <name>`: Dump only the exact framework name (repeatable, `.framework` optional)
-- `--filter <substring>`: Substring filter for framework names (repeatable)
-- `--layout <bundle|headers>`: Output layout (`bundle` keeps `.framework` dirs, `headers` removes the `.framework` suffix)
-- `--list-runtimes`: List available iOS runtimes and exit
-- `--list-devices`: List devices for a runtime and exit (use `--runtime`)
-- `--runtime <version>`: Runtime version for `--list-devices`
-- `--json`: JSON output for list commands
-- `--shared-cache`: Use dyld shared cache when dumping (enabled by default; set `PH_SHARED_CACHE=0` to disable)
-- `-D`, `--verbose`: Enable verbose logging
+| Option | Description |
+| --- | --- |
+| `--platform <ios\|macos>` | Target platform (default: `ios`; you can also set `PH_PLATFORM`) |
+| `--device <udid\|name>` | Choose a simulator device |
+| `--out <dir>` | Output directory |
+| `--force` | Always dump headers even if they already exist (successful frameworks replace their output directory; failures keep existing output and are recorded in `_failures.txt`) |
+| `--skip-existing` | Skip frameworks that already exist (useful to override `PH_FORCE=1`) |
+| `--exec-mode <host\|simulator>` | Force execution mode |
+| `--framework <name>` | Dump only the exact framework name (repeatable, `.framework` optional) |
+| `--filter <substring>` | Substring filter for framework names (repeatable) |
+| `--layout <bundle\|headers>` | Output layout (`bundle` keeps `.framework` dirs, `headers` removes the `.framework` suffix) |
+| `--list-runtimes` | List available iOS runtimes and exit |
+| `--list-devices` | List devices for a runtime and exit (use `--runtime`) |
+| `--runtime <version>` | Runtime version for `--list-devices` |
+| `--json` | JSON output for list commands |
+| `--shared-cache` | Use dyld shared cache when dumping (enabled by default; set `PH_SHARED_CACHE=0` to disable) |
+| `-D`, `--verbose` | Enable verbose logging |
 
 `--list-runtimes`, `--list-devices`, `--runtime`, and `--device` are iOS-only options.
 

--- a/Sources/PrivateHeaderKitDump/main.swift
+++ b/Sources/PrivateHeaderKitDump/main.swift
@@ -962,7 +962,7 @@ private func run() throws {
                 execMode: mode,
                 requestedExecMode: requestedExecMode,
                 args: parsed,
-                allowMacOSSelection: !hasExplicitPlatform,
+                allowMacOSSelection: !hasExplicitPlatform && requestedExecMode != .simulator,
                 categories: categories,
                 frameworkNames: frameworkNames,
                 frameworkFilters: frameworkFilters,

--- a/Sources/PrivateHeaderKitDump/main.swift
+++ b/Sources/PrivateHeaderKitDump/main.swift
@@ -606,6 +606,7 @@ private func interactiveSetup(
     hostHeaderdumpBin: URL?,
     headerdumpBin: URL,
     execMode: ExecMode,
+    requestedExecMode: ExecMode?,
     args: DumpArguments,
     allowMacOSSelection: Bool,
     categories: [String],
@@ -665,6 +666,7 @@ private func interactiveSetup(
     }
 
     if case .macos = target {
+        try validatePlatformArguments(args: args, platform: .macos, requestedExecMode: requestedExecMode)
         guard let hostHeaderdumpBin else {
             throw ToolingError.message("headerdump not found (run `swift run -c release privateheaderkit-install` first)")
         }
@@ -958,6 +960,7 @@ private func run() throws {
                 hostHeaderdumpBin: binaries.host,
                 headerdumpBin: headerdumpBin,
                 execMode: mode,
+                requestedExecMode: requestedExecMode,
                 args: parsed,
                 allowMacOSSelection: !hasExplicitPlatform,
                 categories: categories,


### PR DESCRIPTION
Summary:
- Add a `macOS` option to the interactive target list shown in `privateheaderkit-dump` when running without a version argument.
- Keep default/non-interactive platform resolution behavior by removing the standalone platform prompt path.
- Update README option sections to Markdown tables and adjust usage section numbering/text for consistency.

Testing:
- swift test