### PR TITLE
fix(dump): harden runtime fallback and resume handling

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -32,8 +32,18 @@ let package = Package(
     ],
     targets: [
         .target(
+            name: "HeaderDumpRuntimeObjC",
+            dependencies: [],
+            path: "Sources/HeaderDumpRuntimeObjC",
+            publicHeadersPath: "include"
+        ),
+        .target(
             name: "HeaderDumpCore",
             dependencies: [
+                .target(
+                    name: "HeaderDumpRuntimeObjC",
+                    condition: .when(platforms: [.macOS, .iOS])
+                ),
                 .product(name: "MachOKit", package: "MachOKit"),
                 .product(name: "MachOObjCSection", package: "MachOObjCSection"),
                 .product(name: "ObjCDump", package: "swift-objc-dump"),
@@ -69,6 +79,10 @@ let package = Package(
             name: "HeaderDumpCLITests",
             dependencies: [
                 "HeaderDumpCore",
+                .target(
+                    name: "HeaderDumpRuntimeObjC",
+                    condition: .when(platforms: [.macOS, .iOS])
+                ),
                 .product(name: "MachOKit", package: "MachOKit"),
             ]
         ),

--- a/Sources/HeaderDumpCore/HeaderDumpMain.swift
+++ b/Sources/HeaderDumpCore/HeaderDumpMain.swift
@@ -12,6 +12,7 @@ import Glibc
 #endif
 #if canImport(ObjectiveC)
 import ObjectiveC
+import HeaderDumpRuntimeObjC
 #endif
 
 protocol FileExistenceChecking {
@@ -976,6 +977,86 @@ private func dumpObjC(
 }
 
 #if canImport(ObjectiveC)
+private func runtimePropertyInfo(
+    from snapshot: PHRuntimeObjCPropertySnapshot
+) -> ObjCPropertyInfo {
+    ObjCPropertyInfo(
+        name: snapshot.name,
+        attributes: snapshot.attributesString,
+        isClassProperty: snapshot.isClassProperty
+    )
+}
+
+private func runtimeMethodInfo(
+    from snapshot: PHRuntimeObjCMethodSnapshot
+) -> ObjCMethodInfo {
+    ObjCMethodInfo(
+        name: snapshot.name,
+        typeEncoding: snapshot.typeEncoding,
+        isClassMethod: snapshot.isClassMethod
+    )
+}
+
+private func runtimeIvarInfo(
+    from snapshot: PHRuntimeObjCIvarSnapshot
+) -> ObjCIvarInfo {
+    ObjCIvarInfo(
+        name: snapshot.name,
+        typeEncoding: snapshot.typeEncoding,
+        offset: Int(snapshot.offset)
+    )
+}
+
+private func runtimeProtocolInfo(
+    from snapshot: PHRuntimeObjCProtocolSnapshot
+) -> ObjCProtocolInfo {
+    ObjCProtocolInfo(
+        name: snapshot.name,
+        protocols: snapshot.protocols.map(runtimeProtocolInfo(from:)),
+        classProperties: snapshot.classProperties.map(runtimePropertyInfo(from:)),
+        properties: snapshot.properties.map(runtimePropertyInfo(from:)),
+        classMethods: snapshot.classMethods.map(runtimeMethodInfo(from:)),
+        methods: snapshot.methods.map(runtimeMethodInfo(from:)),
+        optionalClassProperties: snapshot.optionalClassProperties.map(runtimePropertyInfo(from:)),
+        optionalProperties: snapshot.optionalProperties.map(runtimePropertyInfo(from:)),
+        optionalClassMethods: snapshot.optionalClassMethods.map(runtimeMethodInfo(from:)),
+        optionalMethods: snapshot.optionalMethods.map(runtimeMethodInfo(from:))
+    )
+}
+
+private func runtimeClassInfo(
+    for cls: AnyClass,
+    fallbackName: String,
+    imagePath: String,
+    options: DumpOptions
+) -> ObjCClassInfo? {
+    var failedStage: NSString?
+    guard let snapshot = PHRuntimeObjCInspector.snapshot(for: cls, failedStage: &failedStage) else {
+        if options.verbose {
+            let stage = (failedStage as String?) ?? "unknown"
+            fputs(
+                "headerdump: runtime fallback skip class \(fallbackName) image=\(imagePath) stage=\(stage)\n",
+                stderr
+            )
+        }
+        return nil
+    }
+
+    return ObjCClassInfo(
+        name: snapshot.name,
+        version: snapshot.version,
+        imageName: snapshot.imageName,
+        instanceSize: Int(snapshot.instanceSize),
+        superClassName: snapshot.superClassName,
+        protocols: snapshot.protocols.map(runtimeProtocolInfo(from:)),
+        ivars: snapshot.ivars.map(runtimeIvarInfo(from:)),
+        classProperties: snapshot.classProperties.map(runtimePropertyInfo(from:)),
+        properties: snapshot.properties.map(runtimePropertyInfo(from:)),
+        classMethods: snapshot.classMethods.map(runtimeMethodInfo(from:)),
+        methods: snapshot.methods.map(runtimeMethodInfo(from:))
+    )
+}
+
 private func runtimeClassInfos(for imagePath: String, options: DumpOptions) -> [ObjCClassInfo] {
     guard options.useRuntimeFallback else { return [] }
     let targetPaths = runtimeFallbackTargetImagePaths(for: imagePath)
@@ -1018,7 +1099,14 @@ private func runtimeClassInfos(for imagePath: String, options: DumpOptions) -> [
         let name = String(cString: namePtr)
         if let only = options.onlyOneClass, only != name { continue }
         if let cls = NSClassFromString(name) ?? (objc_getClass(name) as? AnyClass) {
-            infos.append(ObjCClassInfo(cls))
+            if let info = runtimeClassInfo(
+                for: cls,
+                fallbackName: name,
+                imagePath: imagePath,
+                options: options
+            ) {
+                infos.append(info)
+            }
         }
     }
     if infos.isEmpty {
@@ -1054,7 +1142,14 @@ private func runtimeClassInfosByImageName(
 
         let name = String(cString: class_getName(cls))
         if let only = options.onlyOneClass, only != name { continue }
-        infos.append(ObjCClassInfo(cls))
+        if let info = runtimeClassInfo(
+            for: cls,
+            fallbackName: name,
+            imagePath: imagePath,
+            options: options
+        ) {
+            infos.append(info)
+        }
     }
 
     if options.verbose, !infos.isEmpty {

--- a/Sources/HeaderDumpRuntimeObjC/RuntimeFallbackClassInfo.m
+++ b/Sources/HeaderDumpRuntimeObjC/RuntimeFallbackClassInfo.m
@@ -1,0 +1,506 @@
+#import "HeaderDumpRuntimeObjC.h"
+
+static NSString * const PHRuntimeStageName = @"name";
+static NSString * const PHRuntimeStageImage = @"imageName";
+static NSString * const PHRuntimeStageVersion = @"version";
+static NSString * const PHRuntimeStageInstanceSize = @"instanceSize";
+static NSString * const PHRuntimeStageSuperclass = @"superClassName";
+static NSString * const PHRuntimeStageProtocols = @"protocols";
+static NSString * const PHRuntimeStageIvars = @"ivars";
+static NSString * const PHRuntimeStageClassProperties = @"classProperties";
+static NSString * const PHRuntimeStageProperties = @"properties";
+static NSString * const PHRuntimeStageClassMethods = @"classMethods";
+static NSString * const PHRuntimeStageMethods = @"methods";
+static NSString * const PHRuntimeStageOptionalClassProperties = @"optionalClassProperties";
+static NSString * const PHRuntimeStageOptionalProperties = @"optionalProperties";
+static NSString * const PHRuntimeStageOptionalClassMethods = @"optionalClassMethods";
+static NSString * const PHRuntimeStageOptionalMethods = @"optionalMethods";
+
+@interface PHRuntimeObjCPropertySnapshot ()
+- (instancetype)initWithName:(NSString *)name
+            attributesString:(NSString *)attributesString
+               classProperty:(BOOL)classProperty;
+@end
+
+@implementation PHRuntimeObjCPropertySnapshot
+- (instancetype)initWithName:(NSString *)name
+            attributesString:(NSString *)attributesString
+               classProperty:(BOOL)classProperty {
+    self = [super init];
+    if (self) {
+        _name = [name copy];
+        _attributesString = [attributesString copy];
+        _classProperty = classProperty;
+    }
+    return self;
+}
+@end
+
+@interface PHRuntimeObjCMethodSnapshot ()
+- (instancetype)initWithName:(NSString *)name
+                typeEncoding:(NSString *)typeEncoding
+                 classMethod:(BOOL)classMethod;
+@end
+
+@implementation PHRuntimeObjCMethodSnapshot
+- (instancetype)initWithName:(NSString *)name
+                typeEncoding:(NSString *)typeEncoding
+                 classMethod:(BOOL)classMethod {
+    self = [super init];
+    if (self) {
+        _name = [name copy];
+        _typeEncoding = [typeEncoding copy];
+        _classMethod = classMethod;
+    }
+    return self;
+}
+@end
+
+@interface PHRuntimeObjCIvarSnapshot ()
+- (instancetype)initWithName:(NSString *)name
+                typeEncoding:(NSString *)typeEncoding
+                      offset:(ptrdiff_t)offset;
+@end
+
+@implementation PHRuntimeObjCIvarSnapshot
+- (instancetype)initWithName:(NSString *)name
+                typeEncoding:(NSString *)typeEncoding
+                      offset:(ptrdiff_t)offset {
+    self = [super init];
+    if (self) {
+        _name = [name copy];
+        _typeEncoding = [typeEncoding copy];
+        _offset = offset;
+    }
+    return self;
+}
+@end
+
+@interface PHRuntimeObjCProtocolSnapshot ()
+- (instancetype)initWithName:(NSString *)name
+                   protocols:(NSArray<PHRuntimeObjCProtocolSnapshot *> *)protocols
+             classProperties:(NSArray<PHRuntimeObjCPropertySnapshot *> *)classProperties
+                  properties:(NSArray<PHRuntimeObjCPropertySnapshot *> *)properties
+                classMethods:(NSArray<PHRuntimeObjCMethodSnapshot *> *)classMethods
+                     methods:(NSArray<PHRuntimeObjCMethodSnapshot *> *)methods
+      optionalClassProperties:(NSArray<PHRuntimeObjCPropertySnapshot *> *)optionalClassProperties
+           optionalProperties:(NSArray<PHRuntimeObjCPropertySnapshot *> *)optionalProperties
+         optionalClassMethods:(NSArray<PHRuntimeObjCMethodSnapshot *> *)optionalClassMethods
+              optionalMethods:(NSArray<PHRuntimeObjCMethodSnapshot *> *)optionalMethods;
+@end
+
+@implementation PHRuntimeObjCProtocolSnapshot
+- (instancetype)initWithName:(NSString *)name
+                   protocols:(NSArray<PHRuntimeObjCProtocolSnapshot *> *)protocols
+             classProperties:(NSArray<PHRuntimeObjCPropertySnapshot *> *)classProperties
+                  properties:(NSArray<PHRuntimeObjCPropertySnapshot *> *)properties
+                classMethods:(NSArray<PHRuntimeObjCMethodSnapshot *> *)classMethods
+                     methods:(NSArray<PHRuntimeObjCMethodSnapshot *> *)methods
+      optionalClassProperties:(NSArray<PHRuntimeObjCPropertySnapshot *> *)optionalClassProperties
+           optionalProperties:(NSArray<PHRuntimeObjCPropertySnapshot *> *)optionalProperties
+         optionalClassMethods:(NSArray<PHRuntimeObjCMethodSnapshot *> *)optionalClassMethods
+              optionalMethods:(NSArray<PHRuntimeObjCMethodSnapshot *> *)optionalMethods {
+    self = [super init];
+    if (self) {
+        _name = [name copy];
+        _protocols = [protocols copy];
+        _classProperties = [classProperties copy];
+        _properties = [properties copy];
+        _classMethods = [classMethods copy];
+        _methods = [methods copy];
+        _optionalClassProperties = [optionalClassProperties copy];
+        _optionalProperties = [optionalProperties copy];
+        _optionalClassMethods = [optionalClassMethods copy];
+        _optionalMethods = [optionalMethods copy];
+    }
+    return self;
+}
+@end
+
+@interface PHRuntimeObjCClassSnapshot ()
+- (instancetype)initWithName:(NSString *)name
+                     version:(int32_t)version
+                   imageName:(NSString * _Nullable)imageName
+                instanceSize:(NSUInteger)instanceSize
+              superClassName:(NSString * _Nullable)superClassName
+                   protocols:(NSArray<PHRuntimeObjCProtocolSnapshot *> *)protocols
+                       ivars:(NSArray<PHRuntimeObjCIvarSnapshot *> *)ivars
+             classProperties:(NSArray<PHRuntimeObjCPropertySnapshot *> *)classProperties
+                  properties:(NSArray<PHRuntimeObjCPropertySnapshot *> *)properties
+                classMethods:(NSArray<PHRuntimeObjCMethodSnapshot *> *)classMethods
+                     methods:(NSArray<PHRuntimeObjCMethodSnapshot *> *)methods;
+@end
+
+@implementation PHRuntimeObjCClassSnapshot
+- (instancetype)initWithName:(NSString *)name
+                     version:(int32_t)version
+                   imageName:(NSString * _Nullable)imageName
+                instanceSize:(NSUInteger)instanceSize
+              superClassName:(NSString * _Nullable)superClassName
+                   protocols:(NSArray<PHRuntimeObjCProtocolSnapshot *> *)protocols
+                       ivars:(NSArray<PHRuntimeObjCIvarSnapshot *> *)ivars
+             classProperties:(NSArray<PHRuntimeObjCPropertySnapshot *> *)classProperties
+                  properties:(NSArray<PHRuntimeObjCPropertySnapshot *> *)properties
+                classMethods:(NSArray<PHRuntimeObjCMethodSnapshot *> *)classMethods
+                     methods:(NSArray<PHRuntimeObjCMethodSnapshot *> *)methods {
+    self = [super init];
+    if (self) {
+        _name = [name copy];
+        _version = version;
+        _imageName = [imageName copy];
+        _instanceSize = instanceSize;
+        _superClassName = [superClassName copy];
+        _protocols = [protocols copy];
+        _ivars = [ivars copy];
+        _classProperties = [classProperties copy];
+        _properties = [properties copy];
+        _classMethods = [classMethods copy];
+        _methods = [methods copy];
+    }
+    return self;
+}
+@end
+
+static NSArray<PHRuntimeObjCProtocolSnapshot *> * _Nullable
+PHRuntimeProtocolSnapshotsFromList(Protocol * __unsafe_unretained const _Nullable *start,
+                                   unsigned int count,
+                                   NSString * _Nullable * _Nullable failedStage);
+
+static NSArray<PHRuntimeObjCPropertySnapshot *> * _Nullable
+PHRuntimePropertySnapshotsForClass(Class cls, BOOL isInstance, NSString *stage, NSString * _Nullable * _Nullable failedStage) {
+    Class target = cls;
+    if (!isInstance) {
+        @try {
+            target = object_getClass((id)cls);
+        } @catch (NSException *) {
+            if (failedStage) { *failedStage = stage; }
+            return nil;
+        }
+        if (target == Nil) {
+            if (failedStage) { *failedStage = stage; }
+            return nil;
+        }
+    }
+
+    objc_property_t *start = NULL;
+    unsigned int count = 0;
+    @try {
+        start = class_copyPropertyList(target, &count);
+    } @catch (NSException *) {
+        if (failedStage) { *failedStage = stage; }
+        return nil;
+    }
+
+    NSMutableArray<PHRuntimeObjCPropertySnapshot *> *result = [NSMutableArray arrayWithCapacity:count];
+    for (unsigned int idx = 0; idx < count; idx++) {
+        const char *name = property_getName(start[idx]);
+        const char *attributes = property_getAttributes(start[idx]);
+        if (!name || !attributes) { continue; }
+        NSString *nameString = [NSString stringWithUTF8String:name];
+        NSString *attributesString = [NSString stringWithUTF8String:attributes];
+        if (!nameString || !attributesString) { continue; }
+        [result addObject:[[PHRuntimeObjCPropertySnapshot alloc] initWithName:nameString
+                                                             attributesString:attributesString
+                                                                classProperty:!isInstance]];
+    }
+    if (start) { free(start); }
+    return result;
+}
+
+static NSArray<PHRuntimeObjCMethodSnapshot *> * _Nullable
+PHRuntimeMethodSnapshotsForClass(Class cls, BOOL isInstance, NSString *stage, NSString * _Nullable * _Nullable failedStage) {
+    Class target = cls;
+    if (!isInstance) {
+        @try {
+            target = object_getClass((id)cls);
+        } @catch (NSException *) {
+            if (failedStage) { *failedStage = stage; }
+            return nil;
+        }
+        if (target == Nil) {
+            if (failedStage) { *failedStage = stage; }
+            return nil;
+        }
+    }
+
+    Method *start = NULL;
+    unsigned int count = 0;
+    @try {
+        start = class_copyMethodList(target, &count);
+    } @catch (NSException *) {
+        if (failedStage) { *failedStage = stage; }
+        return nil;
+    }
+
+    NSMutableArray<PHRuntimeObjCMethodSnapshot *> *result = [NSMutableArray arrayWithCapacity:count];
+    for (unsigned int idx = 0; idx < count; idx++) {
+        const char *typeEncoding = method_getTypeEncoding(start[idx]);
+        SEL selector = method_getName(start[idx]);
+        if (!typeEncoding || selector == NULL) { continue; }
+        NSString *nameString = NSStringFromSelector(selector);
+        NSString *typeString = [NSString stringWithUTF8String:typeEncoding];
+        if (!nameString || !typeString) { continue; }
+        [result addObject:[[PHRuntimeObjCMethodSnapshot alloc] initWithName:nameString
+                                                               typeEncoding:typeString
+                                                                classMethod:!isInstance]];
+    }
+    if (start) { free(start); }
+    return result;
+}
+
+static NSArray<PHRuntimeObjCIvarSnapshot *> * _Nullable
+PHRuntimeIvarSnapshotsForClass(Class cls, NSString * _Nullable * _Nullable failedStage) {
+    Ivar *start = NULL;
+    unsigned int count = 0;
+    @try {
+        start = class_copyIvarList(cls, &count);
+    } @catch (NSException *) {
+        if (failedStage) { *failedStage = PHRuntimeStageIvars; }
+        return nil;
+    }
+
+    NSMutableArray<PHRuntimeObjCIvarSnapshot *> *result = [NSMutableArray arrayWithCapacity:count];
+    for (unsigned int idx = 0; idx < count; idx++) {
+        const char *name = ivar_getName(start[idx]);
+        const char *typeEncoding = ivar_getTypeEncoding(start[idx]);
+        if (!name || !typeEncoding) { continue; }
+        NSString *nameString = [NSString stringWithUTF8String:name];
+        NSString *typeString = [NSString stringWithUTF8String:typeEncoding];
+        if (!nameString || !typeString) { continue; }
+        [result addObject:[[PHRuntimeObjCIvarSnapshot alloc] initWithName:nameString
+                                                             typeEncoding:typeString
+                                                                   offset:ivar_getOffset(start[idx])]];
+    }
+    if (start) { free(start); }
+    return result;
+}
+
+static NSArray<PHRuntimeObjCMethodSnapshot *> * _Nullable
+PHRuntimeMethodSnapshotsForProtocol(Protocol *protocol, BOOL isRequired, BOOL isInstance, NSString *stage, NSString * _Nullable * _Nullable failedStage) {
+    struct objc_method_description *start = NULL;
+    unsigned int count = 0;
+    @try {
+        start = protocol_copyMethodDescriptionList(protocol, isRequired, isInstance, &count);
+    } @catch (NSException *) {
+        if (failedStage) { *failedStage = stage; }
+        return nil;
+    }
+
+    NSMutableArray<PHRuntimeObjCMethodSnapshot *> *result = [NSMutableArray arrayWithCapacity:count];
+    for (unsigned int idx = 0; idx < count; idx++) {
+        if (start[idx].name == NULL || start[idx].types == NULL) { continue; }
+        NSString *nameString = NSStringFromSelector(start[idx].name);
+        NSString *typeString = [NSString stringWithUTF8String:start[idx].types];
+        if (!nameString || !typeString) { continue; }
+        [result addObject:[[PHRuntimeObjCMethodSnapshot alloc] initWithName:nameString
+                                                               typeEncoding:typeString
+                                                                classMethod:!isInstance]];
+    }
+    if (start) { free(start); }
+    return result;
+}
+
+static NSArray<PHRuntimeObjCPropertySnapshot *> * _Nullable
+PHRuntimePropertySnapshotsForProtocol(Protocol *protocol, BOOL isRequired, BOOL isInstance, NSString *stage, NSString * _Nullable * _Nullable failedStage) {
+    objc_property_t *start = NULL;
+    unsigned int count = 0;
+    @try {
+        start = protocol_copyPropertyList2(protocol, &count, isRequired, isInstance);
+    } @catch (NSException *) {
+        if (failedStage) { *failedStage = stage; }
+        return nil;
+    }
+
+    NSMutableArray<PHRuntimeObjCPropertySnapshot *> *result = [NSMutableArray arrayWithCapacity:count];
+    for (unsigned int idx = 0; idx < count; idx++) {
+        const char *name = property_getName(start[idx]);
+        const char *attributes = property_getAttributes(start[idx]);
+        if (!name || !attributes) { continue; }
+        NSString *nameString = [NSString stringWithUTF8String:name];
+        NSString *attributesString = [NSString stringWithUTF8String:attributes];
+        if (!nameString || !attributesString) { continue; }
+        [result addObject:[[PHRuntimeObjCPropertySnapshot alloc] initWithName:nameString
+                                                             attributesString:attributesString
+                                                                classProperty:!isInstance]];
+    }
+    if (start) { free(start); }
+    return result;
+}
+
+static PHRuntimeObjCProtocolSnapshot * _Nullable
+PHRuntimeProtocolSnapshot(Protocol *protocol, NSString * _Nullable * _Nullable failedStage) {
+    NSString *name = nil;
+    @try {
+        const char *protocolName = protocol_getName(protocol);
+        if (!protocolName) {
+            if (failedStage) { *failedStage = PHRuntimeStageProtocols; }
+            return nil;
+        }
+        name = [NSString stringWithUTF8String:protocolName];
+    } @catch (NSException *) {
+        if (failedStage) { *failedStage = PHRuntimeStageProtocols; }
+        return nil;
+    }
+    if (!name) {
+        if (failedStage) { *failedStage = PHRuntimeStageProtocols; }
+        return nil;
+    }
+
+    Protocol *__unsafe_unretained *protocolStart = NULL;
+    unsigned int protocolCount = 0;
+    @try {
+        protocolStart = protocol_copyProtocolList(protocol, &protocolCount);
+    } @catch (NSException *) {
+        if (failedStage) { *failedStage = PHRuntimeStageProtocols; }
+        return nil;
+    }
+    NSArray<PHRuntimeObjCProtocolSnapshot *> *protocols = PHRuntimeProtocolSnapshotsFromList(protocolStart, protocolCount, failedStage);
+    if (protocolStart) { free(protocolStart); }
+    if (!protocols && failedStage && *failedStage) { return nil; }
+
+    NSArray<PHRuntimeObjCPropertySnapshot *> *classProperties = PHRuntimePropertySnapshotsForProtocol(protocol, YES, NO, PHRuntimeStageClassProperties, failedStage);
+    if (!classProperties && failedStage && *failedStage) { return nil; }
+    NSArray<PHRuntimeObjCPropertySnapshot *> *properties = PHRuntimePropertySnapshotsForProtocol(protocol, YES, YES, PHRuntimeStageProperties, failedStage);
+    if (!properties && failedStage && *failedStage) { return nil; }
+    NSArray<PHRuntimeObjCMethodSnapshot *> *classMethods = PHRuntimeMethodSnapshotsForProtocol(protocol, YES, NO, PHRuntimeStageClassMethods, failedStage);
+    if (!classMethods && failedStage && *failedStage) { return nil; }
+    NSArray<PHRuntimeObjCMethodSnapshot *> *methods = PHRuntimeMethodSnapshotsForProtocol(protocol, YES, YES, PHRuntimeStageMethods, failedStage);
+    if (!methods && failedStage && *failedStage) { return nil; }
+    NSArray<PHRuntimeObjCPropertySnapshot *> *optionalClassProperties = PHRuntimePropertySnapshotsForProtocol(protocol, NO, NO, PHRuntimeStageOptionalClassProperties, failedStage);
+    if (!optionalClassProperties && failedStage && *failedStage) { return nil; }
+    NSArray<PHRuntimeObjCPropertySnapshot *> *optionalProperties = PHRuntimePropertySnapshotsForProtocol(protocol, NO, YES, PHRuntimeStageOptionalProperties, failedStage);
+    if (!optionalProperties && failedStage && *failedStage) { return nil; }
+    NSArray<PHRuntimeObjCMethodSnapshot *> *optionalClassMethods = PHRuntimeMethodSnapshotsForProtocol(protocol, NO, NO, PHRuntimeStageOptionalClassMethods, failedStage);
+    if (!optionalClassMethods && failedStage && *failedStage) { return nil; }
+    NSArray<PHRuntimeObjCMethodSnapshot *> *optionalMethods = PHRuntimeMethodSnapshotsForProtocol(protocol, NO, YES, PHRuntimeStageOptionalMethods, failedStage);
+    if (!optionalMethods && failedStage && *failedStage) { return nil; }
+
+    return [[PHRuntimeObjCProtocolSnapshot alloc] initWithName:name
+                                                     protocols:protocols ?: @[]
+                                               classProperties:classProperties ?: @[]
+                                                    properties:properties ?: @[]
+                                                  classMethods:classMethods ?: @[]
+                                                       methods:methods ?: @[]
+                                        optionalClassProperties:optionalClassProperties ?: @[]
+                                             optionalProperties:optionalProperties ?: @[]
+                                           optionalClassMethods:optionalClassMethods ?: @[]
+                                                optionalMethods:optionalMethods ?: @[]];
+}
+
+static NSArray<PHRuntimeObjCProtocolSnapshot *> * _Nullable
+PHRuntimeProtocolSnapshotsFromList(Protocol * __unsafe_unretained const _Nullable *start,
+                                   unsigned int count,
+                                   NSString * _Nullable * _Nullable failedStage) {
+    NSMutableArray<PHRuntimeObjCProtocolSnapshot *> *result = [NSMutableArray arrayWithCapacity:count];
+    if (start == NULL || count == 0) { return result; }
+
+    for (unsigned int idx = 0; idx < count; idx++) {
+        Protocol *protocol = start[idx];
+        if (!protocol) { continue; }
+        PHRuntimeObjCProtocolSnapshot *snapshot = PHRuntimeProtocolSnapshot(protocol, failedStage);
+        if (!snapshot && failedStage && *failedStage) {
+            return nil;
+        }
+        if (snapshot) {
+            [result addObject:snapshot];
+        }
+    }
+    return result;
+}
+
+static NSArray<PHRuntimeObjCProtocolSnapshot *> * _Nullable
+PHRuntimeProtocolSnapshotsForClass(Class cls, NSString * _Nullable * _Nullable failedStage) {
+    Protocol *__unsafe_unretained *start = NULL;
+    unsigned int count = 0;
+    @try {
+        start = class_copyProtocolList(cls, &count);
+    } @catch (NSException *) {
+        if (failedStage) { *failedStage = PHRuntimeStageProtocols; }
+        return nil;
+    }
+    NSArray<PHRuntimeObjCProtocolSnapshot *> *result = PHRuntimeProtocolSnapshotsFromList(start, count, failedStage);
+    if (start) { free(start); }
+    return result;
+}
+
+@implementation PHRuntimeObjCInspector
++ (PHRuntimeObjCClassSnapshot *)snapshotForClass:(Class)cls
+                                    failedStage:(NSString * _Nullable * _Nullable)failedStage {
+    if (failedStage) { *failedStage = nil; }
+
+    NSString *name = nil;
+    @try {
+        name = NSStringFromClass(cls);
+    } @catch (NSException *) {
+        if (failedStage) { *failedStage = PHRuntimeStageName; }
+        return nil;
+    }
+    if (!name) {
+        if (failedStage) { *failedStage = PHRuntimeStageName; }
+        return nil;
+    }
+
+    NSString *imageName = nil;
+    @try {
+        const char *image = class_getImageName(cls);
+        if (image) {
+            imageName = [NSString stringWithUTF8String:image];
+        }
+    } @catch (NSException *) {
+        if (failedStage) { *failedStage = PHRuntimeStageImage; }
+        return nil;
+    }
+
+    int32_t version = 0;
+    @try {
+        version = class_getVersion(cls);
+    } @catch (NSException *) {
+        if (failedStage) { *failedStage = PHRuntimeStageVersion; }
+        return nil;
+    }
+
+    NSUInteger instanceSize = 0;
+    @try {
+        instanceSize = class_getInstanceSize(cls);
+    } @catch (NSException *) {
+        if (failedStage) { *failedStage = PHRuntimeStageInstanceSize; }
+        return nil;
+    }
+
+    NSString *superClassName = nil;
+    @try {
+        Class superClass = class_getSuperclass(cls);
+        if (superClass) {
+            superClassName = NSStringFromClass(superClass);
+        }
+    } @catch (NSException *) {
+        if (failedStage) { *failedStage = PHRuntimeStageSuperclass; }
+        return nil;
+    }
+
+    NSArray<PHRuntimeObjCProtocolSnapshot *> *protocols = PHRuntimeProtocolSnapshotsForClass(cls, failedStage);
+    if (!protocols && failedStage && *failedStage) { return nil; }
+    NSArray<PHRuntimeObjCIvarSnapshot *> *ivars = PHRuntimeIvarSnapshotsForClass(cls, failedStage);
+    if (!ivars && failedStage && *failedStage) { return nil; }
+    NSArray<PHRuntimeObjCPropertySnapshot *> *classProperties = PHRuntimePropertySnapshotsForClass(cls, NO, PHRuntimeStageClassProperties, failedStage);
+    if (!classProperties && failedStage && *failedStage) { return nil; }
+    NSArray<PHRuntimeObjCPropertySnapshot *> *properties = PHRuntimePropertySnapshotsForClass(cls, YES, PHRuntimeStageProperties, failedStage);
+    if (!properties && failedStage && *failedStage) { return nil; }
+    NSArray<PHRuntimeObjCMethodSnapshot *> *classMethods = PHRuntimeMethodSnapshotsForClass(cls, NO, PHRuntimeStageClassMethods, failedStage);
+    if (!classMethods && failedStage && *failedStage) { return nil; }
+    NSArray<PHRuntimeObjCMethodSnapshot *> *methods = PHRuntimeMethodSnapshotsForClass(cls, YES, PHRuntimeStageMethods, failedStage);
+    if (!methods && failedStage && *failedStage) { return nil; }
+
+    return [[PHRuntimeObjCClassSnapshot alloc] initWithName:name
+                                                    version:version
+                                                  imageName:imageName
+                                               instanceSize:instanceSize
+                                             superClassName:superClassName
+                                                  protocols:protocols ?: @[]
+                                                      ivars:ivars ?: @[]
+                                            classProperties:classProperties ?: @[]
+                                                 properties:properties ?: @[]
+                                               classMethods:classMethods ?: @[]
+                                                    methods:methods ?: @[]];
+}
+@end

--- a/Sources/HeaderDumpRuntimeObjC/include/HeaderDumpRuntimeObjC.h
+++ b/Sources/HeaderDumpRuntimeObjC/include/HeaderDumpRuntimeObjC.h
@@ -1,0 +1,66 @@
+#import <Foundation/Foundation.h>
+#import <objc/runtime.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface PHRuntimeObjCPropertySnapshot : NSObject
+@property (nonatomic, readonly, copy) NSString *name;
+@property (nonatomic, readonly, copy) NSString *attributesString;
+@property (nonatomic, readonly, getter=isClassProperty) BOOL classProperty;
+- (instancetype)init NS_UNAVAILABLE;
++ (instancetype)new NS_UNAVAILABLE;
+@end
+
+@interface PHRuntimeObjCMethodSnapshot : NSObject
+@property (nonatomic, readonly, copy) NSString *name;
+@property (nonatomic, readonly, copy) NSString *typeEncoding;
+@property (nonatomic, readonly, getter=isClassMethod) BOOL classMethod;
+- (instancetype)init NS_UNAVAILABLE;
++ (instancetype)new NS_UNAVAILABLE;
+@end
+
+@interface PHRuntimeObjCIvarSnapshot : NSObject
+@property (nonatomic, readonly, copy) NSString *name;
+@property (nonatomic, readonly, copy) NSString *typeEncoding;
+@property (nonatomic, readonly) ptrdiff_t offset;
+- (instancetype)init NS_UNAVAILABLE;
++ (instancetype)new NS_UNAVAILABLE;
+@end
+
+@interface PHRuntimeObjCProtocolSnapshot : NSObject
+@property (nonatomic, readonly, copy) NSString *name;
+@property (nonatomic, readonly, copy) NSArray<PHRuntimeObjCProtocolSnapshot *> *protocols;
+@property (nonatomic, readonly, copy) NSArray<PHRuntimeObjCPropertySnapshot *> *classProperties;
+@property (nonatomic, readonly, copy) NSArray<PHRuntimeObjCPropertySnapshot *> *properties;
+@property (nonatomic, readonly, copy) NSArray<PHRuntimeObjCMethodSnapshot *> *classMethods;
+@property (nonatomic, readonly, copy) NSArray<PHRuntimeObjCMethodSnapshot *> *methods;
+@property (nonatomic, readonly, copy) NSArray<PHRuntimeObjCPropertySnapshot *> *optionalClassProperties;
+@property (nonatomic, readonly, copy) NSArray<PHRuntimeObjCPropertySnapshot *> *optionalProperties;
+@property (nonatomic, readonly, copy) NSArray<PHRuntimeObjCMethodSnapshot *> *optionalClassMethods;
+@property (nonatomic, readonly, copy) NSArray<PHRuntimeObjCMethodSnapshot *> *optionalMethods;
+- (instancetype)init NS_UNAVAILABLE;
++ (instancetype)new NS_UNAVAILABLE;
+@end
+
+@interface PHRuntimeObjCClassSnapshot : NSObject
+@property (nonatomic, readonly, copy) NSString *name;
+@property (nonatomic, readonly) int32_t version;
+@property (nonatomic, readonly, copy, nullable) NSString *imageName;
+@property (nonatomic, readonly) NSUInteger instanceSize;
+@property (nonatomic, readonly, copy, nullable) NSString *superClassName;
+@property (nonatomic, readonly, copy) NSArray<PHRuntimeObjCProtocolSnapshot *> *protocols;
+@property (nonatomic, readonly, copy) NSArray<PHRuntimeObjCIvarSnapshot *> *ivars;
+@property (nonatomic, readonly, copy) NSArray<PHRuntimeObjCPropertySnapshot *> *classProperties;
+@property (nonatomic, readonly, copy) NSArray<PHRuntimeObjCPropertySnapshot *> *properties;
+@property (nonatomic, readonly, copy) NSArray<PHRuntimeObjCMethodSnapshot *> *classMethods;
+@property (nonatomic, readonly, copy) NSArray<PHRuntimeObjCMethodSnapshot *> *methods;
+- (instancetype)init NS_UNAVAILABLE;
++ (instancetype)new NS_UNAVAILABLE;
+@end
+
+@interface PHRuntimeObjCInspector : NSObject
++ (nullable PHRuntimeObjCClassSnapshot *)snapshotForClass:(Class)cls
+                                             failedStage:(NSString * _Nullable * _Nullable)failedStage;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Sources/PrivateHeaderKitDump/main.swift
+++ b/Sources/PrivateHeaderKitDump/main.swift
@@ -53,7 +53,7 @@ private struct MacOSVersionInfo {
     let buildVersion: String
 }
 
-private struct Context {
+struct Context {
     var platform: TargetPlatform
     var execMode: ExecMode
     var headerdumpBin: URL
@@ -1365,6 +1365,14 @@ private func fileManagerIsDirectory(_ url: URL, fileManager: FileManager = .defa
 }
 
 private let normalizedBundleExtensions: Set<String> = ["app", "bundle", "xpc", "appex"]
+private let completionMarkerFileName = ".privateheaderkit-complete.json"
+
+internal struct CompletionMarker: Codable {
+    let tool: String
+    let imagePath: String
+    let layout: String
+    let completedAt: String
+}
 
 private func normalizedBundleDirURLIfNeeded(_ url: URL) -> URL {
     let ext = url.pathExtension.lowercased()
@@ -1392,19 +1400,26 @@ private func denormalizeNestedXPCAndPlugIns(in bundleDir: URL, overwrite: Bool) 
     try FileOps.denormalizeBundleDirs(in: plugInsDir, bundleExtension: "appex", overwrite: overwrite, fileManager: fm)
 }
 
-private func directoryContainsHeaderArtifacts(_ dir: URL, fileManager: FileManager = .default) -> Bool {
-    guard fileManagerIsDirectory(dir, fileManager: fileManager) else { return false }
-    guard let entries = try? fileManager.contentsOfDirectory(
-        at: dir,
-        includingPropertiesForKeys: [.isDirectoryKey, .isRegularFileKey],
+internal func completionMarkerURL(for outputDir: URL) -> URL {
+    outputDir.appendingPathComponent(completionMarkerFileName, isDirectory: false)
+}
+
+internal func hasCompletionMarker(in outputDir: URL, fileManager: FileManager = .default) -> Bool {
+    fileManager.fileExists(atPath: completionMarkerURL(for: outputDir).path)
+}
+
+private func directoryContainsHeaderArtifacts(in outputDir: URL, fileManager: FileManager = .default) -> Bool {
+    guard fileManagerIsDirectory(outputDir, fileManager: fileManager) else { return false }
+    guard let enumerator = fileManager.enumerator(
+        at: outputDir,
+        includingPropertiesForKeys: [.isRegularFileKey],
         options: [.skipsHiddenFiles]
     ) else {
         return false
     }
 
-    for entry in entries {
-        guard (try? entry.resourceValues(forKeys: [.isRegularFileKey]).isRegularFile) == true else { continue }
-        let ext = entry.pathExtension.lowercased()
+    for case let fileURL as URL in enumerator {
+        let ext = fileURL.pathExtension.lowercased()
         if ext == "h" || ext == "swiftinterface" {
             return true
         }
@@ -1412,12 +1427,54 @@ private func directoryContainsHeaderArtifacts(_ dir: URL, fileManager: FileManag
     return false
 }
 
-private func bundleOutputHasHeaderArtifacts(_ bundleDir: URL, fileManager: FileManager = .default) -> Bool {
-    directoryContainsHeaderArtifacts(bundleDir.appendingPathComponent("Headers", isDirectory: true), fileManager: fileManager)
+private func hasCompletedOutput(in outputDir: URL, fileManager: FileManager = .default) -> Bool {
+    hasCompletionMarker(in: outputDir, fileManager: fileManager)
+        && directoryContainsHeaderArtifacts(in: outputDir, fileManager: fileManager)
 }
 
-private func dylibOutputHasHeaderArtifacts(_ dylibDir: URL, fileManager: FileManager = .default) -> Bool {
-    directoryContainsHeaderArtifacts(dylibDir, fileManager: fileManager)
+internal func writeCompletionMarker(
+    in outputDir: URL,
+    imagePath: String,
+    layout: String,
+    fileManager: FileManager = .default
+) throws {
+    try fileManager.createDirectory(at: outputDir, withIntermediateDirectories: true)
+    let formatter = ISO8601DateFormatter()
+    let marker = CompletionMarker(
+        tool: "privateheaderkit-dump",
+        imagePath: imagePath,
+        layout: layout,
+        completedAt: formatter.string(from: Date())
+    )
+    let data = try JSONEncoder().encode(marker)
+    try data.write(to: completionMarkerURL(for: outputDir))
+}
+
+internal func frameworkOutputDir(ctx: Context, category: String, frameworkName: String) -> URL {
+    let base = ctx.outDir.appendingPathComponent(category, isDirectory: true)
+    if ctx.layout == "headers" {
+        let normalizedName = frameworkName.hasSuffix(".framework")
+            ? String(frameworkName.dropLast(".framework".count))
+            : frameworkName
+        return base.appendingPathComponent(normalizedName, isDirectory: true)
+    }
+    return base.appendingPathComponent(frameworkName, isDirectory: true)
+}
+
+internal func systemLibraryOutputDir(ctx: Context, relativePath: String) -> URL {
+    let base = ctx.outDir.appendingPathComponent("SystemLibrary", isDirectory: true)
+    let dest = appendingRelativePath(base, relativePath, isDirectory: true)
+    if ctx.layout == "headers" {
+        return normalizedBundleDirURLIfNeeded(dest)
+    }
+    return dest
+}
+
+internal func dylibOutputDir(ctx: Context, dylibName: String) -> URL {
+    ctx.outDir
+        .appendingPathComponent("usr", isDirectory: true)
+        .appendingPathComponent("lib", isDirectory: true)
+        .appendingPathComponent(dylibName, isDirectory: true)
 }
 
 private func appendingRelativePath(_ base: URL, _ relativePath: String, isDirectory: Bool = true) -> URL {
@@ -1537,31 +1594,11 @@ private func listUsrLibDylibs(ctx: Context) throws -> [String] {
     return dylibs
 }
 
-private func existingFrameworksInCategory(ctx: Context, category: String, frameworks: Set<String>) -> Set<String> {
-    let categoryDir = ctx.outDir.appendingPathComponent(category, isDirectory: true)
-    guard FileOps.isDirectory(categoryDir) else { return [] }
-
-    let basePath = categoryDir.path
+internal func existingFrameworksInCategory(ctx: Context, category: String, frameworks: Set<String>) -> Set<String> {
     var existing: Set<String> = []
-    let fileManager = FileManager.default
-    guard let enumerator = fileManager.enumerator(at: categoryDir, includingPropertiesForKeys: [.isDirectoryKey], options: []) else {
-        return []
-    }
-
-    for case let url as URL in enumerator {
-        if FileOps.isDirectory(url), url.lastPathComponent.hasPrefix(".tmp") {
-            enumerator.skipDescendants()
-            continue
-        }
-        let ext = url.pathExtension.lowercased()
-        if ext != "h" && ext != "swiftinterface" { continue }
-        guard url.path.hasPrefix(basePath + "/") else { continue }
-        let rel = url.path.dropFirst(basePath.count + 1)
-        guard let top = rel.split(separator: "/").first else { continue }
-        let topName = String(top)
-        let frameworkName = (ctx.layout == "headers") ? FileOps.normalizeFrameworkName(topName) : topName
-        if frameworks.contains(frameworkName) {
-            existing.insert(frameworkName)
+    for framework in frameworks {
+        if hasCompletedOutput(in: frameworkOutputDir(ctx: ctx, category: category, frameworkName: framework)) {
+            existing.insert(framework)
         }
     }
     return existing
@@ -1587,7 +1624,7 @@ private func dumpCategory(category: String, ctx: Context, runner: CommandRunning
     return false
 }
 
-private func dumpCategorySplit(category: String, ctx: Context, runner: CommandRunning) throws -> Bool {
+internal func dumpCategorySplit(category: String, ctx: Context, runner: CommandRunning) throws -> Bool {
     try throwIfTerminationRequested()
     let frameworks = try listFrameworks(category: category, ctx: ctx)
     if frameworks.isEmpty {
@@ -1662,13 +1699,18 @@ private func dumpCategorySplit(category: String, ctx: Context, runner: CommandRu
             }
 
             try relocateFrameworkOutput(ctx: ctx, category: category, frameworkName: item)
+            let outputDir = frameworkOutputDir(ctx: ctx, category: category, frameworkName: item)
+            let nestedFailed = failures.contains { $0.hasPrefix(path + "/") }
             if ctx.layout == "headers" {
-                try normalizeFrameworkDir(ctx: ctx, category: category, frameworkName: item, overwrite: !ctx.skipExisting)
-                let baseName = item.hasSuffix(".framework") ? String(item.dropLast(".framework".count)) : item
-                let dest = ctx.outDir
-                    .appendingPathComponent(category, isDirectory: true)
-                    .appendingPathComponent(baseName, isDirectory: true)
-                try normalizeNestedXPCAndPlugIns(in: dest, overwrite: !ctx.skipExisting)
+                try normalizeFrameworkDir(ctx: ctx, category: category, frameworkName: item, overwrite: true)
+                try normalizeNestedXPCAndPlugIns(in: outputDir, overwrite: true)
+            }
+            if !nestedFailed {
+                try writeCompletionMarker(
+                    in: outputDir,
+                    imagePath: path,
+                    layout: ctx.layout
+                )
             }
             if inlineProgress {
                 renderInlineProgressEnd("\(progressText) (elapsed: \(frameworkElapsedText)s)")
@@ -1687,7 +1729,7 @@ private func dumpCategorySplit(category: String, ctx: Context, runner: CommandRu
     return false
 }
 
-private func dumpSystemLibraryItems(ctx: Context, items: [String], runner: CommandRunning) throws -> Bool {
+internal func dumpSystemLibraryItems(ctx: Context, items: [String], runner: CommandRunning) throws -> Bool {
     try throwIfTerminationRequested()
     print("Dumping: SystemLibrary")
 
@@ -1707,20 +1749,18 @@ private func dumpSystemLibraryItems(ctx: Context, items: [String], runner: Comma
     for (idx, relPath) in items.enumerated() {
         try throwIfTerminationRequested()
 
-        let dest = appendingRelativePath(outBase, relPath, isDirectory: true)
-        let normalizedDest = normalizedBundleDirURLIfNeeded(dest)
-        if ctx.skipExisting,
-           (bundleOutputHasHeaderArtifacts(dest, fileManager: fileManager) || bundleOutputHasHeaderArtifacts(normalizedDest, fileManager: fileManager))
-        {
+        let denormalizedDest = appendingRelativePath(outBase, relPath, isDirectory: true)
+        let outputDir = systemLibraryOutputDir(ctx: ctx, relativePath: relPath)
+        if ctx.skipExisting, hasCompletedOutput(in: outputDir) {
             // Best-effort: keep existing outputs consistent with the requested layout even when skipping.
             //
             // In particular, switching from `--layout headers` to `--layout bundle` should not require a re-dump:
             // rename `Foo` -> `Foo.bundle` (and similarly for nested XPC/appex bundles) when possible.
             var existingDir: URL?
-            if fileManager.fileExists(atPath: dest.path) {
-                existingDir = dest
-            } else if fileManager.fileExists(atPath: normalizedDest.path) {
-                existingDir = normalizedDest
+            if fileManager.fileExists(atPath: denormalizedDest.path) {
+                existingDir = denormalizedDest
+            } else if fileManager.fileExists(atPath: outputDir.path) {
+                existingDir = outputDir
             }
 
             if var bundleDir = existingDir {
@@ -1733,7 +1773,7 @@ private func dumpSystemLibraryItems(ctx: Context, items: [String], runner: Comma
                     )) ?? bundleDir
                     try? normalizeNestedXPCAndPlugIns(in: bundleDir, overwrite: false)
                 } else {
-                    let ext = dest.pathExtension
+                    let ext = denormalizedDest.pathExtension
                     bundleDir = (try? FileOps.denormalizeBundleDir(
                         bundleDir,
                         bundleExtension: ext,
@@ -1781,22 +1821,33 @@ private func dumpSystemLibraryItems(ctx: Context, items: [String], runner: Comma
         }
 
         try relocateSystemLibraryItemOutput(ctx: ctx, systemLibraryRelativePath: relPath, destBaseDir: outBase)
+        let nestedFailed = failures.contains { $0.hasPrefix("SystemLibrary/\(relPath)/") }
 
         if normalizeBundles {
-            var bundleDir = dest
+            var bundleDir = denormalizedDest
             bundleDir = try FileOps.normalizeBundleDir(
                 bundleDir,
                 allowedExtensions: normalizedBundleExtensions,
-                overwrite: !ctx.skipExisting,
+                overwrite: true,
                 fileManager: fileManager
             )
-            try normalizeNestedXPCAndPlugIns(in: bundleDir, overwrite: !ctx.skipExisting)
-        } else if dest.path != normalizedDest.path {
+            try normalizeNestedXPCAndPlugIns(in: bundleDir, overwrite: true)
+        } else {
             // When switching layouts with `--force`, remove stale "headers" layout output (e.g. `Foo`)
             // next to the fresh bundle output (e.g. `Foo.bundle`) so one run produces a consistent layout.
-            if fileManager.fileExists(atPath: normalizedDest.path) {
+            let normalizedDest = normalizedBundleDirURLIfNeeded(denormalizedDest)
+            if normalizedDest.path != denormalizedDest.path,
+               fileManager.fileExists(atPath: normalizedDest.path)
+            {
                 try? fileManager.removeItem(at: normalizedDest)
             }
+        }
+        if !nestedFailed {
+            try writeCompletionMarker(
+                in: outputDir,
+                imagePath: "SystemLibrary/\(relPath)",
+                layout: ctx.layout
+            )
         }
 
         if inlineProgress {
@@ -1829,15 +1880,11 @@ private func dumpUsrLibDylibItems(ctx: Context, dylibs: [String], runner: Comman
     let inlineProgress = canInlineFrameworkProgress(ctx: ctx)
     let fileManager = FileManager.default
 
-    let outBase = ctx.outDir
-        .appendingPathComponent("usr", isDirectory: true)
-        .appendingPathComponent("lib", isDirectory: true)
-
     for (idx, name) in dylibs.enumerated() {
         try throwIfTerminationRequested()
 
-        let dest = outBase.appendingPathComponent(name, isDirectory: true)
-        if ctx.skipExisting, dylibOutputHasHeaderArtifacts(dest, fileManager: fileManager) {
+        let outputDir = dylibOutputDir(ctx: ctx, dylibName: name)
+        if ctx.skipExisting, hasCompletedOutput(in: outputDir, fileManager: fileManager) {
             print("Skipping existing: usr/lib (\(idx + 1)/\(total)) \(name)")
             continue
         }
@@ -1877,6 +1924,12 @@ private func dumpUsrLibDylibItems(ctx: Context, dylibs: [String], runner: Comman
         }
 
         try relocateUsrLibOutput(ctx: ctx, dylibName: name)
+        try writeCompletionMarker(
+            in: outputDir,
+            imagePath: "usr/lib/\(name)",
+            layout: ctx.layout,
+            fileManager: fileManager
+        )
 
         if inlineProgress {
             renderInlineProgressEnd("\(progressText) (elapsed: \(elapsedText)s)")
@@ -1894,7 +1947,12 @@ private func dumpUsrLibDylibItems(ctx: Context, dylibs: [String], runner: Comman
     return false
 }
 
-private func relocateSystemLibraryItemOutput(ctx: Context, systemLibraryRelativePath: String, destBaseDir: URL) throws {
+private func relocateSystemLibraryItemOutput(
+    ctx: Context,
+    systemLibraryRelativePath: String,
+    destBaseDir: URL,
+    overwrite: Bool = true
+) throws {
     let fileManager = FileManager.default
     var src: URL?
     for base in FileOps.stageSystemLibraryRoots(stageDir: ctx.stageDir, runtimeRoot: ctx.systemRoot) {
@@ -1910,7 +1968,6 @@ private func relocateSystemLibraryItemOutput(ctx: Context, systemLibraryRelative
     try fileManager.createDirectory(at: dest.deletingLastPathComponent(), withIntermediateDirectories: true)
 
     if fileManager.fileExists(atPath: dest.path) {
-        let overwrite = !ctx.skipExisting
         if overwrite {
             try FileOps.moveReplace(src: src, dest: dest, fileManager: fileManager)
         } else {
@@ -1922,7 +1979,11 @@ private func relocateSystemLibraryItemOutput(ctx: Context, systemLibraryRelative
     }
 }
 
-private func relocateUsrLibOutput(ctx: Context, dylibName: String) throws {
+private func relocateUsrLibOutput(
+    ctx: Context,
+    dylibName: String,
+    overwrite: Bool = true
+) throws {
     let fileManager = FileManager.default
     var src: URL?
     for base in FileOps.stageUsrLibRoots(stageDir: ctx.stageDir, runtimeRoot: ctx.systemRoot) {
@@ -1941,7 +2002,6 @@ private func relocateUsrLibOutput(ctx: Context, dylibName: String) throws {
     let dest = destDir.appendingPathComponent(dylibName, isDirectory: true)
 
     if fileManager.fileExists(atPath: dest.path) {
-        let overwrite = !ctx.skipExisting
         if overwrite {
             try FileOps.moveReplace(src: src, dest: dest, fileManager: fileManager)
         } else {
@@ -1953,7 +2013,12 @@ private func relocateUsrLibOutput(ctx: Context, dylibName: String) throws {
     }
 }
 
-private func relocateFrameworkOutput(ctx: Context, category: String, frameworkName: String) throws {
+private func relocateFrameworkOutput(
+    ctx: Context,
+    category: String,
+    frameworkName: String,
+    overwrite: Bool = true
+) throws {
     let fileManager = FileManager.default
     var src: URL?
     for base in FileOps.stageSystemLibraryRoots(stageDir: ctx.stageDir, runtimeRoot: ctx.systemRoot) {
@@ -1970,7 +2035,6 @@ private func relocateFrameworkOutput(ctx: Context, category: String, frameworkNa
     let dest = destDir.appendingPathComponent(frameworkName, isDirectory: true)
 
     if fileManager.fileExists(atPath: dest.path) {
-        let overwrite = !ctx.skipExisting
         if overwrite {
             try FileOps.moveReplace(src: src, dest: dest, fileManager: fileManager)
         } else {

--- a/Sources/PrivateHeaderKitDump/main.swift
+++ b/Sources/PrivateHeaderKitDump/main.swift
@@ -1432,6 +1432,13 @@ private func hasCompletedOutput(in outputDir: URL, fileManager: FileManager = .d
         && directoryContainsHeaderArtifacts(in: outputDir, fileManager: fileManager)
 }
 
+private func firstCompletedOutput(in candidates: [URL], fileManager: FileManager = .default) -> URL? {
+    for candidate in candidates where hasCompletedOutput(in: candidate, fileManager: fileManager) {
+        return candidate
+    }
+    return nil
+}
+
 internal func writeCompletionMarker(
     in outputDir: URL,
     imagePath: String,
@@ -1461,6 +1468,17 @@ internal func frameworkOutputDir(ctx: Context, category: String, frameworkName: 
     return base.appendingPathComponent(frameworkName, isDirectory: true)
 }
 
+private func frameworkOutputDirs(ctx: Context, category: String, frameworkName: String) -> (headers: URL, bundle: URL) {
+    let base = ctx.outDir.appendingPathComponent(category, isDirectory: true)
+    let normalizedName = frameworkName.hasSuffix(".framework")
+        ? String(frameworkName.dropLast(".framework".count))
+        : frameworkName
+    return (
+        headers: base.appendingPathComponent(normalizedName, isDirectory: true),
+        bundle: base.appendingPathComponent(frameworkName, isDirectory: true)
+    )
+}
+
 internal func systemLibraryOutputDir(ctx: Context, relativePath: String) -> URL {
     let base = ctx.outDir.appendingPathComponent("SystemLibrary", isDirectory: true)
     let dest = appendingRelativePath(base, relativePath, isDirectory: true)
@@ -1468,6 +1486,15 @@ internal func systemLibraryOutputDir(ctx: Context, relativePath: String) -> URL 
         return normalizedBundleDirURLIfNeeded(dest)
     }
     return dest
+}
+
+private func systemLibraryOutputDirs(ctx: Context, relativePath: String) -> (headers: URL, bundle: URL) {
+    let base = ctx.outDir.appendingPathComponent("SystemLibrary", isDirectory: true)
+    let bundle = appendingRelativePath(base, relativePath, isDirectory: true)
+    return (
+        headers: normalizedBundleDirURLIfNeeded(bundle),
+        bundle: bundle
+    )
 }
 
 internal func dylibOutputDir(ctx: Context, dylibName: String) -> URL {
@@ -1597,7 +1624,11 @@ private func listUsrLibDylibs(ctx: Context) throws -> [String] {
 internal func existingFrameworksInCategory(ctx: Context, category: String, frameworks: Set<String>) -> Set<String> {
     var existing: Set<String> = []
     for framework in frameworks {
-        if hasCompletedOutput(in: frameworkOutputDir(ctx: ctx, category: category, frameworkName: framework)) {
+        let paths = frameworkOutputDirs(ctx: ctx, category: category, frameworkName: framework)
+        let candidates = ctx.layout == "headers"
+            ? [paths.headers, paths.bundle]
+            : [paths.bundle, paths.headers]
+        if firstCompletedOutput(in: candidates) != nil {
             existing.insert(framework)
         }
     }
@@ -1646,17 +1677,34 @@ internal func dumpCategorySplit(category: String, ctx: Context, runner: CommandR
         if ctx.skipExisting, existing.contains(item) {
             // Best-effort: keep nested XPCServices/PlugIns outputs consistent with the requested layout
             // even when skipping.
+            let paths = frameworkOutputDirs(ctx: ctx, category: category, frameworkName: item)
+            let targetDir = ctx.layout == "headers" ? paths.headers : paths.bundle
+            let completedDir = firstCompletedOutput(
+                in: ctx.layout == "headers" ? [paths.headers, paths.bundle] : [paths.bundle, paths.headers]
+            )
+            let overwrite = completedDir?.path != targetDir.path
+                && FileManager.default.fileExists(atPath: targetDir.path)
+                && !hasCompletedOutput(in: targetDir)
             if ctx.layout == "headers" {
-                let baseName = item.hasSuffix(".framework") ? String(item.dropLast(".framework".count)) : item
-                let dest = ctx.outDir
-                    .appendingPathComponent(category, isDirectory: true)
-                    .appendingPathComponent(baseName, isDirectory: true)
-                try? normalizeNestedXPCAndPlugIns(in: dest, overwrite: false)
+                if completedDir?.path == paths.bundle.path {
+                    _ = try? FileOps.normalizeBundleDir(
+                        paths.bundle,
+                        allowedExtensions: ["framework"],
+                        overwrite: overwrite,
+                        fileManager: .default
+                    )
+                }
+                try? normalizeNestedXPCAndPlugIns(in: paths.headers, overwrite: overwrite)
             } else {
-                let dest = ctx.outDir
-                    .appendingPathComponent(category, isDirectory: true)
-                    .appendingPathComponent(item, isDirectory: true)
-                try? denormalizeNestedXPCAndPlugIns(in: dest, overwrite: false)
+                if completedDir?.path == paths.headers.path {
+                    _ = try? FileOps.denormalizeBundleDir(
+                        paths.headers,
+                        bundleExtension: "framework",
+                        overwrite: overwrite,
+                        fileManager: .default
+                    )
+                }
+                try? denormalizeNestedXPCAndPlugIns(in: paths.bundle, overwrite: overwrite)
             }
             print("Skipping existing: \(category) (\(idx + 1)/\(total)) \(item)")
             continue
@@ -1749,38 +1797,44 @@ internal func dumpSystemLibraryItems(ctx: Context, items: [String], runner: Comm
     for (idx, relPath) in items.enumerated() {
         try throwIfTerminationRequested()
 
-        let denormalizedDest = appendingRelativePath(outBase, relPath, isDirectory: true)
-        let outputDir = systemLibraryOutputDir(ctx: ctx, relativePath: relPath)
-        if ctx.skipExisting, hasCompletedOutput(in: outputDir) {
+        let paths = systemLibraryOutputDirs(ctx: ctx, relativePath: relPath)
+        let denormalizedDest = paths.bundle
+        let outputDir = ctx.layout == "headers" ? paths.headers : paths.bundle
+        let skipCandidates = ctx.layout == "headers"
+            ? [paths.headers, paths.bundle]
+            : [paths.bundle, paths.headers]
+        if ctx.skipExisting, let completedDir = firstCompletedOutput(in: skipCandidates) {
             // Best-effort: keep existing outputs consistent with the requested layout even when skipping.
             //
             // In particular, switching from `--layout headers` to `--layout bundle` should not require a re-dump:
             // rename `Foo` -> `Foo.bundle` (and similarly for nested XPC/appex bundles) when possible.
-            var existingDir: URL?
-            if fileManager.fileExists(atPath: denormalizedDest.path) {
-                existingDir = denormalizedDest
-            } else if fileManager.fileExists(atPath: outputDir.path) {
-                existingDir = outputDir
-            }
+            let overwrite = completedDir.path != outputDir.path
+                && fileManager.fileExists(atPath: outputDir.path)
+                && !hasCompletedOutput(in: outputDir)
 
-            if var bundleDir = existingDir {
+            var bundleDir = completedDir
+            if fileManager.fileExists(atPath: completedDir.path) {
                 if normalizeBundles {
-                    bundleDir = (try? FileOps.normalizeBundleDir(
-                        bundleDir,
-                        allowedExtensions: normalizedBundleExtensions,
-                        overwrite: false,
-                        fileManager: fileManager
-                    )) ?? bundleDir
-                    try? normalizeNestedXPCAndPlugIns(in: bundleDir, overwrite: false)
+                    if completedDir.path != paths.headers.path {
+                        bundleDir = (try? FileOps.normalizeBundleDir(
+                            bundleDir,
+                            allowedExtensions: normalizedBundleExtensions,
+                            overwrite: overwrite,
+                            fileManager: fileManager
+                        )) ?? bundleDir
+                    }
+                    try? normalizeNestedXPCAndPlugIns(in: bundleDir, overwrite: overwrite)
                 } else {
                     let ext = denormalizedDest.pathExtension
-                    bundleDir = (try? FileOps.denormalizeBundleDir(
-                        bundleDir,
-                        bundleExtension: ext,
-                        overwrite: false,
-                        fileManager: fileManager
-                    )) ?? bundleDir
-                    try? denormalizeNestedXPCAndPlugIns(in: bundleDir, overwrite: false)
+                    if completedDir.path != paths.bundle.path {
+                        bundleDir = (try? FileOps.denormalizeBundleDir(
+                            bundleDir,
+                            bundleExtension: ext,
+                            overwrite: overwrite,
+                            fileManager: fileManager
+                        )) ?? bundleDir
+                    }
+                    try? denormalizeNestedXPCAndPlugIns(in: bundleDir, overwrite: overwrite)
                 }
             }
             print("Skipping existing: SystemLibrary (\(idx + 1)/\(total)) \(relPath)")

--- a/Tests/HeaderDumpCLITests/HeaderDumpCLITests.swift
+++ b/Tests/HeaderDumpCLITests/HeaderDumpCLITests.swift
@@ -1,6 +1,9 @@
 import Foundation
 import Testing
 import MachOKit
+#if canImport(HeaderDumpRuntimeObjC)
+import HeaderDumpRuntimeObjC
+#endif
 @testable import HeaderDumpCore
 
 #if canImport(Darwin)
@@ -206,6 +209,16 @@ private func loadMachO(at url: URL) throws -> MachOFile {
 
 @Suite(.serialized)
 struct HeaderDumpCLITests {
+#if canImport(ObjectiveC) && canImport(HeaderDumpRuntimeObjC)
+    @Test func runtimeInspectorBuildsNSObjectSnapshot() {
+        var failedStage: NSString?
+        let snapshot = PHRuntimeObjCInspector.snapshot(for: NSObject.self, failedStage: &failedStage)
+        #expect(snapshot != nil)
+        #expect(failedStage == nil)
+        #expect(snapshot?.name == "NSObject")
+    }
+#endif
+
     @Test func parseArgumentsPopulatesOptions() {
         let args = [
             "-o", "/tmp/out",

--- a/Tests/PrivateHeaderKitDumpTests/PrivateHeaderKitDumpTests.swift
+++ b/Tests/PrivateHeaderKitDumpTests/PrivateHeaderKitDumpTests.swift
@@ -65,6 +65,94 @@ private func makeDeviceInfo(name: String, udid: String, state: String) throws ->
     return try JSONDecoder().decode(DeviceInfo.self, from: Data(payload.utf8))
 }
 
+private func makeContext(outDir: URL, layout: String = "headers") -> Context {
+    Context(
+        platform: .ios,
+        execMode: .host,
+        headerdumpBin: URL(fileURLWithPath: "/usr/bin/true"),
+        osVersionLabel: "26.3.1",
+        systemRoot: "/tmp/runtime",
+        runtimeId: nil,
+        runtimeBuild: nil,
+        macOSBuildVersion: nil,
+        device: nil,
+        outDir: outDir,
+        stageDir: outDir.appendingPathComponent(".tmp-stage", isDirectory: true),
+        skipExisting: true,
+        useSharedCache: true,
+        verbose: false,
+        layout: layout,
+        categories: ["Frameworks"],
+        frameworkNames: [],
+        frameworkFilters: []
+    )
+}
+
+private func makeFakeHeaderdumpScript(
+    at url: URL,
+    invocationLog: URL,
+    nestedFailureToggle: URL? = nil,
+    failingNestedSuffix: String? = nil
+) throws {
+    let toggleCheck: String
+    if let nestedFailureToggle, let failingNestedSuffix {
+        toggleCheck = """
+        if [[ -f "\(nestedFailureToggle.path)" && "$source_path" == *"\(failingNestedSuffix)" ]]; then
+          print -u2 -- "simulated failure for $source_path"
+          exit 1
+        fi
+        """
+    } else {
+        toggleCheck = ""
+    }
+
+    let script = """
+    #!/bin/zsh
+    set -euo pipefail
+
+    stage_dir=""
+    source_path=""
+    while [[ $# -gt 0 ]]; do
+      case "$1" in
+        -o)
+          stage_dir="$2"
+          shift 2
+          ;;
+        -r)
+          source_path="$2"
+          shift 2
+          ;;
+        -b|-h|-s|-R|-c|-D)
+          shift
+          ;;
+        *)
+          if [[ -z "$source_path" ]]; then
+            source_path="$1"
+          fi
+          shift
+          ;;
+      esac
+    done
+
+    print -r -- "$source_path" >> "\(invocationLog.path)"
+    \(toggleCheck)
+    relative_path="${source_path#*/System/Library/}"
+    output_dir="$stage_dir/System/Library/$relative_path/Headers"
+    mkdir -p "$output_dir"
+    print -r -- "// generated: $relative_path" > "$output_dir/Generated.h"
+    """
+
+    try script.write(to: url, atomically: true, encoding: .utf8)
+    try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: url.path)
+}
+
+private func invocationLines(at url: URL) throws -> [String] {
+    guard FileManager.default.fileExists(atPath: url.path) else { return [] }
+    return try String(contentsOf: url, encoding: .utf8)
+        .split(separator: "\n")
+        .map(String.init)
+}
+
 @Suite struct PrivateHeaderKitDumpTests {
     @Test func targetFrameworkOnlySelectsFrameworks() throws {
         var args = DumpArguments()
@@ -215,5 +303,192 @@ private func makeDeviceInfo(name: String, udid: String, state: String) throws ->
         #expect(picked.name == cloneName)
         #expect(picked.udid == "CLONED-UDID")
         #expect(runner.capturedRunCaptureCommands.count == 1)
+    }
+
+    @Test func existingFrameworksRequireCompletionMarker() throws {
+        let outDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: outDir, withIntermediateDirectories: true)
+        let ctx = makeContext(outDir: outDir)
+
+        let completeDir = frameworkOutputDir(ctx: ctx, category: "Frameworks", frameworkName: "Complete.framework")
+        let partialDir = frameworkOutputDir(ctx: ctx, category: "Frameworks", frameworkName: "Partial.framework")
+        let markerOnlyDir = frameworkOutputDir(ctx: ctx, category: "Frameworks", frameworkName: "MarkerOnly.framework")
+        try FileManager.default.createDirectory(at: completeDir.appendingPathComponent("Headers", isDirectory: true), withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: partialDir.appendingPathComponent("Headers", isDirectory: true), withIntermediateDirectories: true)
+        try Data("ok".utf8).write(to: completeDir.appendingPathComponent("Headers/Complete.h"))
+        try Data("ok".utf8).write(to: partialDir.appendingPathComponent("Headers/Partial.h"))
+        try FileManager.default.createDirectory(at: markerOnlyDir, withIntermediateDirectories: true)
+        try writeCompletionMarker(in: completeDir, imagePath: "Frameworks/Complete.framework", layout: ctx.layout)
+        try writeCompletionMarker(in: markerOnlyDir, imagePath: "Frameworks/MarkerOnly.framework", layout: ctx.layout)
+
+        let existing = existingFrameworksInCategory(
+            ctx: ctx,
+            category: "Frameworks",
+            frameworks: Set(["complete.framework", "partial.framework", "markeronly.framework"])
+        )
+        #expect(existing == Set(["complete.framework"]))
+    }
+
+    @Test func writeCompletionMarkerCreatesExpectedMetadata() throws {
+        let outDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: outDir, withIntermediateDirectories: true)
+
+        try writeCompletionMarker(
+            in: outDir,
+            imagePath: "usr/lib/libobjc.A.dylib",
+            layout: "headers"
+        )
+
+        let data = try Data(contentsOf: completionMarkerURL(for: outDir))
+        let marker = try JSONDecoder().decode(CompletionMarker.self, from: data)
+        #expect(marker.tool == "privateheaderkit-dump")
+        #expect(marker.imagePath == "usr/lib/libobjc.A.dylib")
+        #expect(marker.layout == "headers")
+        #expect(!marker.completedAt.isEmpty)
+        #expect(hasCompletionMarker(in: outDir))
+    }
+
+    @Test func splitFrameworkRerunsMarkerlessPartialAndSkipsCompletedFramework() throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let runtimeRoot = tempDir.appendingPathComponent("RuntimeRoot", isDirectory: true)
+        let outDir = tempDir.appendingPathComponent("Out", isDirectory: true)
+        let frameworkDir = runtimeRoot
+            .appendingPathComponent("System/Library/Frameworks/Foo.framework", isDirectory: true)
+        let invocationLog = tempDir.appendingPathComponent("invocations.log", isDirectory: false)
+        let scriptURL = tempDir.appendingPathComponent("fake-headerdump.zsh", isDirectory: false)
+
+        try FileManager.default.createDirectory(at: frameworkDir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: outDir, withIntermediateDirectories: true)
+        try makeFakeHeaderdumpScript(at: scriptURL, invocationLog: invocationLog)
+
+        var ctx = makeContext(outDir: outDir)
+        ctx.platform = .macos
+        ctx.systemRoot = runtimeRoot.path
+        ctx.headerdumpBin = scriptURL
+        ctx.stageDir = tempDir.appendingPathComponent(".tmp-stage", isDirectory: true)
+        ctx.categories = ["Frameworks"]
+        ctx.skipExisting = true
+        ctx.layout = "headers"
+
+        let outputDir = frameworkOutputDir(ctx: ctx, category: "Frameworks", frameworkName: "Foo.framework")
+        let staleHeader = outputDir.appendingPathComponent("Headers/PartialOnly.h", isDirectory: false)
+        try FileManager.default.createDirectory(at: staleHeader.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try Data("stale".utf8).write(to: staleHeader)
+
+        try FileOps.resetStageDir(ctx.stageDir)
+        let hadFailures = try dumpCategorySplit(category: "Frameworks", ctx: ctx, runner: StubCommandRunner())
+        #expect(hadFailures == false)
+        #expect(FileManager.default.fileExists(atPath: outputDir.appendingPathComponent("Headers/Generated.h").path))
+        #expect(!FileManager.default.fileExists(atPath: staleHeader.path))
+        #expect(hasCompletionMarker(in: outputDir))
+        #expect(try invocationLines(at: invocationLog).count == 1)
+
+        try FileOps.resetStageDir(ctx.stageDir)
+        let hadFailuresOnSecondRun = try dumpCategorySplit(category: "Frameworks", ctx: ctx, runner: StubCommandRunner())
+        #expect(hadFailuresOnSecondRun == false)
+        #expect(try invocationLines(at: invocationLog).count == 1)
+    }
+
+    @Test func splitFrameworkSkipsMarkerUntilNestedFailureIsRecovered() throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let runtimeRoot = tempDir.appendingPathComponent("RuntimeRoot", isDirectory: true)
+        let outDir = tempDir.appendingPathComponent("Out", isDirectory: true)
+        let frameworkDir = runtimeRoot
+            .appendingPathComponent("System/Library/Frameworks/Foo.framework/XPCServices/Bad.xpc", isDirectory: true)
+        let invocationLog = tempDir.appendingPathComponent("invocations.log", isDirectory: false)
+        let failureToggle = tempDir.appendingPathComponent("fail-nested", isDirectory: false)
+        let scriptURL = tempDir.appendingPathComponent("fake-headerdump.zsh", isDirectory: false)
+
+        try FileManager.default.createDirectory(at: frameworkDir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: outDir, withIntermediateDirectories: true)
+        try Data().write(to: failureToggle)
+        try makeFakeHeaderdumpScript(
+            at: scriptURL,
+            invocationLog: invocationLog,
+            nestedFailureToggle: failureToggle,
+            failingNestedSuffix: "XPCServices/Bad.xpc"
+        )
+
+        var ctx = makeContext(outDir: outDir)
+        ctx.platform = .macos
+        ctx.systemRoot = runtimeRoot.path
+        ctx.headerdumpBin = scriptURL
+        ctx.stageDir = tempDir.appendingPathComponent(".tmp-stage", isDirectory: true)
+        ctx.categories = ["Frameworks"]
+        ctx.skipExisting = true
+        ctx.layout = "headers"
+        ctx.nestedEnabled = true
+
+        let outputDir = frameworkOutputDir(ctx: ctx, category: "Frameworks", frameworkName: "Foo.framework")
+
+        try FileOps.resetStageDir(ctx.stageDir)
+        let firstHadFailures = try dumpCategorySplit(category: "Frameworks", ctx: ctx, runner: StubCommandRunner())
+        #expect(firstHadFailures == true)
+        #expect(!hasCompletionMarker(in: outputDir))
+        let failuresPath = outDir.appendingPathComponent("_failures.txt", isDirectory: false)
+        let failuresText = try String(contentsOf: failuresPath, encoding: .utf8)
+        #expect(failuresText.contains("Frameworks/Foo.framework/XPCServices/Bad.xpc"))
+        #expect(try invocationLines(at: invocationLog).count == 2)
+
+        try FileManager.default.removeItem(at: failureToggle)
+        try FileOps.resetStageDir(ctx.stageDir)
+        let secondHadFailures = try dumpCategorySplit(category: "Frameworks", ctx: ctx, runner: StubCommandRunner())
+        #expect(secondHadFailures == false)
+        #expect(hasCompletionMarker(in: outputDir))
+        #expect(FileManager.default.fileExists(atPath: outputDir.appendingPathComponent("Headers/Generated.h").path))
+        #expect(try invocationLines(at: invocationLog).count == 4)
+    }
+
+    @Test func systemLibraryBundleLayoutRemovesStaleHeadersLayoutDirectory() throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let runtimeRoot = tempDir.appendingPathComponent("RuntimeRoot", isDirectory: true)
+        let outDir = tempDir.appendingPathComponent("Out", isDirectory: true)
+        let bundleDir = runtimeRoot
+            .appendingPathComponent("System/Library/PreferenceBundles/Foo.bundle", isDirectory: true)
+        let invocationLog = tempDir.appendingPathComponent("invocations.log", isDirectory: false)
+        let scriptURL = tempDir.appendingPathComponent("fake-headerdump.zsh", isDirectory: false)
+
+        try FileManager.default.createDirectory(at: bundleDir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: outDir, withIntermediateDirectories: true)
+        try makeFakeHeaderdumpScript(at: scriptURL, invocationLog: invocationLog)
+
+        var ctx = makeContext(outDir: outDir, layout: "bundle")
+        ctx.platform = .macos
+        ctx.systemRoot = runtimeRoot.path
+        ctx.headerdumpBin = scriptURL
+        ctx.stageDir = tempDir.appendingPathComponent(".tmp-stage", isDirectory: true)
+        ctx.skipExisting = false
+
+        let staleHeadersLayoutDir = outDir
+            .appendingPathComponent("SystemLibrary/PreferenceBundles/Foo", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: staleHeadersLayoutDir.appendingPathComponent("Headers", isDirectory: true),
+            withIntermediateDirectories: true
+        )
+        try Data("stale".utf8).write(to: staleHeadersLayoutDir.appendingPathComponent("Headers/Old.h"))
+        try writeCompletionMarker(
+            in: staleHeadersLayoutDir,
+            imagePath: "SystemLibrary/PreferenceBundles/Foo.bundle",
+            layout: "headers"
+        )
+
+        try FileOps.resetStageDir(ctx.stageDir)
+        let hadFailures = try dumpSystemLibraryItems(
+            ctx: ctx,
+            items: ["PreferenceBundles/Foo.bundle"],
+            runner: StubCommandRunner()
+        )
+
+        let bundleOutputDir = systemLibraryOutputDir(ctx: ctx, relativePath: "PreferenceBundles/Foo.bundle")
+        #expect(hadFailures == false)
+        #expect(!FileManager.default.fileExists(atPath: staleHeadersLayoutDir.path))
+        #expect(FileManager.default.fileExists(atPath: bundleOutputDir.appendingPathComponent("Headers/Generated.h").path))
+        #expect(hasCompletionMarker(in: bundleOutputDir))
+        #expect(try invocationLines(at: invocationLog).count == 1)
     }
 }

--- a/Tests/PrivateHeaderKitDumpTests/PrivateHeaderKitDumpTests.swift
+++ b/Tests/PrivateHeaderKitDumpTests/PrivateHeaderKitDumpTests.swift
@@ -491,4 +491,109 @@ private func invocationLines(at url: URL) throws -> [String] {
         #expect(hasCompletionMarker(in: bundleOutputDir))
         #expect(try invocationLines(at: invocationLog).count == 1)
     }
+
+    @Test func splitFrameworkSkipsCompletedAlternateLayoutWithoutRedump() throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let runtimeRoot = tempDir.appendingPathComponent("RuntimeRoot", isDirectory: true)
+        let outDir = tempDir.appendingPathComponent("Out", isDirectory: true)
+        let frameworkDir = runtimeRoot
+            .appendingPathComponent("System/Library/Frameworks/Foo.framework", isDirectory: true)
+        let invocationLog = tempDir.appendingPathComponent("invocations.log", isDirectory: false)
+        let scriptURL = tempDir.appendingPathComponent("fake-headerdump.zsh", isDirectory: false)
+
+        try FileManager.default.createDirectory(at: frameworkDir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: outDir, withIntermediateDirectories: true)
+        try makeFakeHeaderdumpScript(at: scriptURL, invocationLog: invocationLog)
+
+        var ctx = makeContext(outDir: outDir, layout: "headers")
+        ctx.platform = .macos
+        ctx.systemRoot = runtimeRoot.path
+        ctx.headerdumpBin = scriptURL
+        ctx.stageDir = tempDir.appendingPathComponent(".tmp-stage", isDirectory: true)
+        ctx.categories = ["Frameworks"]
+        ctx.skipExisting = true
+
+        let alternateLayoutDir = outDir
+            .appendingPathComponent("Frameworks/Foo.framework", isDirectory: true)
+        let normalizedDir = frameworkOutputDir(ctx: ctx, category: "Frameworks", frameworkName: "Foo.framework")
+        try FileManager.default.createDirectory(
+            at: alternateLayoutDir.appendingPathComponent("Headers", isDirectory: true),
+            withIntermediateDirectories: true
+        )
+        try FileManager.default.createDirectory(
+            at: normalizedDir.appendingPathComponent("Headers", isDirectory: true),
+            withIntermediateDirectories: true
+        )
+        try Data("ok".utf8).write(to: alternateLayoutDir.appendingPathComponent("Headers/Generated.h"))
+        try Data("stale".utf8).write(to: normalizedDir.appendingPathComponent("Headers/Stale.h"))
+        try writeCompletionMarker(
+            in: alternateLayoutDir,
+            imagePath: "Frameworks/Foo.framework",
+            layout: "bundle"
+        )
+
+        try FileOps.resetStageDir(ctx.stageDir)
+        let hadFailures = try dumpCategorySplit(category: "Frameworks", ctx: ctx, runner: StubCommandRunner())
+
+        #expect(hadFailures == false)
+        #expect(FileManager.default.fileExists(atPath: normalizedDir.appendingPathComponent("Headers/Generated.h").path))
+        #expect(!FileManager.default.fileExists(atPath: normalizedDir.appendingPathComponent("Headers/Stale.h").path))
+        #expect(hasCompletionMarker(in: normalizedDir))
+        #expect(try invocationLines(at: invocationLog).isEmpty)
+    }
+
+    @Test func systemLibrarySkipsCompletedAlternateLayoutWithoutRedump() throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let runtimeRoot = tempDir.appendingPathComponent("RuntimeRoot", isDirectory: true)
+        let outDir = tempDir.appendingPathComponent("Out", isDirectory: true)
+        let bundleDir = runtimeRoot
+            .appendingPathComponent("System/Library/PreferenceBundles/Foo.bundle", isDirectory: true)
+        let invocationLog = tempDir.appendingPathComponent("invocations.log", isDirectory: false)
+        let scriptURL = tempDir.appendingPathComponent("fake-headerdump.zsh", isDirectory: false)
+
+        try FileManager.default.createDirectory(at: bundleDir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: outDir, withIntermediateDirectories: true)
+        try makeFakeHeaderdumpScript(at: scriptURL, invocationLog: invocationLog)
+
+        var ctx = makeContext(outDir: outDir, layout: "headers")
+        ctx.platform = .macos
+        ctx.systemRoot = runtimeRoot.path
+        ctx.headerdumpBin = scriptURL
+        ctx.stageDir = tempDir.appendingPathComponent(".tmp-stage", isDirectory: true)
+        ctx.skipExisting = true
+
+        let alternateLayoutDir = outDir
+            .appendingPathComponent("SystemLibrary/PreferenceBundles/Foo.bundle", isDirectory: true)
+        let normalizedDir = systemLibraryOutputDir(ctx: ctx, relativePath: "PreferenceBundles/Foo.bundle")
+        try FileManager.default.createDirectory(
+            at: alternateLayoutDir.appendingPathComponent("Headers", isDirectory: true),
+            withIntermediateDirectories: true
+        )
+        try FileManager.default.createDirectory(
+            at: normalizedDir.appendingPathComponent("Headers", isDirectory: true),
+            withIntermediateDirectories: true
+        )
+        try Data("ok".utf8).write(to: alternateLayoutDir.appendingPathComponent("Headers/Generated.h"))
+        try Data("stale".utf8).write(to: normalizedDir.appendingPathComponent("Headers/Stale.h"))
+        try writeCompletionMarker(
+            in: alternateLayoutDir,
+            imagePath: "SystemLibrary/PreferenceBundles/Foo.bundle",
+            layout: "bundle"
+        )
+
+        try FileOps.resetStageDir(ctx.stageDir)
+        let hadFailures = try dumpSystemLibraryItems(
+            ctx: ctx,
+            items: ["PreferenceBundles/Foo.bundle"],
+            runner: StubCommandRunner()
+        )
+
+        #expect(hadFailures == false)
+        #expect(FileManager.default.fileExists(atPath: normalizedDir.appendingPathComponent("Headers/Generated.h").path))
+        #expect(!FileManager.default.fileExists(atPath: normalizedDir.appendingPathComponent("Headers/Stale.h").path))
+        #expect(hasCompletionMarker(in: normalizedDir))
+        #expect(try invocationLines(at: invocationLog).isEmpty)
+    }
 }


### PR DESCRIPTION
Summary:
- Add an Objective-C runtime snapshot shim so simulator runtime fallback can isolate per-class introspection failures instead of crashing the whole dump
- Switch `--skip-existing` to completion-marker-based resume with artifact validation and alternate-layout reuse so incomplete outputs are regenerated while successful items still skip cleanly
- Add regression coverage for partial reruns, nested bundle failures, SystemLibrary layout switches, alternate-layout skips, and Objective-C-only test/dependency wiring

Testing:
- `swift test --disable-automatic-resolution`
- `~/.local/bin/privateheaderkit-dump 26.3.1 --device 1B58261C-B539-4DB0-B7F0-39839E705ABC --target CloudKit --out /tmp/phk-cloudkit-runtimefix -D`
- `~/.local/bin/privateheaderkit-dump 26.3.1 --device 1B58261C-B539-4DB0-B7F0-39839E705ABC --target AuthenticationServices --target Contacts --target ContactsUI --out /tmp/phk-sim-regression-20260322-1935`
- `~/.local/bin/privateheaderkit-dump --platform macos --target AuthenticationServices --out /tmp/phk-resume-manual-20260322-1936 --skip-existing`
- `~/.local/bin/privateheaderkit-dump --platform macos --target AuthenticationServices --out /tmp/phk-marker-only-manual-20260322-1944 --skip-existing`