### PR TITLE
feat: expand dump scope to SystemLibrary and usr/lib

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -72,5 +72,11 @@ let package = Package(
                 .product(name: "MachOKit", package: "MachOKit"),
             ]
         ),
+        .testTarget(
+            name: "PrivateHeaderKitDumpTests",
+            dependencies: [
+                "PrivateHeaderKitDump",
+            ]
+        ),
     ]
 )

--- a/README.ja.md
+++ b/README.ja.md
@@ -61,26 +61,25 @@ privateheaderkit-dump 26.2
 
 ### 3) 対象を指定してダンプする（`--target`）
 
-`--target` を使うと、ダンプ対象を選べます（複数指定可・足し算）。  
-`--target` を付けない場合は `--target @frameworks` と同じです。
+`--target` でダンプ対象を絞り込めます。複数回指定すると、それらすべてがダンプされます。
 
 ```
-# Framework 1つ
+# Framework を 1つだけ
 privateheaderkit-dump 26.2 --target SafariShared
 
-# SystemLibrary の bundle 1つ
+# SystemLibrary の bundle を 1つだけ
 privateheaderkit-dump 26.2 --target PreferenceBundles/Foo.bundle
 
-# /usr/lib の dylib 1つ
+# /usr/lib の dylib を 1つだけ
 privateheaderkit-dump 26.2 --target /usr/lib/libobjc.A.dylib
 
 # プリセット
-privateheaderkit-dump 26.2 --target @frameworks
-privateheaderkit-dump 26.2 --target @system
-privateheaderkit-dump 26.2 --target @all
+privateheaderkit-dump 26.2 --target @frameworks  # Frameworks / PrivateFrameworks
+privateheaderkit-dump 26.2 --target @system      # @frameworks + SystemLibrary bundles
+privateheaderkit-dump 26.2 --target @all         # @system + /usr/lib dylibs
 
-# 「Frameworks 全部」+「SystemLibrary の bundle 1つ」
-privateheaderkit-dump 26.2 --target @frameworks --target PreferenceBundles/Foo.bundle
+# 複数指定の例
+privateheaderkit-dump 26.2 --target SafariShared --target UIKitCore
 
 # ネストバンドルのダンプを無効化
 privateheaderkit-dump 26.2 --target SafariShared --no-nested
@@ -106,7 +105,7 @@ privateheaderkit-dump --list-devices --runtime 26.0.1
 | `--force` | 既存ヘッダがあっても常に再生成する（成功したフレームワークは出力を丸ごと置換。失敗分は既存出力を残し `_failures.txt` に記録） |
 | `--skip-existing` | 既に出力済みのフレームワークはスキップ（`PH_FORCE=1` を一時的に打ち消したい場合など） |
 | `--exec-mode <host\|simulator>` | 実行モードを強制 |
-| `--target <value>` | ダンプ対象を指定（複数指定可・足し算）。省略すると `@frameworks`（`/System/Library/{Frameworks,PrivateFrameworks}` 全部）。プリセット: `@frameworks`, `@system`, `@all` |
+| `--target <value>` | ダンプ対象を指定（複数指定可）。プリセット: `@frameworks`, `@system`, `@all` |
 | `--no-nested` | ネストバンドル（`XPCServices` / `PlugIns`）のダンプを無効化（デフォルト有効） |
 | `--layout <bundle\|headers>` | 出力レイアウト（`bundle` は `.framework` を保持、`headers` は `.framework` を外す） |
 | `--framework <name>` | (Legacy) 指定したフレームワークのみダンプ（複数指定可、`.framework` は省略可） |

--- a/README.ja.md
+++ b/README.ja.md
@@ -82,6 +82,9 @@ privateheaderkit-dump 26.2 --scope all --no-nested
 privateheaderkit-dump 26.2 --scope frameworks --nested
 ```
 
+`--layout headers`（デフォルト）の場合、検索しやすいように出力側のバンドル拡張子を外します:
+`.framework`, `.app`, `.bundle`, `.xpc`, `.appex`
+
 ### 4) ランタイム/デバイス一覧（iOS）
 
 ```

--- a/README.ja.md
+++ b/README.ja.md
@@ -59,27 +59,29 @@ privateheaderkit-dump 26.2
 `Frameworks` と `PrivateFrameworks` をまとめて出力します。  
 （`--out` / `PH_OUT_DIR` に指定した相対パスはカレントディレクトリを基準に解釈されます。従来どおりリポジトリ配下に出したい場合は、リポジトリrootで実行して `--out generated-headers/iOS/<version>` を指定するか `PH_OUT_DIR` を指定してください）
 
-### 3) Framework 以外も出力したい場合
+### 3) 対象を指定してダンプする（`--target`）
 
-既定では `/System/Library/{Frameworks,PrivateFrameworks}` のみを対象にダンプします。
+既定では `/System/Library/{Frameworks,PrivateFrameworks}` を対象にダンプします。
 
-`/System/Library` 配下の `.app/.bundle/.xpc/.appex` なども追加でダンプして `<out>/SystemLibrary/...` に出したい場合:
-
-```
-privateheaderkit-dump 26.2 --scope system
-```
-
-さらに `/usr/lib/*.dylib` も追加でダンプして `<out>/usr/lib/...` に出したい場合:
+`--target` を 1 つでも指定した場合は、指定したターゲットだけをダンプします（暗黙のデフォルトは無し）。
 
 ```
-privateheaderkit-dump 26.2 --scope all
-```
+# Framework 1つ（ネストバンドルもデフォルトで出力）
+privateheaderkit-dump 26.2 --target SafariShared
 
-ネストバンドル（`XPCServices/*.xpc`, `PlugIns/*.appex`）は `--scope system|all` のときはデフォルトで有効です。必要なら上書きできます:
+# SystemLibrary の bundle 1つ
+privateheaderkit-dump 26.2 --target PreferenceBundles/Foo.bundle
 
-```
-privateheaderkit-dump 26.2 --scope all --no-nested
-privateheaderkit-dump 26.2 --scope frameworks --nested
+# /usr/lib の dylib 1つ
+privateheaderkit-dump 26.2 --target /usr/lib/libobjc.A.dylib
+
+# プリセット（大量出力）
+privateheaderkit-dump 26.2 --target @frameworks
+privateheaderkit-dump 26.2 --target @system
+privateheaderkit-dump 26.2 --target @all
+
+# ネストバンドルのダンプを無効化
+privateheaderkit-dump 26.2 --target SafariShared --no-nested
 ```
 
 `--layout headers`（デフォルト）の場合、検索しやすいように出力側のバンドル拡張子を外します:
@@ -102,12 +104,13 @@ privateheaderkit-dump --list-devices --runtime 26.0.1
 | `--force` | 既存ヘッダがあっても常に再生成する（成功したフレームワークは出力を丸ごと置換。失敗分は既存出力を残し `_failures.txt` に記録） |
 | `--skip-existing` | 既に出力済みのフレームワークはスキップ（`PH_FORCE=1` を一時的に打ち消したい場合など） |
 | `--exec-mode <host\|simulator>` | 実行モードを強制 |
-| `--framework <name>` | 指定したフレームワークのみダンプ（複数指定可、`.framework` は省略可） |
-| `--filter <substring>` | フレームワーク名の部分一致フィルタ（複数指定可） |
-| `--scope <frameworks\|system\|all>` | ダンプ範囲（デフォルトは `frameworks`） |
-| `--nested` | ネストバンドル（`XPCServices` / `PlugIns`）もダンプ |
-| `--no-nested` | ネストバンドルのダンプを無効化（`--scope frameworks` のデフォルト） |
+| `--target <value>` | ダンプ対象を指定（複数指定可）。プリセット: `@frameworks`, `@system`, `@all` |
+| `--no-nested` | ネストバンドル（`XPCServices` / `PlugIns`）のダンプを無効化（デフォルト有効） |
 | `--layout <bundle\|headers>` | 出力レイアウト（`bundle` は `.framework` を保持、`headers` は `.framework` を外す） |
+| `--framework <name>` | (Legacy) 指定したフレームワークのみダンプ（複数指定可、`.framework` は省略可） |
+| `--filter <substring>` | (Legacy) フレームワーク名の部分一致フィルタ（複数指定可） |
+| `--scope <frameworks\|system\|all>` | (Legacy) ダンプ範囲（デフォルトは `frameworks`） |
+| `--nested` | (Legacy) ネストバンドルのダンプを有効化（現在はデフォルト有効） |
 | `--list-runtimes` | 利用可能な iOS ランタイム一覧を表示して終了 |
 | `--list-devices` | ランタイム内のデバイス一覧を表示して終了（`--runtime` 併用） |
 | `--runtime <version>` | `--list-devices` 用のランタイム指定 |

--- a/README.ja.md
+++ b/README.ja.md
@@ -59,7 +59,30 @@ privateheaderkit-dump 26.2
 `Frameworks` と `PrivateFrameworks` をまとめて出力します。  
 （`--out` / `PH_OUT_DIR` に指定した相対パスはカレントディレクトリを基準に解釈されます。従来どおりリポジトリ配下に出したい場合は、リポジトリrootで実行して `--out generated-headers/iOS/<version>` を指定するか `PH_OUT_DIR` を指定してください）
 
-### 3) ランタイム/デバイス一覧（iOS）
+### 3) Framework 以外も出力したい場合
+
+既定では `/System/Library/{Frameworks,PrivateFrameworks}` のみを対象にダンプします。
+
+`/System/Library` 配下の `.app/.bundle/.xpc/.appex` なども追加でダンプして `<out>/SystemLibrary/...` に出したい場合:
+
+```
+privateheaderkit-dump 26.2 --scope system
+```
+
+さらに `/usr/lib/*.dylib` も追加でダンプして `<out>/usr/lib/...` に出したい場合:
+
+```
+privateheaderkit-dump 26.2 --scope all
+```
+
+ネストバンドル（`XPCServices/*.xpc`, `PlugIns/*.appex`）は `--scope system|all` のときはデフォルトで有効です。必要なら上書きできます:
+
+```
+privateheaderkit-dump 26.2 --scope all --no-nested
+privateheaderkit-dump 26.2 --scope frameworks --nested
+```
+
+### 4) ランタイム/デバイス一覧（iOS）
 
 ```
 privateheaderkit-dump --list-runtimes
@@ -78,6 +101,9 @@ privateheaderkit-dump --list-devices --runtime 26.0.1
 | `--exec-mode <host\|simulator>` | 実行モードを強制 |
 | `--framework <name>` | 指定したフレームワークのみダンプ（複数指定可、`.framework` は省略可） |
 | `--filter <substring>` | フレームワーク名の部分一致フィルタ（複数指定可） |
+| `--scope <frameworks\|system\|all>` | ダンプ範囲（デフォルトは `frameworks`） |
+| `--nested` | ネストバンドル（`XPCServices` / `PlugIns`）もダンプ |
+| `--no-nested` | ネストバンドルのダンプを無効化（`--scope frameworks` のデフォルト） |
 | `--layout <bundle\|headers>` | 出力レイアウト（`bundle` は `.framework` を保持、`headers` は `.framework` を外す） |
 | `--list-runtimes` | 利用可能な iOS ランタイム一覧を表示して終了 |
 | `--list-devices` | ランタイム内のデバイス一覧を表示して終了（`--runtime` 併用） |

--- a/README.ja.md
+++ b/README.ja.md
@@ -61,12 +61,11 @@ privateheaderkit-dump 26.2
 
 ### 3) 対象を指定してダンプする（`--target`）
 
-既定では `/System/Library/{Frameworks,PrivateFrameworks}` を対象にダンプします。
-
-`--target` を 1 つでも指定した場合は、指定したターゲットだけをダンプします（暗黙のデフォルトは無し）。
+`--target` を使うと、ダンプ対象を選べます（複数指定可・足し算）。  
+`--target` を付けない場合は `--target @frameworks` と同じです。
 
 ```
-# Framework 1つ（ネストバンドルもデフォルトで出力）
+# Framework 1つ
 privateheaderkit-dump 26.2 --target SafariShared
 
 # SystemLibrary の bundle 1つ
@@ -75,10 +74,13 @@ privateheaderkit-dump 26.2 --target PreferenceBundles/Foo.bundle
 # /usr/lib の dylib 1つ
 privateheaderkit-dump 26.2 --target /usr/lib/libobjc.A.dylib
 
-# プリセット（大量出力）
+# プリセット
 privateheaderkit-dump 26.2 --target @frameworks
 privateheaderkit-dump 26.2 --target @system
 privateheaderkit-dump 26.2 --target @all
+
+# 「Frameworks 全部」+「SystemLibrary の bundle 1つ」
+privateheaderkit-dump 26.2 --target @frameworks --target PreferenceBundles/Foo.bundle
 
 # ネストバンドルのダンプを無効化
 privateheaderkit-dump 26.2 --target SafariShared --no-nested
@@ -104,7 +106,7 @@ privateheaderkit-dump --list-devices --runtime 26.0.1
 | `--force` | 既存ヘッダがあっても常に再生成する（成功したフレームワークは出力を丸ごと置換。失敗分は既存出力を残し `_failures.txt` に記録） |
 | `--skip-existing` | 既に出力済みのフレームワークはスキップ（`PH_FORCE=1` を一時的に打ち消したい場合など） |
 | `--exec-mode <host\|simulator>` | 実行モードを強制 |
-| `--target <value>` | ダンプ対象を指定（複数指定可）。プリセット: `@frameworks`, `@system`, `@all` |
+| `--target <value>` | ダンプ対象を指定（複数指定可・足し算）。省略すると `@frameworks`（`/System/Library/{Frameworks,PrivateFrameworks}` 全部）。プリセット: `@frameworks`, `@system`, `@all` |
 | `--no-nested` | ネストバンドル（`XPCServices` / `PlugIns`）のダンプを無効化（デフォルト有効） |
 | `--layout <bundle\|headers>` | 出力レイアウト（`bundle` は `.framework` を保持、`headers` は `.framework` を外す） |
 | `--framework <name>` | (Legacy) 指定したフレームワークのみダンプ（複数指定可、`.framework` は省略可） |

--- a/README.md
+++ b/README.md
@@ -61,8 +61,7 @@ This dumps both `Frameworks` and `PrivateFrameworks`.
 
 ### 3) Dump specific targets (`--target`)
 
-`--target` lets you select what to dump (repeatable, additive).  
-If you don't pass `--target`, it's the same as `--target @frameworks`.
+Use `--target` to specify what to dump. You can use it multiple times to include multiple targets.
 
 Examples:
 
@@ -77,12 +76,12 @@ privateheaderkit-dump 26.2 --target PreferenceBundles/Foo.bundle
 privateheaderkit-dump 26.2 --target /usr/lib/libobjc.A.dylib
 
 # Presets
-privateheaderkit-dump 26.2 --target @frameworks
-privateheaderkit-dump 26.2 --target @system
-privateheaderkit-dump 26.2 --target @all
+privateheaderkit-dump 26.2 --target @frameworks  # Frameworks / PrivateFrameworks
+privateheaderkit-dump 26.2 --target @system      # @frameworks + SystemLibrary bundles
+privateheaderkit-dump 26.2 --target @all         # @system + /usr/lib dylibs
 
-# "All frameworks" + "one SystemLibrary bundle"
-privateheaderkit-dump 26.2 --target @frameworks --target PreferenceBundles/Foo.bundle
+# Multiple targets example
+privateheaderkit-dump 26.2 --target SafariShared --target UIKitCore
 
 # Disable nested bundle dumping
 privateheaderkit-dump 26.2 --target SafariShared --no-nested
@@ -108,7 +107,7 @@ privateheaderkit-dump --list-devices --runtime 26.0.1
 | `--force` | Always dump headers even if they already exist (successful frameworks replace their output directory; failures keep existing output and are recorded in `_failures.txt`) |
 | `--skip-existing` | Skip frameworks that already exist (useful to override `PH_FORCE=1`) |
 | `--exec-mode <host\|simulator>` | Force execution mode |
-| `--target <value>` | Select dump target (repeatable, additive). If omitted, it's the same as `@frameworks`. Presets: `@frameworks`, `@system`, `@all`. |
+| `--target <value>` | Select dump target (repeatable). Presets: `@frameworks`, `@system`, `@all`. |
 | `--no-nested` | Disable nested `XPCServices` / `PlugIns` bundle dumping (default: enabled) |
 | `--layout <bundle\|headers>` | Output layout (`bundle` keeps `.framework` dirs, `headers` removes the `.framework` suffix) |
 | `--framework <name>` | (Legacy) Dump only the exact framework name (repeatable, `.framework` optional) |

--- a/README.md
+++ b/README.md
@@ -59,7 +59,31 @@ Default output directory is `~/PrivateHeaderKit/generated-headers/iOS/<version>`
 This dumps both `Frameworks` and `PrivateFrameworks`.
 (Relative paths passed to `--out` / `PH_OUT_DIR` are resolved from the current directory. If you want the old output under this repo, run from the repo root and pass `--out generated-headers/iOS/<version>` or set `PH_OUT_DIR`.)
 
-### 3) List runtimes / devices (iOS only)
+### 3) Dump more than frameworks
+
+By default, `privateheaderkit-dump` only dumps `/System/Library/{Frameworks,PrivateFrameworks}`.
+
+To also dump other bundles under `/System/Library` (e.g. `.app`, `.bundle`, `.xpc`, `.appex`) into `<out>/SystemLibrary/...`:
+
+```
+privateheaderkit-dump 26.2 --scope system
+```
+
+To also dump `/usr/lib/*.dylib` into `<out>/usr/lib/...`:
+
+```
+privateheaderkit-dump 26.2 --scope all
+```
+
+Nested bundles (`XPCServices/*.xpc`, `PlugIns/*.appex`) are dumped by default for `--scope system|all`.
+You can override:
+
+```
+privateheaderkit-dump 26.2 --scope all --no-nested
+privateheaderkit-dump 26.2 --scope frameworks --nested
+```
+
+### 4) List runtimes / devices (iOS only)
 
 ```
 privateheaderkit-dump --list-runtimes
@@ -78,6 +102,9 @@ privateheaderkit-dump --list-devices --runtime 26.0.1
 | `--exec-mode <host\|simulator>` | Force execution mode |
 | `--framework <name>` | Dump only the exact framework name (repeatable, `.framework` optional) |
 | `--filter <substring>` | Substring filter for framework names (repeatable) |
+| `--scope <frameworks\|system\|all>` | Dump scope (default: `frameworks`) |
+| `--nested` | Also dump nested `XPCServices` / `PlugIns` bundles |
+| `--no-nested` | Disable nested bundle dumping (default for `--scope frameworks`) |
 | `--layout <bundle\|headers>` | Output layout (`bundle` keeps `.framework` dirs, `headers` removes the `.framework` suffix) |
 | `--list-runtimes` | List available iOS runtimes and exit |
 | `--list-devices` | List devices for a runtime and exit (use `--runtime`) |

--- a/README.md
+++ b/README.md
@@ -61,14 +61,13 @@ This dumps both `Frameworks` and `PrivateFrameworks`.
 
 ### 3) Dump specific targets (`--target`)
 
-By default, `privateheaderkit-dump` dumps `/System/Library/{Frameworks,PrivateFrameworks}`.
-
-If you pass one or more `--target` flags, it dumps only those targets (no implicit defaults).
+`--target` lets you select what to dump (repeatable, additive).  
+If you don't pass `--target`, it's the same as `--target @frameworks`.
 
 Examples:
 
 ```
-# A single framework (nested XPCServices/PlugIns are dumped by default)
+# A single framework
 privateheaderkit-dump 26.2 --target SafariShared
 
 # A single SystemLibrary bundle
@@ -77,10 +76,13 @@ privateheaderkit-dump 26.2 --target PreferenceBundles/Foo.bundle
 # A single usr/lib dylib
 privateheaderkit-dump 26.2 --target /usr/lib/libobjc.A.dylib
 
-# Presets (large outputs)
+# Presets
 privateheaderkit-dump 26.2 --target @frameworks
 privateheaderkit-dump 26.2 --target @system
 privateheaderkit-dump 26.2 --target @all
+
+# "All frameworks" + "one SystemLibrary bundle"
+privateheaderkit-dump 26.2 --target @frameworks --target PreferenceBundles/Foo.bundle
 
 # Disable nested bundle dumping
 privateheaderkit-dump 26.2 --target SafariShared --no-nested
@@ -106,7 +108,7 @@ privateheaderkit-dump --list-devices --runtime 26.0.1
 | `--force` | Always dump headers even if they already exist (successful frameworks replace their output directory; failures keep existing output and are recorded in `_failures.txt`) |
 | `--skip-existing` | Skip frameworks that already exist (useful to override `PH_FORCE=1`) |
 | `--exec-mode <host\|simulator>` | Force execution mode |
-| `--target <value>` | Dump target (repeatable). Presets: `@frameworks`, `@system`, `@all`. |
+| `--target <value>` | Select dump target (repeatable, additive). If omitted, it's the same as `@frameworks`. Presets: `@frameworks`, `@system`, `@all`. |
 | `--no-nested` | Disable nested `XPCServices` / `PlugIns` bundle dumping (default: enabled) |
 | `--layout <bundle\|headers>` | Output layout (`bundle` keeps `.framework` dirs, `headers` removes the `.framework` suffix) |
 | `--framework <name>` | (Legacy) Dump only the exact framework name (repeatable, `.framework` optional) |

--- a/README.md
+++ b/README.md
@@ -59,28 +59,31 @@ Default output directory is `~/PrivateHeaderKit/generated-headers/iOS/<version>`
 This dumps both `Frameworks` and `PrivateFrameworks`.
 (Relative paths passed to `--out` / `PH_OUT_DIR` are resolved from the current directory. If you want the old output under this repo, run from the repo root and pass `--out generated-headers/iOS/<version>` or set `PH_OUT_DIR`.)
 
-### 3) Dump more than frameworks
+### 3) Dump specific targets (`--target`)
 
-By default, `privateheaderkit-dump` only dumps `/System/Library/{Frameworks,PrivateFrameworks}`.
+By default, `privateheaderkit-dump` dumps `/System/Library/{Frameworks,PrivateFrameworks}`.
 
-To also dump other bundles under `/System/Library` (e.g. `.app`, `.bundle`, `.xpc`, `.appex`) into `<out>/SystemLibrary/...`:
+If you pass one or more `--target` flags, it dumps only those targets (no implicit defaults).
 
-```
-privateheaderkit-dump 26.2 --scope system
-```
-
-To also dump `/usr/lib/*.dylib` into `<out>/usr/lib/...`:
+Examples:
 
 ```
-privateheaderkit-dump 26.2 --scope all
-```
+# A single framework (nested XPCServices/PlugIns are dumped by default)
+privateheaderkit-dump 26.2 --target SafariShared
 
-Nested bundles (`XPCServices/*.xpc`, `PlugIns/*.appex`) are dumped by default for `--scope system|all`.
-You can override:
+# A single SystemLibrary bundle
+privateheaderkit-dump 26.2 --target PreferenceBundles/Foo.bundle
 
-```
-privateheaderkit-dump 26.2 --scope all --no-nested
-privateheaderkit-dump 26.2 --scope frameworks --nested
+# A single usr/lib dylib
+privateheaderkit-dump 26.2 --target /usr/lib/libobjc.A.dylib
+
+# Presets (large outputs)
+privateheaderkit-dump 26.2 --target @frameworks
+privateheaderkit-dump 26.2 --target @system
+privateheaderkit-dump 26.2 --target @all
+
+# Disable nested bundle dumping
+privateheaderkit-dump 26.2 --target SafariShared --no-nested
 ```
 
 When `--layout headers` (default), output bundle directory suffixes are stripped for easier searching:
@@ -103,12 +106,13 @@ privateheaderkit-dump --list-devices --runtime 26.0.1
 | `--force` | Always dump headers even if they already exist (successful frameworks replace their output directory; failures keep existing output and are recorded in `_failures.txt`) |
 | `--skip-existing` | Skip frameworks that already exist (useful to override `PH_FORCE=1`) |
 | `--exec-mode <host\|simulator>` | Force execution mode |
-| `--framework <name>` | Dump only the exact framework name (repeatable, `.framework` optional) |
-| `--filter <substring>` | Substring filter for framework names (repeatable) |
-| `--scope <frameworks\|system\|all>` | Dump scope (default: `frameworks`) |
-| `--nested` | Also dump nested `XPCServices` / `PlugIns` bundles |
-| `--no-nested` | Disable nested bundle dumping (default for `--scope frameworks`) |
+| `--target <value>` | Dump target (repeatable). Presets: `@frameworks`, `@system`, `@all`. |
+| `--no-nested` | Disable nested `XPCServices` / `PlugIns` bundle dumping (default: enabled) |
 | `--layout <bundle\|headers>` | Output layout (`bundle` keeps `.framework` dirs, `headers` removes the `.framework` suffix) |
+| `--framework <name>` | (Legacy) Dump only the exact framework name (repeatable, `.framework` optional) |
+| `--filter <substring>` | (Legacy) Substring filter for framework names (repeatable) |
+| `--scope <frameworks\|system\|all>` | (Legacy) Dump scope (default: `frameworks`) |
+| `--nested` | (Legacy) Enable nested bundle dumping (now enabled by default) |
 | `--list-runtimes` | List available iOS runtimes and exit |
 | `--list-devices` | List devices for a runtime and exit (use `--runtime`) |
 | `--runtime <version>` | Runtime version for `--list-devices` |

--- a/README.md
+++ b/README.md
@@ -83,6 +83,9 @@ privateheaderkit-dump 26.2 --scope all --no-nested
 privateheaderkit-dump 26.2 --scope frameworks --nested
 ```
 
+When `--layout headers` (default), output bundle directory suffixes are stripped for easier searching:
+`.framework`, `.app`, `.bundle`, `.xpc`, `.appex`.
+
 ### 4) List runtimes / devices (iOS only)
 
 ```

--- a/Sources/PrivateHeaderKitDump/main.swift
+++ b/Sources/PrivateHeaderKitDump/main.swift
@@ -76,7 +76,13 @@ private struct Context {
 
     var isSplit: Bool {
         // macOS host dumps are more reliable/observable per framework than a single recursive run.
-        platform == .macos || execMode == .simulator || !frameworkNames.isEmpty || !frameworkFilters.isEmpty || skipExisting
+        // Also: nested bundle dumping (XPCServices/PlugIns) is implemented via per-bundle invocations.
+        platform == .macos
+            || execMode == .simulator
+            || nestedEnabled
+            || !frameworkNames.isEmpty
+            || !frameworkFilters.isEmpty
+            || skipExisting
     }
 }
 
@@ -263,7 +269,9 @@ private func printUsage() {
       --force                    Always dump even if headers already exist
       --skip-existing             Skip frameworks that already exist (useful to override PH_FORCE=1)
       --exec-mode <host|simulator>
-      --target <value>           Dump target (repeatable)
+      --target <value>           Select dump target (repeatable, additive)
+                                - If omitted: dumps all frameworks (@frameworks)
+                                - If present: dumps ONLY the selected targets
                                 Presets: @frameworks | @system | @all
                                 Framework: SafariShared
                                 SystemLibrary item: PreferenceBundles/Foo.bundle

--- a/Sources/PrivateHeaderKitDump/main.swift
+++ b/Sources/PrivateHeaderKitDump/main.swift
@@ -1791,6 +1791,12 @@ private func dumpSystemLibraryItems(ctx: Context, items: [String], runner: Comma
                 fileManager: fileManager
             )
             try normalizeNestedXPCAndPlugIns(in: bundleDir, overwrite: !ctx.skipExisting)
+        } else if dest.path != normalizedDest.path {
+            // When switching layouts with `--force`, remove stale "headers" layout output (e.g. `Foo`)
+            // next to the fresh bundle output (e.g. `Foo.bundle`) so one run produces a consistent layout.
+            if fileManager.fileExists(atPath: normalizedDest.path) {
+                try? fileManager.removeItem(at: normalizedDest)
+            }
         }
 
         if inlineProgress {

--- a/Sources/PrivateHeaderKitDump/main.swift
+++ b/Sources/PrivateHeaderKitDump/main.swift
@@ -526,6 +526,11 @@ private func normalizeSystemLibraryRelativeTarget(_ value: String) throws -> Str
         throw ToolingError.invalidArgument("SystemLibrary target must not be under Frameworks/PrivateFrameworks: \(value) (use --target <FrameworkName> instead)")
     }
 
+    let parts = normalized.split(separator: "/").map(String.init)
+    if parts.contains(".") || parts.contains("..") {
+        throw ToolingError.invalidArgument("SystemLibrary target must not contain '.' or '..' path components: \(value)")
+    }
+
     let ext = URL(fileURLWithPath: normalized).pathExtension.lowercased()
     guard systemBundleTargetExtensions.contains(ext) else {
         throw ToolingError.invalidArgument("SystemLibrary target must be .app/.bundle/.xpc/.appex: \(value)")

--- a/Tests/PrivateHeaderKitDumpTests/PrivateHeaderKitDumpTests.swift
+++ b/Tests/PrivateHeaderKitDumpTests/PrivateHeaderKitDumpTests.swift
@@ -1,0 +1,71 @@
+import Testing
+
+@testable import PrivateHeaderKitDump
+
+@Suite struct PrivateHeaderKitDumpTests {
+    @Test func targetFrameworkOnlySelectsFrameworks() throws {
+        var args = DumpArguments()
+        args.targets = ["SafariShared"]
+
+        let selection = try buildDumpSelection(args)
+        #expect(selection.categories == ["Frameworks", "PrivateFrameworks"])
+        #expect(selection.frameworkNames.contains("safarishared.framework"))
+        #expect(selection.dumpAllSystemLibraryExtras == false)
+        #expect(selection.systemLibraryItems.isEmpty)
+        #expect(selection.dumpAllUsrLibDylibs == false)
+        #expect(selection.usrLibDylibs.isEmpty)
+        #expect(selection.dumpAllFrameworks == false)
+        #expect(resolveNestedEnabled(args) == true)
+    }
+
+    @Test func targetSystemItemOnlyDoesNotDumpFrameworks() throws {
+        var args = DumpArguments()
+        args.targets = ["PreferenceBundles/Foo.bundle"]
+
+        let selection = try buildDumpSelection(args)
+        #expect(selection.categories.isEmpty)
+        #expect(selection.dumpAllSystemLibraryExtras == false)
+        #expect(selection.systemLibraryItems == ["PreferenceBundles/Foo.bundle"])
+        #expect(selection.dumpAllUsrLibDylibs == false)
+        #expect(selection.usrLibDylibs.isEmpty)
+    }
+
+    @Test func targetAllPresetEnablesAllScopes() throws {
+        var args = DumpArguments()
+        args.targets = ["@all"]
+
+        let selection = try buildDumpSelection(args)
+        #expect(selection.categories == ["Frameworks", "PrivateFrameworks"])
+        #expect(selection.dumpAllSystemLibraryExtras == true)
+        #expect(selection.dumpAllUsrLibDylibs == true)
+        #expect(selection.dumpAllFrameworks == true)
+        #expect(selection.frameworkNames.isEmpty)
+    }
+
+    @Test func noNestedDisablesNested() {
+        var args = DumpArguments()
+        args.targets = ["SafariShared"]
+        args.nested = false
+        #expect(resolveNestedEnabled(args) == false)
+    }
+
+    @Test func legacyScopeAllEqualsAllPreset() throws {
+        var args = DumpArguments()
+        args.scope = .all
+
+        let selection = try buildDumpSelection(args)
+        #expect(selection.categories == ["Frameworks", "PrivateFrameworks"])
+        #expect(selection.dumpAllSystemLibraryExtras == true)
+        #expect(selection.dumpAllUsrLibDylibs == true)
+    }
+
+    @Test func targetUsrLibDylibParsesName() throws {
+        var args = DumpArguments()
+        args.targets = ["/usr/lib/libobjc.A.dylib"]
+
+        let selection = try buildDumpSelection(args)
+        #expect(selection.categories.isEmpty)
+        #expect(selection.dumpAllUsrLibDylibs == false)
+        #expect(selection.usrLibDylibs == ["libobjc.A.dylib"])
+    }
+}

--- a/Tests/PrivateHeaderKitDumpTests/PrivateHeaderKitDumpTests.swift
+++ b/Tests/PrivateHeaderKitDumpTests/PrivateHeaderKitDumpTests.swift
@@ -1,6 +1,7 @@
 import Testing
 
 @testable import PrivateHeaderKitDump
+import PrivateHeaderKitTooling
 
 @Suite struct PrivateHeaderKitDumpTests {
     @Test func targetFrameworkOnlySelectsFrameworks() throws {
@@ -67,5 +68,29 @@ import Testing
         #expect(selection.categories.isEmpty)
         #expect(selection.dumpAllUsrLibDylibs == false)
         #expect(selection.usrLibDylibs == ["libobjc.A.dylib"])
+    }
+
+    @Test func systemLibraryTargetRejectsDotDotComponents() {
+        let targets = [
+            "../Foo.bundle",
+            "PreferenceBundles/../Foo.bundle",
+            "./Foo.bundle",
+            "PreferenceBundles/./Foo.bundle",
+        ]
+        for target in targets {
+            var args = DumpArguments()
+            args.targets = [target]
+            do {
+                _ = try buildDumpSelection(args)
+                #expect(Bool(false))
+            } catch let error as ToolingError {
+                guard case .invalidArgument = error else {
+                    #expect(Bool(false))
+                    continue
+                }
+            } catch {
+                #expect(Bool(false))
+            }
+        }
     }
 }


### PR DESCRIPTION
Summary:
- Add `--target` (repeatable) to select dump targets, including presets: `@frameworks`, `@system`, `@all`
- Enable nested bundle dumping (XPCServices/PlugIns) by default; add `--no-nested` to disable
- Ensure nested bundle dumping is honored even in cases that would otherwise take the recursive framework path (e.g. iOS host mode with `--force`)
- Expand dump support beyond frameworks to include SystemLibrary bundles (.app/.bundle/.xpc/.appex) and `/usr/lib/*.dylib`
- Include symlinked `/usr/lib/*.dylib` entries when expanding presets (many runtimes use symlink stubs)
- Harden SystemLibrary target parsing by rejecting `.` / `..` path components
- Keep SystemLibrary outputs consistent with the requested `--layout` even when `--skip-existing` is used (supports switching `headers` <-> `bundle` without re-dumping)
- Remove stale SystemLibrary outputs when switching layouts with `--force` (avoid mixed layout duplicates)
- Keep nested XPCServices/PlugIns bundle dir names consistent with the requested `--layout` when skipping existing frameworks
- Treat symlink-to-directory bundles (Cryptex) as bundles so frameworks like SafariServices can be dumped reliably
- Normalize output layout (optional bundle suffix stripping) and improve relocation (incl. Cryptex roots)
- Add/extend tests and update docs

Testing:
- swift test