### PR TITLE
Rebuild deterministic test coverage

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -82,10 +82,18 @@ let package = Package(
             ],
             path: "Tests/PrivateHeaderKitToolingTestHelper"
         ),
+        .target(
+            name: "PrivateHeaderKitTestSupport",
+            dependencies: [
+                "PrivateHeaderKitTooling",
+            ],
+            path: "Tests/PrivateHeaderKitTestSupport"
+        ),
         .testTarget(
             name: "HeaderDumpCLITests",
             dependencies: [
                 "HeaderDumpCore",
+                "PrivateHeaderKitTestSupport",
                 .target(
                     name: "HeaderDumpRuntimeObjC",
                     condition: .when(platforms: [.macOS, .iOS])
@@ -97,16 +105,25 @@ let package = Package(
             name: "PrivateHeaderKitDumpTests",
             dependencies: [
                 "PrivateHeaderKitDump",
+                "PrivateHeaderKitTestSupport",
             ]
         ),
         .testTarget(
             name: "PrivateHeaderKitToolingTests",
             dependencies: [
                 "PrivateHeaderKitTooling",
+                "PrivateHeaderKitTestSupport",
                 .target(
                     name: "PrivateHeaderKitToolingTestHelper",
                     condition: .when(platforms: [.macOS])
                 ),
+            ]
+        ),
+        .testTarget(
+            name: "PrivateHeaderKitInstallTests",
+            dependencies: [
+                "PrivateHeaderKitInstall",
+                "PrivateHeaderKitTestSupport",
             ]
         ),
     ]

--- a/README.md
+++ b/README.md
@@ -133,6 +133,12 @@ privateheaderkit-dump --list-devices --runtime 26.0.1
 - You can override the device type used for auto-creation with `PH_DEVICE_TYPE` (device name or identifier).
 - Environment overrides: `PH_PLATFORM`, `PH_EXEC_MODE`, `PH_OUT_DIR`, `PH_FORCE=1|0`, `PH_SKIP_EXISTING=1|0`, `PH_LAYOUT`, `PH_SHARED_CACHE=1|0`, `PH_VERBOSE=1|0`, `PH_VERBOSE_SKIP=1`, `PH_DEVICE_TYPE`, `PH_PROFILE=1|0`, `PH_SWIFT_EVENTS=1|0`
 
+## Testing
+
+`swift test` is expected to be deterministic. Regular tests should use fixed fixture trees, injected environments, and stub command runners only.
+
+Do not add regular tests that depend on the host dyld shared cache, installed system apps, simulator availability, runtime boot state, wall-clock time, generated `swiftc` binaries, network access, or stress loops. If an integration smoke test needs one of those dependencies, guard it behind an explicit opt-in such as `PHK_RUN_INTEGRATION_TESTS=1` and keep it out of the default acceptance path.
+
 ## License
 
 - MIT for this workspace: see `LICENSE`.

--- a/Sources/HeaderDumpCore/HeaderDumpMain.swift
+++ b/Sources/HeaderDumpCore/HeaderDumpMain.swift
@@ -1353,6 +1353,9 @@ func dumpSwift(
     interfaceBuilderFactory: SwiftInterfaceBuildingFactory = DefaultSwiftInterfaceBuilderFactory(),
     fileManager: FileManager
 ) async throws {
+    if shouldSkipSwiftInterface(imagePath: imagePath, outputDir: outputDir, options: options, fileManager: fileManager) {
+        return
+    }
     let builder = try interfaceBuilderFactory.makeBuilder(machO: machO)
     try await dumpSwiftInterface(
         imagePath: imagePath,
@@ -1372,6 +1375,20 @@ func dumpSwift(
     )
 }
 
+func swiftInterfaceOutputURL(imagePath: String, outputDir: URL) -> URL {
+    let moduleName = URL(fileURLWithPath: imagePath).lastPathComponent
+    return outputDir.appendingPathComponent("\(moduleName).swiftinterface")
+}
+
+func shouldSkipSwiftInterface(
+    imagePath: String,
+    outputDir: URL,
+    options: DumpOptions,
+    fileManager: FileExistenceChecking
+) -> Bool {
+    options.skipExisting && fileManager.fileExists(atPath: swiftInterfaceOutputURL(imagePath: imagePath, outputDir: outputDir).path)
+}
+
 func dumpSwiftInterface(
     imagePath: String,
     outputDir: URL,
@@ -1379,10 +1396,9 @@ func dumpSwiftInterface(
     fileManager: FileManager,
     buildInterface: () async throws -> String
 ) async throws {
-    let moduleName = URL(fileURLWithPath: imagePath).lastPathComponent
-    let outputURL = outputDir.appendingPathComponent("\(moduleName).swiftinterface")
+    let outputURL = swiftInterfaceOutputURL(imagePath: imagePath, outputDir: outputDir)
 
-    if options.skipExisting && fileManager.fileExists(atPath: outputURL.path) {
+    if shouldSkipSwiftInterface(imagePath: imagePath, outputDir: outputDir, options: options, fileManager: fileManager) {
         return
     }
 

--- a/Sources/HeaderDumpCore/HeaderDumpMain.swift
+++ b/Sources/HeaderDumpCore/HeaderDumpMain.swift
@@ -110,6 +110,7 @@ struct ParsedArguments {
 
 func parseArguments(
     _ args: [String],
+    environment: [String: String] = ProcessInfo.processInfo.environment,
     exitHandler: (Int32) -> Void = { exit($0) },
     printUsageHandler: () -> Void = printUsage
 ) -> ParsedArguments? {
@@ -159,11 +160,11 @@ func parseArguments(
 
     guard let inputPath else { return nil }
     if !options.useRuntimeFallback {
-        options.useRuntimeFallback = shouldUseRuntimeFallback()
+        options.useRuntimeFallback = shouldUseRuntimeFallback(environment: environment)
     }
-    options.logSkippedClasses = shouldLogSkippedClasses()
-    options.profile = shouldProfile()
-    options.logSwiftEvents = shouldLogSwiftEvents()
+    options.logSkippedClasses = shouldLogSkippedClasses(environment: environment)
+    options.profile = shouldProfile(environment: environment)
+    options.logSwiftEvents = shouldLogSwiftEvents(environment: environment)
     return ParsedArguments(options: options, inputPath: inputPath)
 }
 
@@ -186,43 +187,46 @@ private func printUsage() {
     print(text)
 }
 
-func shouldUseRuntimeFallback() -> Bool {
-    let env = ProcessInfo.processInfo.environment
-    return env["PH_RUNTIME_ROOT"] != nil || env["SIMCTL_CHILD_PH_RUNTIME_ROOT"] != nil
+func shouldUseRuntimeFallback(environment: [String: String] = ProcessInfo.processInfo.environment) -> Bool {
+    environment["PH_RUNTIME_ROOT"] != nil || environment["SIMCTL_CHILD_PH_RUNTIME_ROOT"] != nil
 }
 
-func shouldLogSkippedClasses() -> Bool {
-    ProcessInfo.processInfo.environment["PH_VERBOSE_SKIP"] == "1"
+func shouldLogSkippedClasses(environment: [String: String] = ProcessInfo.processInfo.environment) -> Bool {
+    environment["PH_VERBOSE_SKIP"] == "1"
 }
 
-func shouldProfile() -> Bool {
-    let env = ProcessInfo.processInfo.environment
-    return env["PH_PROFILE"] == "1" || env["SIMCTL_CHILD_PH_PROFILE"] == "1"
+func shouldProfile(environment: [String: String] = ProcessInfo.processInfo.environment) -> Bool {
+    environment["PH_PROFILE"] == "1" || environment["SIMCTL_CHILD_PH_PROFILE"] == "1"
 }
 
-func shouldLogSwiftEvents() -> Bool {
-    let env = ProcessInfo.processInfo.environment
-    return env["PH_SWIFT_EVENTS"] == "1" || env["SIMCTL_CHILD_PH_SWIFT_EVENTS"] == "1"
+func shouldLogSwiftEvents(environment: [String: String] = ProcessInfo.processInfo.environment) -> Bool {
+    environment["PH_SWIFT_EVENTS"] == "1" || environment["SIMCTL_CHILD_PH_SWIFT_EVENTS"] == "1"
 }
 
-private func runtimeRootPath() -> String? {
-    let env = ProcessInfo.processInfo.environment
-    return env["PH_RUNTIME_ROOT"] ?? env["SIMCTL_CHILD_PH_RUNTIME_ROOT"]
+private func runtimeRootPath(environment: [String: String] = ProcessInfo.processInfo.environment) -> String? {
+    environment["PH_RUNTIME_ROOT"] ?? environment["SIMCTL_CHILD_PH_RUNTIME_ROOT"]
 }
 
-func resolveRuntimeURL(_ url: URL) -> URL {
-    guard let runtimeRoot = runtimeRootPath() else { return url }
+func resolveRuntimeURL(
+    _ url: URL,
+    environment: [String: String] = ProcessInfo.processInfo.environment,
+    fileManager: FileExistenceChecking = FileManager.default
+) -> URL {
+    guard let runtimeRoot = runtimeRootPath(environment: environment) else { return url }
     let path = url.standardizedFileURL.path
     guard path.hasPrefix("/") else { return url }
     let candidate = URL(fileURLWithPath: runtimeRoot).appendingPathComponent(String(path.dropFirst()))
-    if FileManager.default.fileExists(atPath: candidate.path) {
+    if fileManager.fileExists(atPath: candidate.path) {
         return candidate
     }
     return url
 }
 
-func stripRuntimeRoot(from path: String) -> String {
-    guard let runtimeRoot = runtimeRootPath() else { return path }
+func stripRuntimeRoot(
+    from path: String,
+    environment: [String: String] = ProcessInfo.processInfo.environment
+) -> String {
+    guard let runtimeRoot = runtimeRootPath(environment: environment) else { return path }
     if path.hasPrefix(runtimeRoot) {
         var trimmed = path.dropFirst(runtimeRoot.count)
         if trimmed.first == "/" {
@@ -441,7 +445,10 @@ private func loadFromSharedCache(imagePath: String) -> MachOFile? {
     return nil
 }
 
-func normalizedCacheImagePaths(for path: String) -> [String] {
+func normalizedCacheImagePaths(
+    for path: String,
+    environment: [String: String] = ProcessInfo.processInfo.environment
+) -> [String] {
     var results: [String] = [path]
 
     // On macOS, cache entries for frameworks frequently use versioned image paths
@@ -459,11 +466,10 @@ func normalizedCacheImagePaths(for path: String) -> [String] {
         }
     }
 
-    let env = ProcessInfo.processInfo.environment
     let rootCandidates = [
-        env["PH_RUNTIME_ROOT"],
-        env["DYLD_ROOT_PATH"],
-        env["SIMCTL_CHILD_DYLD_ROOT_PATH"]
+        environment["PH_RUNTIME_ROOT"],
+        environment["DYLD_ROOT_PATH"],
+        environment["SIMCTL_CHILD_DYLD_ROOT_PATH"]
     ].compactMap { $0 }
 
     for runtimeRoot in rootCandidates {
@@ -490,12 +496,14 @@ func normalizedCacheImagePaths(for path: String) -> [String] {
     return unique
 }
 
-func sharedCachePath(fileManager: FileExistenceChecking = FileManager.default) -> String {
-    let env = ProcessInfo.processInfo.environment
+func sharedCachePath(
+    fileManager: FileExistenceChecking = FileManager.default,
+    environment: [String: String] = ProcessInfo.processInfo.environment
+) -> String {
     let rootCandidates = [
-        env["PH_RUNTIME_ROOT"],
-        env["DYLD_ROOT_PATH"],
-        env["SIMCTL_CHILD_DYLD_ROOT_PATH"]
+        environment["PH_RUNTIME_ROOT"],
+        environment["DYLD_ROOT_PATH"],
+        environment["SIMCTL_CHILD_DYLD_ROOT_PATH"]
     ].compactMap { $0 }
 
     for runtimeRoot in rootCandidates {
@@ -1284,10 +1292,13 @@ private func runtimeClassInfosByImageName(
     return infos
 }
 
-func runtimeFallbackTargetImagePaths(for imagePath: String) -> Set<String> {
+func runtimeFallbackTargetImagePaths(
+    for imagePath: String,
+    environment: [String: String] = ProcessInfo.processInfo.environment
+) -> Set<String> {
     Set(
-        normalizedCacheImagePaths(for: imagePath).map {
-            normalizedImagePath(stripRuntimeRoot(from: $0))
+        normalizedCacheImagePaths(for: imagePath, environment: environment).map {
+            normalizedImagePath(stripRuntimeRoot(from: $0, environment: environment))
         }
     )
 }
@@ -1342,16 +1353,13 @@ func dumpSwift(
     interfaceBuilderFactory: SwiftInterfaceBuildingFactory = DefaultSwiftInterfaceBuilderFactory(),
     fileManager: FileManager
 ) async throws {
-    let moduleName = URL(fileURLWithPath: imagePath).lastPathComponent
-    let outputURL = outputDir.appendingPathComponent("\(moduleName).swiftinterface")
-
-    if options.skipExisting && fileManager.fileExists(atPath: outputURL.path) {
-        return
-    }
-
-    let builder = try interfaceBuilderFactory.makeBuilder(machO: machO)
-    do {
-        let text = try await withSilencedStdout(!options.verbose) {
+    try await dumpSwiftInterface(
+        imagePath: imagePath,
+        outputDir: outputDir,
+        options: options,
+        fileManager: fileManager,
+        buildInterface: {
+            let builder = try interfaceBuilderFactory.makeBuilder(machO: machO)
             let prepareStart = profileNowNanoseconds(enabled: options.profile)
             try await builder.prepare()
             profileLogDuration(enabled: options.profile, imagePath: imagePath, name: "dumpSwift.prepare", since: prepareStart)
@@ -1360,6 +1368,27 @@ func dumpSwift(
             let text = try await builder.printRoot()
             profileLogDuration(enabled: options.profile, imagePath: imagePath, name: "dumpSwift.printRoot", since: printStart)
             return text
+        }
+    )
+}
+
+func dumpSwiftInterface(
+    imagePath: String,
+    outputDir: URL,
+    options: DumpOptions,
+    fileManager: FileManager,
+    buildInterface: () async throws -> String
+) async throws {
+    let moduleName = URL(fileURLWithPath: imagePath).lastPathComponent
+    let outputURL = outputDir.appendingPathComponent("\(moduleName).swiftinterface")
+
+    if options.skipExisting && fileManager.fileExists(atPath: outputURL.path) {
+        return
+    }
+
+    do {
+        let text = try await withSilencedStdout(!options.verbose) {
+            try await buildInterface()
         }
         if text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             return

--- a/Sources/HeaderDumpCore/HeaderDumpMain.swift
+++ b/Sources/HeaderDumpCore/HeaderDumpMain.swift
@@ -1353,13 +1353,13 @@ func dumpSwift(
     interfaceBuilderFactory: SwiftInterfaceBuildingFactory = DefaultSwiftInterfaceBuilderFactory(),
     fileManager: FileManager
 ) async throws {
+    let builder = try interfaceBuilderFactory.makeBuilder(machO: machO)
     try await dumpSwiftInterface(
         imagePath: imagePath,
         outputDir: outputDir,
         options: options,
         fileManager: fileManager,
         buildInterface: {
-            let builder = try interfaceBuilderFactory.makeBuilder(machO: machO)
             let prepareStart = profileNowNanoseconds(enabled: options.profile)
             try await builder.prepare()
             profileLogDuration(enabled: options.profile, imagePath: imagePath, name: "dumpSwift.prepare", since: prepareStart)

--- a/Sources/PrivateHeaderKitDump/PrivateHeaderKitDumpMain.swift
+++ b/Sources/PrivateHeaderKitDump/PrivateHeaderKitDumpMain.swift
@@ -149,11 +149,12 @@ private func normalizedEnvValue(_ value: String?) -> String? {
 
 private func runDumpStreaming(
     _ command: [String],
+    runner: CommandRunning,
     env: [String: String]? = nil,
     cwd: URL? = nil,
     streamOutput: Bool = true
 ) throws -> StreamingCommandResult {
-    try runStreamingSubprocess(
+    try runner.runStreaming(
         command,
         env: env,
         cwd: cwd,
@@ -1396,7 +1397,8 @@ internal func writeCompletionMarker(
     in outputDir: URL,
     imagePath: String,
     layout: String,
-    fileManager: FileManager = .default
+    fileManager: FileManager = .default,
+    date: Date = Date()
 ) throws {
     try fileManager.createDirectory(at: outputDir, withIntermediateDirectories: true)
     let formatter = ISO8601DateFormatter()
@@ -1404,7 +1406,7 @@ internal func writeCompletionMarker(
         tool: "privateheaderkit-dump",
         imagePath: imagePath,
         layout: layout,
-        completedAt: formatter.string(from: Date())
+        completedAt: formatter.string(from: date)
     )
     let data = try JSONEncoder().encode(marker)
     try data.write(to: completionMarkerURL(for: outputDir))
@@ -2171,7 +2173,7 @@ private func runHeaderdumpHost(
             env = ["SIMCTL_CHILD_DYLD_ROOT_PATH": ctx.systemRoot]
         }
     }
-    let result = try runDumpStreaming(cmd, env: env, cwd: nil, streamOutput: streamOutput)
+    let result = try runDumpStreaming(cmd, runner: runner, env: env, cwd: nil, streamOutput: streamOutput)
     try throwIfTerminationRequested()
     return result
 }
@@ -2225,11 +2227,11 @@ private func runHeaderdumpSimulator(
         env["SIMCTL_CHILD_PH_SYMBOL_PROFILE"] = "1"
     }
 
-    var result = try runDumpStreaming(cmd, env: env, cwd: nil, streamOutput: streamOutput)
+    var result = try runDumpStreaming(cmd, runner: runner, env: env, cwd: nil, streamOutput: streamOutput)
     try throwIfTerminationRequested()
     if result.status != 0, shouldRetrySimulatorBoot(result.lastLines) {
         try Simctl.ensureDeviceBooted(&device, runner: runner, force: true)
-        result = try runDumpStreaming(cmd, env: env, cwd: nil, streamOutput: streamOutput)
+        result = try runDumpStreaming(cmd, runner: runner, env: env, cwd: nil, streamOutput: streamOutput)
         try throwIfTerminationRequested()
     }
     return result
@@ -2269,7 +2271,7 @@ private func runHeaderdumpPathHost(
         }
     }
 
-    let result = try runDumpStreaming(cmd, env: env, cwd: nil, streamOutput: streamOutput)
+    let result = try runDumpStreaming(cmd, runner: runner, env: env, cwd: nil, streamOutput: streamOutput)
     try throwIfTerminationRequested()
     return result
 }
@@ -2303,11 +2305,11 @@ private func runHeaderdumpPathSimulator(
         env["SIMCTL_CHILD_PH_SYMBOL_PROFILE"] = "1"
     }
 
-    var result = try runDumpStreaming(cmd, env: env, cwd: nil, streamOutput: streamOutput)
+    var result = try runDumpStreaming(cmd, runner: runner, env: env, cwd: nil, streamOutput: streamOutput)
     try throwIfTerminationRequested()
     if result.status != 0, shouldRetrySimulatorBoot(result.lastLines) {
         try Simctl.ensureDeviceBooted(&device, runner: runner, force: true)
-        result = try runDumpStreaming(cmd, env: env, cwd: nil, streamOutput: streamOutput)
+        result = try runDumpStreaming(cmd, runner: runner, env: env, cwd: nil, streamOutput: streamOutput)
         try throwIfTerminationRequested()
     }
     return result

--- a/Sources/PrivateHeaderKitInstall/PrivateHeaderKitInstallMain.swift
+++ b/Sources/PrivateHeaderKitInstall/PrivateHeaderKitInstallMain.swift
@@ -9,13 +9,13 @@ import Glibc
 
 #if os(macOS)
 
-private struct InstallOptions {
+struct InstallOptions {
     var prefix: String?
     var bindir: String?
     var dryRun: Bool
 }
 
-private enum InstallError: Error, CustomStringConvertible {
+enum InstallError: Error, CustomStringConvertible {
     case message(String)
 
     var description: String {
@@ -62,7 +62,7 @@ private func printUsage() {
     print(text)
 }
 
-private func parseOptions(_ args: [String], environment: [String: String]) throws -> InstallOptions {
+func parseOptions(_ args: [String], environment: [String: String]) throws -> InstallOptions {
     var options = InstallOptions(prefix: nil, bindir: nil, dryRun: false)
     if let envPrefix = environment["PREFIX"]?.trimmingCharacters(in: .whitespacesAndNewlines),
        !envPrefix.isEmpty {
@@ -120,7 +120,7 @@ private func parseOptions(_ args: [String], environment: [String: String]) throw
     return options
 }
 
-private func resolveBinDir(prefix: String?, bindir: String?) -> URL {
+func resolveBinDir(prefix: String?, bindir: String?) -> URL {
     if let bindir {
         return URL(fileURLWithPath: PathUtils.expandTilde(bindir), isDirectory: true)
     }
@@ -135,7 +135,7 @@ private func logError(_ message: String) {
     FileHandle.standardError.write(data)
 }
 
-private func repositoryRoot(from executableURL: URL) -> URL? {
+func repositoryRoot(from executableURL: URL) -> URL? {
     var current = executableURL
     while current.path != "/" {
         if current.lastPathComponent == ".build" {
@@ -146,7 +146,7 @@ private func repositoryRoot(from executableURL: URL) -> URL? {
     return nil
 }
 
-private func looksLikePrivateHeaderKitRepo(_ repoRoot: URL, fileManager: FileManager) -> Bool {
+func looksLikePrivateHeaderKitRepo(_ repoRoot: URL, fileManager: FileManager) -> Bool {
     // Avoid accidentally treating some other Swift package as this repository.
     let markers = [
         repoRoot.appendingPathComponent("Sources/HeaderDumpCore/HeaderDumpMain.swift"),
@@ -155,13 +155,13 @@ private func looksLikePrivateHeaderKitRepo(_ repoRoot: URL, fileManager: FileMan
     return markers.allSatisfy { fileManager.fileExists(atPath: $0.path) }
 }
 
-private func buildProducts(_ products: [String], in directory: URL, runner: CommandRunning) throws {
+func buildProducts(_ products: [String], in directory: URL, runner: CommandRunning) throws {
     for product in products {
         try runner.runSimple(["swift", "build", "-c", "release", "--product", product], env: nil, cwd: directory)
     }
 }
 
-private func resolveSwiftBinDir(repoRoot: URL, runner: CommandRunning) -> URL? {
+func resolveSwiftBinDir(repoRoot: URL, runner: CommandRunning) -> URL? {
     // `swift build --show-bin-path` prints a single path line, but be defensive and pick the last non-empty line.
     guard let output = try? runner.runCapture(["swift", "build", "-c", "release", "--show-bin-path"], env: nil, cwd: repoRoot) else {
         return nil
@@ -175,7 +175,11 @@ private func resolveSwiftBinDir(repoRoot: URL, runner: CommandRunning) -> URL? {
     return URL(fileURLWithPath: path, isDirectory: true)
 }
 
-private func resolveXcodeScheme(repoRoot: URL, runner: CommandRunning) throws -> String {
+func resolveXcodeScheme(
+    repoRoot: URL,
+    runner: CommandRunning,
+    environment: [String: String] = ProcessInfo.processInfo.environment
+) throws -> String {
     struct ListOutput: Decodable {
         struct Container: Decodable {
             let schemes: [String]?
@@ -205,7 +209,7 @@ private func resolveXcodeScheme(repoRoot: URL, runner: CommandRunning) throws ->
         }
     }
 
-    let configuredRaw = ProcessInfo.processInfo.environment["PH_XCODE_SCHEME"]
+    let configuredRaw = environment["PH_XCODE_SCHEME"]
     let configured = configuredRaw?.trimmingCharacters(in: .whitespacesAndNewlines)
     if let configured, !configured.isEmpty {
         if schemes.isEmpty || schemes.contains(configured) {

--- a/Sources/PrivateHeaderKitTooling/FileOps.swift
+++ b/Sources/PrivateHeaderKitTooling/FileOps.swift
@@ -6,10 +6,15 @@ import Glibc
 #endif
 
 public enum FileOps {
-    public static func buildStageDir(outDir: URL, pid: Int32 = getpid(), date: Date = Date()) -> URL {
+    public static func buildStageDir(
+        outDir: URL,
+        pid: Int32 = getpid(),
+        date: Date = Date(),
+        timeZone: TimeZone = .current
+    ) -> URL {
         let formatter = DateFormatter()
         formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone.current
+        formatter.timeZone = timeZone
         formatter.dateFormat = "yyyyMMddHHmmss"
         let token = "\(pid)-\(formatter.string(from: date))"
         return outDir.appendingPathComponent(".tmp-\(token)", isDirectory: true)

--- a/Sources/PrivateHeaderKitTooling/ProcessRunner.swift
+++ b/Sources/PrivateHeaderKitTooling/ProcessRunner.swift
@@ -16,6 +16,27 @@ public protocol CommandRunning {
     func runCapture(_ command: [String], env: [String: String]?, cwd: URL?) throws -> String
     func runSimple(_ command: [String], env: [String: String]?, cwd: URL?) throws
     func runStreaming(_ command: [String], env: [String: String]?, cwd: URL?) throws -> StreamingCommandResult
+    func runStreaming(
+        _ command: [String],
+        env: [String: String]?,
+        cwd: URL?,
+        streamOutput: Bool,
+        onLaunch: ((Int32) -> Void)?,
+        onCleanup: ((Int32) -> Void)?
+    ) throws -> StreamingCommandResult
+}
+
+public extension CommandRunning {
+    func runStreaming(
+        _ command: [String],
+        env: [String: String]?,
+        cwd: URL?,
+        streamOutput _: Bool,
+        onLaunch _: ((Int32) -> Void)?,
+        onCleanup _: ((Int32) -> Void)?
+    ) throws -> StreamingCommandResult {
+        try runStreaming(command, env: env, cwd: cwd)
+    }
 }
 
 #if os(macOS)
@@ -38,18 +59,38 @@ public final class ProcessRunner: CommandRunning {
     }
 
     public func runStreaming(_ command: [String], env: [String: String]? = nil, cwd: URL? = nil) throws -> StreamingCommandResult {
-        try runStreamingSubprocess(
+        try runStreaming(
             command,
             env: env,
             cwd: cwd,
             streamOutput: true,
+            onLaunch: nil,
+            onCleanup: nil
+        )
+    }
+
+    public func runStreaming(
+        _ command: [String],
+        env: [String: String]? = nil,
+        cwd: URL? = nil,
+        streamOutput: Bool,
+        onLaunch: ((Int32) -> Void)?,
+        onCleanup: ((Int32) -> Void)?
+    ) throws -> StreamingCommandResult {
+        try runStreamingSubprocess(
+            command,
+            env: env,
+            cwd: cwd,
+            streamOutput: streamOutput,
             onLaunch: { pid in
                 gActiveToolingSubprocessPid = pid
+                onLaunch?(pid)
             },
             onCleanup: { pid in
                 if gActiveToolingSubprocessPid == pid {
                     gActiveToolingSubprocessPid = 0
                 }
+                onCleanup?(pid)
             }
         )
     }
@@ -142,6 +183,17 @@ public final class ProcessRunner: CommandRunning {
     }
 
     public func runStreaming(_ command: [String], env: [String: String]?, cwd: URL?) throws -> StreamingCommandResult {
+        throw ToolingError.unsupported("process execution is not available on this platform")
+    }
+
+    public func runStreaming(
+        _ command: [String],
+        env: [String: String]?,
+        cwd: URL?,
+        streamOutput _: Bool,
+        onLaunch _: ((Int32) -> Void)?,
+        onCleanup _: ((Int32) -> Void)?
+    ) throws -> StreamingCommandResult {
         throw ToolingError.unsupported("process execution is not available on this platform")
     }
 }

--- a/Tests/HeaderDumpCLITests/HeaderDumpCLITests.swift
+++ b/Tests/HeaderDumpCLITests/HeaderDumpCLITests.swift
@@ -393,6 +393,30 @@ struct HeaderDumpObjCHeaderNameTests {
 
 @Suite
 struct HeaderDumpSwiftInterfaceTests {
+    @Test func shouldSkipSwiftInterfaceUsesInjectedFileExistence() {
+        let outputDir = URL(fileURLWithPath: "/tmp/out", isDirectory: true)
+        let outputPath = outputDir.appendingPathComponent("FixtureSkip.swiftinterface").path
+        let fake = FakeFileManager(existing: [outputPath])
+
+        var options = DumpOptions(outputDir: outputDir)
+        options.skipExisting = true
+
+        #expect(shouldSkipSwiftInterface(
+            imagePath: "/tmp/FixtureSkip",
+            outputDir: outputDir,
+            options: options,
+            fileManager: fake
+        ) == true)
+
+        options.skipExisting = false
+        #expect(shouldSkipSwiftInterface(
+            imagePath: "/tmp/FixtureSkip",
+            outputDir: outputDir,
+            options: options,
+            fileManager: fake
+        ) == false)
+    }
+
     @Test func dumpSwiftInterfaceSkipsExistingFileWithoutBuilding() async throws {
         let dirs = try makeTemporaryTestDirectories()
         let outputDir = dirs.root.appendingPathComponent("out", isDirectory: true)

--- a/Tests/HeaderDumpCLITests/HeaderDumpCLITests.swift
+++ b/Tests/HeaderDumpCLITests/HeaderDumpCLITests.swift
@@ -1,10 +1,10 @@
 import Foundation
 import Testing
-import MachOKit
 #if canImport(HeaderDumpRuntimeObjC)
 import HeaderDumpRuntimeObjC
 #endif
 @testable import HeaderDumpCore
+import PrivateHeaderKitTestSupport
 
 #if canImport(Darwin)
 import Darwin
@@ -18,207 +18,8 @@ private struct FakeFileManager: FileExistenceChecking {
     }
 }
 
-private final class RecordingBuilder: SwiftInterfaceBuilding {
-    var preparedCount = 0
-    var printedCount = 0
-    let output: String
-
-    init(output: String) {
-        self.output = output
-    }
-
-    func prepare() async throws {
-        preparedCount += 1
-    }
-
-    func printRoot() async throws -> String {
-        printedCount += 1
-        return output
-    }
-}
-
-private final class RecordingFactory: SwiftInterfaceBuildingFactory {
-    var makeCount = 0
-    let builder: SwiftInterfaceBuilding
-
-    init(builder: SwiftInterfaceBuilding) {
-        self.builder = builder
-    }
-
-    func makeBuilder(machO: MachOFile) throws -> SwiftInterfaceBuilding {
-        makeCount += 1
-        return builder
-    }
-}
-
-private struct ProcessFailure: Error, CustomStringConvertible {
-    let status: Int32
-    let stdout: String
-    let stderr: String
-
-    var description: String {
-        "Process failed with status \(status)\nstdout:\n\(stdout)\nstderr:\n\(stderr)"
-    }
-}
-
-private enum TestError: Error {
-    case missingMachO
-}
-
-private func runProcess(_ executable: URL, _ arguments: [String]) throws -> (String, String) {
-    let process = Process()
-    process.executableURL = executable
-    process.arguments = arguments
-
-    let stdout = Pipe()
-    let stderr = Pipe()
-    process.standardOutput = stdout
-    process.standardError = stderr
-
-    try process.run()
-    process.waitUntilExit()
-
-    let stdoutData = stdout.fileHandleForReading.readDataToEndOfFile()
-    let stderrData = stderr.fileHandleForReading.readDataToEndOfFile()
-    let stdoutText = String(data: stdoutData, encoding: .utf8) ?? ""
-    let stderrText = String(data: stderrData, encoding: .utf8) ?? ""
-
-    if process.terminationStatus != 0 {
-        throw ProcessFailure(status: process.terminationStatus, stdout: stdoutText, stderr: stderrText)
-    }
-
-    return (stdoutText, stderrText)
-}
-
-private func makeTempDir() throws -> URL {
-    let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
-    try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
-    return dir
-}
-
-private func currentEnvValue(_ key: String) -> String? {
-    guard let value = getenv(key) else { return nil }
-    return String(cString: value)
-}
-
-private func withEnvironment<T>(_ values: [String: String?], _ body: () throws -> T) rethrows -> T {
-    var previous: [String: String?] = [:]
-    for key in values.keys {
-        previous[key] = currentEnvValue(key)
-    }
-    for (key, value) in values {
-        if let value {
-            setenv(key, value, 1)
-        } else {
-            unsetenv(key)
-        }
-    }
-    defer {
-        for (key, value) in previous {
-            if let value {
-                setenv(key, value, 1)
-            } else {
-                unsetenv(key)
-            }
-        }
-    }
-    return try body()
-}
-
-private func withEnvironment<T>(_ values: [String: String?], _ body: () async throws -> T) async rethrows -> T {
-    var previous: [String: String?] = [:]
-    for key in values.keys {
-        previous[key] = currentEnvValue(key)
-    }
-    for (key, value) in values {
-        if let value {
-            setenv(key, value, 1)
-        } else {
-            unsetenv(key)
-        }
-    }
-    defer {
-        for (key, value) in previous {
-            if let value {
-                setenv(key, value, 1)
-            } else {
-                unsetenv(key)
-            }
-        }
-    }
-    return try await body()
-}
-
-#if os(macOS)
-private func buildSwiftFixture(in dir: URL, moduleName: String) throws -> URL {
-    let sourceURL = dir.appendingPathComponent("Fixture.swift")
-    let source = """
-    public struct \(moduleName)Type {
-        public init() {}
-    }
-    """
-    try source.write(to: sourceURL, atomically: true, encoding: .utf8)
-
-    let outputURL = dir.appendingPathComponent("\(moduleName).dylib")
-    let xcrunURL = URL(fileURLWithPath: "/usr/bin/xcrun")
-    do {
-        // Avoid dyld chained fixups in the test fixture to prevent flaky crashes during parsing.
-        _ = try runProcess(
-            xcrunURL,
-            [
-                "--sdk", "macosx",
-                "swiftc",
-                "-emit-library",
-                "-module-name", moduleName,
-                sourceURL.path,
-                "-Xlinker", "-no_fixup_chains",
-                "-o", outputURL.path,
-            ]
-        )
-    } catch {
-        // Fallback for older toolchains where `-no_fixup_chains` isn't supported.
-        _ = try runProcess(
-            xcrunURL,
-            [
-                "--sdk", "macosx",
-                "swiftc",
-                "-emit-library",
-                "-module-name", moduleName,
-                sourceURL.path,
-                "-o", outputURL.path,
-            ]
-        )
-    }
-    return outputURL
-}
-
-private func loadMachO(at url: URL) throws -> MachOFile {
-    let file = try loadFromFile(url: url)
-    switch file {
-    case .machO(let machO):
-        return machO
-    case .fat(let fat):
-        let machOFiles = try fat.machOFiles()
-        guard let match = machOFiles.first else {
-            throw TestError.missingMachO
-        }
-        return match
-    }
-}
-#endif
-
-@Suite(.serialized)
-struct HeaderDumpCLITests {
-#if canImport(ObjectiveC) && canImport(HeaderDumpRuntimeObjC)
-    @Test func runtimeInspectorBuildsNSObjectSnapshot() {
-        var failedStage: NSString?
-        let snapshot = PHRuntimeObjCInspector.snapshot(for: NSObject.self, failedStage: &failedStage)
-        #expect(snapshot != nil)
-        #expect(failedStage == nil)
-        #expect(snapshot?.name == "NSObject")
-    }
-#endif
-
+@Suite
+struct HeaderDumpArgumentTests {
     @Test func parseArgumentsPopulatesOptions() {
         let args = [
             "-o", "/tmp/out",
@@ -233,12 +34,7 @@ struct HeaderDumpCLITests {
             "/tmp/input"
         ]
 
-        let parsed = withEnvironment([
-            "PH_RUNTIME_ROOT": nil,
-            "SIMCTL_CHILD_PH_RUNTIME_ROOT": nil
-        ]) {
-            parseArguments(args)
-        }
+        let parsed = parseArguments(args, environment: [:])
 
         #expect(parsed != nil)
         #expect(parsed?.inputPath == "/tmp/input")
@@ -254,17 +50,12 @@ struct HeaderDumpCLITests {
     }
 
     @Test func parseArgumentsIgnoresUnknownFlags() {
-        let parsed = withEnvironment([
-            "PH_RUNTIME_ROOT": nil,
-            "SIMCTL_CHILD_PH_RUNTIME_ROOT": nil
-        ]) {
-            parseArguments(["-Z", "/tmp/input"])
-        }
+        let parsed = parseArguments(["-Z", "/tmp/input"], environment: [:])
         #expect(parsed?.inputPath == "/tmp/input")
     }
 
     @Test func parseArgumentsReturnsNilWithoutInput() {
-        let parsed = parseArguments(["-r"])
+        let parsed = parseArguments(["-r"], environment: [:])
         #expect(parsed == nil)
     }
 
@@ -273,137 +64,66 @@ struct HeaderDumpCLITests {
         var didPrint = false
         let parsed = parseArguments(
             ["--help"],
+            environment: [:],
             exitHandler: { code in exitCode = code },
             printUsageHandler: { didPrint = true }
         )
 
         #expect(parsed == nil)
-        #expect(exitCode == EXIT_SUCCESS)
+        #expect(exitCode == 0)
         #expect(didPrint == true)
     }
+}
 
-    @Test func shouldUseRuntimeFallbackFromEnv() {
-        let enabled = withEnvironment([
-            "PH_RUNTIME_ROOT": "/tmp/runtime",
-            "SIMCTL_CHILD_PH_RUNTIME_ROOT": nil
-        ]) {
-            shouldUseRuntimeFallback()
-        }
-        #expect(enabled == true)
-
-        let enabledSim = withEnvironment([
-            "PH_RUNTIME_ROOT": nil,
-            "SIMCTL_CHILD_PH_RUNTIME_ROOT": "/tmp/runtime"
-        ]) {
-            shouldUseRuntimeFallback()
-        }
-        #expect(enabledSim == true)
-
-        let disabled = withEnvironment([
-            "PH_RUNTIME_ROOT": nil,
-            "SIMCTL_CHILD_PH_RUNTIME_ROOT": nil
-        ]) {
-            shouldUseRuntimeFallback()
-        }
-        #expect(disabled == false)
+@Suite
+struct HeaderDumpEnvironmentTests {
+    @Test func resolvesRuntimeFallbackFromInjectedEnvironment() {
+        #expect(shouldUseRuntimeFallback(environment: ["PH_RUNTIME_ROOT": "/tmp/runtime"]) == true)
+        #expect(shouldUseRuntimeFallback(environment: ["SIMCTL_CHILD_PH_RUNTIME_ROOT": "/tmp/runtime"]) == true)
+        #expect(shouldUseRuntimeFallback(environment: [:]) == false)
     }
 
-    @Test func shouldLogSkippedClassesFromEnv() {
-        let enabled = withEnvironment(["PH_VERBOSE_SKIP": "1"]) {
-            shouldLogSkippedClasses()
-        }
-        #expect(enabled == true)
-
-        let disabled = withEnvironment(["PH_VERBOSE_SKIP": "0"]) {
-            shouldLogSkippedClasses()
-        }
-        #expect(disabled == false)
+    @Test func resolvesLoggingAndProfilingFromInjectedEnvironment() {
+        #expect(shouldLogSkippedClasses(environment: ["PH_VERBOSE_SKIP": "1"]) == true)
+        #expect(shouldLogSkippedClasses(environment: ["PH_VERBOSE_SKIP": "0"]) == false)
+        #expect(shouldProfile(environment: ["PH_PROFILE": "1"]) == true)
+        #expect(shouldProfile(environment: ["SIMCTL_CHILD_PH_PROFILE": "1"]) == true)
+        #expect(shouldProfile(environment: ["PH_PROFILE": "0"]) == false)
+        #expect(shouldLogSwiftEvents(environment: ["PH_SWIFT_EVENTS": "1"]) == true)
+        #expect(shouldLogSwiftEvents(environment: ["SIMCTL_CHILD_PH_SWIFT_EVENTS": "1"]) == true)
+        #expect(shouldLogSwiftEvents(environment: ["PH_SWIFT_EVENTS": "0"]) == false)
     }
+}
 
-    @Test func shouldProfileFromEnv() {
-        let enabled = withEnvironment([
-            "PH_PROFILE": "1",
-            "SIMCTL_CHILD_PH_PROFILE": nil
-        ]) {
-            shouldProfile()
-        }
-        #expect(enabled == true)
-
-        let enabledSim = withEnvironment([
-            "PH_PROFILE": nil,
-            "SIMCTL_CHILD_PH_PROFILE": "1"
-        ]) {
-            shouldProfile()
-        }
-        #expect(enabledSim == true)
-
-        let disabled = withEnvironment([
-            "PH_PROFILE": "0",
-            "SIMCTL_CHILD_PH_PROFILE": nil
-        ]) {
-            shouldProfile()
-        }
-        #expect(disabled == false)
-    }
-
-    @Test func shouldLogSwiftEventsFromEnv() {
-        let enabled = withEnvironment([
-            "PH_SWIFT_EVENTS": "1",
-            "SIMCTL_CHILD_PH_SWIFT_EVENTS": nil
-        ]) {
-            shouldLogSwiftEvents()
-        }
-        #expect(enabled == true)
-
-        let enabledSim = withEnvironment([
-            "PH_SWIFT_EVENTS": nil,
-            "SIMCTL_CHILD_PH_SWIFT_EVENTS": "1"
-        ]) {
-            shouldLogSwiftEvents()
-        }
-        #expect(enabledSim == true)
-
-        let disabled = withEnvironment([
-            "PH_SWIFT_EVENTS": "0",
-            "SIMCTL_CHILD_PH_SWIFT_EVENTS": nil
-        ]) {
-            shouldLogSwiftEvents()
-        }
-        #expect(disabled == false)
-    }
-
-    @Test func resolveRuntimeURLUsesRuntimeRoot() throws {
-        let tempDir = try makeTempDir()
-        let runtimeRoot = tempDir.appendingPathComponent("Runtime")
+@Suite
+struct HeaderDumpPathTests {
+    @Test func resolveRuntimeURLUsesInjectedRuntimeRootAndFileManager() {
+        let runtimeRoot = "/Runtime"
         let inputPath = "/System/Library/Frameworks/Foo.framework/Foo"
-        let candidate = runtimeRoot.appendingPathComponent(String(inputPath.dropFirst()))
-        try FileManager.default.createDirectory(
-            at: candidate.deletingLastPathComponent(),
-            withIntermediateDirectories: true
+        let candidate = "/Runtime/System/Library/Frameworks/Foo.framework/Foo"
+        let fake = FakeFileManager(existing: [candidate])
+
+        let resolved = resolveRuntimeURL(
+            URL(fileURLWithPath: inputPath),
+            environment: ["PH_RUNTIME_ROOT": runtimeRoot],
+            fileManager: fake
         )
-        FileManager.default.createFile(atPath: candidate.path, contents: Data())
+        #expect(resolved.path == candidate)
 
-        let resolved = withEnvironment(["PH_RUNTIME_ROOT": runtimeRoot.path]) {
-            resolveRuntimeURL(URL(fileURLWithPath: inputPath))
-        }
-        #expect(resolved.path == candidate.path)
-
-        let unresolved = withEnvironment(["PH_RUNTIME_ROOT": runtimeRoot.path]) {
-            resolveRuntimeURL(URL(fileURLWithPath: "/System/Library/Frameworks/Bar.framework/Bar"))
-        }
+        let unresolved = resolveRuntimeURL(
+            URL(fileURLWithPath: "/System/Library/Frameworks/Bar.framework/Bar"),
+            environment: ["PH_RUNTIME_ROOT": runtimeRoot],
+            fileManager: fake
+        )
         #expect(unresolved.path == "/System/Library/Frameworks/Bar.framework/Bar")
     }
 
-    @Test func stripRuntimeRootRemovesPrefix() throws {
-        let tempDir = try makeTempDir()
-        let runtimeRoot = tempDir.appendingPathComponent("Runtime")
-        let inputPath = "/System/Library/Frameworks/Foo.framework/Foo"
-        let candidate = runtimeRoot.appendingPathComponent(String(inputPath.dropFirst()))
-
-        let stripped = withEnvironment(["PH_RUNTIME_ROOT": runtimeRoot.path]) {
-            stripRuntimeRoot(from: candidate.path)
-        }
-        #expect(stripped == inputPath)
+    @Test func stripRuntimeRootRemovesInjectedPrefix() {
+        let stripped = stripRuntimeRoot(
+            from: "/Runtime/System/Library/Frameworks/Foo.framework/Foo",
+            environment: ["PH_RUNTIME_ROOT": "/Runtime"]
+        )
+        #expect(stripped == "/System/Library/Frameworks/Foo.framework/Foo")
     }
 
     @Test func normalizePathCollapsesSlashes() {
@@ -411,35 +131,51 @@ struct HeaderDumpCLITests {
     }
 
     @Test func normalizedCacheImagePathsIncludesSystemPaths() {
-        let runtimeRoot = "/Runtime"
-        let path = "/Runtime/System/Library/Frameworks/Foo.framework/Foo"
-        let paths = withEnvironment(["PH_RUNTIME_ROOT": runtimeRoot]) {
-            normalizedCacheImagePaths(for: path)
-        }
-        #expect(paths.first == path)
+        let paths = normalizedCacheImagePaths(
+            for: "/Runtime/System/Library/Frameworks/Foo.framework/Foo",
+            environment: ["PH_RUNTIME_ROOT": "/Runtime"]
+        )
+
+        #expect(paths.first == "/Runtime/System/Library/Frameworks/Foo.framework/Foo")
         #expect(paths.contains("/System/Library/Frameworks/Foo.framework/Foo"))
         #expect(paths.contains("/Runtime/System/Library/Frameworks/Foo.framework/Versions/Current/Foo"))
         #expect(paths.contains("/Runtime/System/Library/Frameworks/Foo.framework/Versions/A/Foo"))
         #expect(Set(paths).count == paths.count)
 
-        let usrPath = "/Runtime/usr/lib/libobjc.A.dylib"
-        let usrPaths = withEnvironment(["PH_RUNTIME_ROOT": runtimeRoot]) {
-            normalizedCacheImagePaths(for: usrPath)
-        }
+        let usrPaths = normalizedCacheImagePaths(
+            for: "/Runtime/usr/lib/libobjc.A.dylib",
+            environment: ["PH_RUNTIME_ROOT": "/Runtime"]
+        )
         #expect(usrPaths.contains("/usr/lib/libobjc.A.dylib"))
     }
 
-#if canImport(ObjectiveC)
+    #if canImport(ObjectiveC)
     @Test func runtimeFallbackTargetImagePathsIncludeVersionedCandidates() {
-        let imagePath = "/System/Library/Frameworks/Foo.framework/Foo"
-        let targets = runtimeFallbackTargetImagePaths(for: imagePath)
+        let targets = runtimeFallbackTargetImagePaths(
+            for: "/Runtime/System/Library/Frameworks/Foo.framework/Foo",
+            environment: ["PH_RUNTIME_ROOT": "/Runtime"]
+        )
 
         #expect(targets.contains("/System/Library/Frameworks/Foo.framework/Foo"))
         #expect(targets.contains("/System/Library/Frameworks/Foo.framework/Versions/Current/Foo"))
         #expect(targets.contains("/System/Library/Frameworks/Foo.framework/Versions/A/Foo"))
     }
-#endif
+    #endif
 
+    @Test func sharedCachePathUsesInjectedFileManagerAndEnvironment() {
+        let simCache = "/Runtime/System/Library/Caches/com.apple.dyld/dyld_sim_shared_cache_arm64e"
+        let fake = FakeFileManager(existing: [simCache])
+        let resolved = sharedCachePath(fileManager: fake, environment: ["PH_RUNTIME_ROOT": "/Runtime"])
+        #expect(resolved == simCache)
+
+        let empty = FakeFileManager(existing: [])
+        let fallback = sharedCachePath(fileManager: empty, environment: [:])
+        #expect(fallback == "/System/Library/Caches/com.apple.dyld/dyld_shared_cache_arm64e")
+    }
+}
+
+@Suite
+struct HeaderDumpBundlePathTests {
     @Test func writeDirectoryBuildsBundlePaths() {
         let outputRoot = URL(fileURLWithPath: "/tmp/out")
         var options = DumpOptions(outputDir: outputRoot)
@@ -475,124 +211,25 @@ struct HeaderDumpCLITests {
     }
 
     @Test func isBundleDirectoryChecksExtensions() {
-        let frameworkURL = URL(fileURLWithPath: "/tmp/Foo.framework", isDirectory: true)
-        let appURL = URL(fileURLWithPath: "/tmp/Foo.app", isDirectory: true)
-        let bundleURL = URL(fileURLWithPath: "/tmp/Foo.bundle", isDirectory: true)
-        let xpcURL = URL(fileURLWithPath: "/tmp/Foo.xpc", isDirectory: true)
-        let appexURL = URL(fileURLWithPath: "/tmp/Foo.appex", isDirectory: true)
-        let fileURL = URL(fileURLWithPath: "/tmp/Foo.framework", isDirectory: false)
-
-        #expect(isBundleDirectory(frameworkURL) == true)
-        #expect(isBundleDirectory(appURL) == true)
-        #expect(isBundleDirectory(bundleURL) == true)
-        #expect(isBundleDirectory(xpcURL) == true)
-        #expect(isBundleDirectory(appexURL) == true)
-        #expect(isBundleDirectory(fileURL) == false)
+        #expect(isBundleDirectory(URL(fileURLWithPath: "/tmp/Foo.framework", isDirectory: true)) == true)
+        #expect(isBundleDirectory(URL(fileURLWithPath: "/tmp/Foo.app", isDirectory: true)) == true)
+        #expect(isBundleDirectory(URL(fileURLWithPath: "/tmp/Foo.bundle", isDirectory: true)) == true)
+        #expect(isBundleDirectory(URL(fileURLWithPath: "/tmp/Foo.xpc", isDirectory: true)) == true)
+        #expect(isBundleDirectory(URL(fileURLWithPath: "/tmp/Foo.appex", isDirectory: true)) == true)
+        #expect(isBundleDirectory(URL(fileURLWithPath: "/tmp/Foo.framework", isDirectory: false)) == false)
     }
 
     @Test func isBundleDirectoryTreatsSymlinkToDirectoryAsBundle() throws {
-        let tempDir = try makeTempDir()
-        let fm = FileManager.default
+        let dirs = try makeTemporaryTestDirectories()
+        let realBundle = dirs.root.appendingPathComponent("Foo.framework", isDirectory: true)
+        try FileManager.default.createDirectory(at: realBundle, withIntermediateDirectories: true)
 
-        let realBundle = tempDir.appendingPathComponent("Foo.framework", isDirectory: true)
-        try fm.createDirectory(at: realBundle, withIntermediateDirectories: true)
+        let linkPath = dirs.root.appendingPathComponent("Link.framework").path
+        try FileManager.default.createSymbolicLink(atPath: linkPath, withDestinationPath: realBundle.path)
 
-        let linkPath = tempDir.appendingPathComponent("Link.framework").path
-        try fm.createSymbolicLink(atPath: linkPath, withDestinationPath: realBundle.path)
-
-        // Intentionally omit `isDirectory: true` so `hasDirectoryPath` stays false.
         let linkURL = URL(fileURLWithPath: linkPath)
         #expect(linkURL.hasDirectoryPath == false)
         #expect(isBundleDirectory(linkURL) == true)
-    }
-
-    @Test func isBundleDirectoryTreatsSymlinkToDirectoryAsBundleForXPCAndAppExtensions() throws {
-        let tempDir = try makeTempDir()
-        let fm = FileManager.default
-
-        let realDir = tempDir.appendingPathComponent("RealDir", isDirectory: true)
-        try fm.createDirectory(at: realDir, withIntermediateDirectories: true)
-
-        let xpcLinkPath = tempDir.appendingPathComponent("Link.xpc").path
-        try fm.createSymbolicLink(atPath: xpcLinkPath, withDestinationPath: realDir.path)
-
-        let appexLinkPath = tempDir.appendingPathComponent("Link.appex").path
-        try fm.createSymbolicLink(atPath: appexLinkPath, withDestinationPath: realDir.path)
-
-        let xpcLinkURL = URL(fileURLWithPath: xpcLinkPath)
-        #expect(xpcLinkURL.hasDirectoryPath == false)
-        #expect(isBundleDirectory(xpcLinkURL) == true)
-
-        let appexLinkURL = URL(fileURLWithPath: appexLinkPath)
-        #expect(appexLinkURL.hasDirectoryPath == false)
-        #expect(isBundleDirectory(appexLinkURL) == true)
-    }
-
-    @Test func resolveBundleExecutableURLRebasesBundleExecutableWhenPossible() {
-        let bundleURL = URL(fileURLWithPath: "/System/Library/Frameworks/SafariServices.framework", isDirectory: true)
-        let resolvedExec = URL(fileURLWithPath: "/System/Cryptexes/OS/System/Library/Frameworks/SafariServices.framework/SafariServices")
-
-        let expectedRebased = bundleURL.appendingPathComponent("SafariServices")
-        let fake = FakeFileManager(existing: [expectedRebased.path])
-
-        let result = resolveBundleExecutableURL(
-            bundleURL,
-            fileManager: fake,
-            bundleExecutableURL: { _ in resolvedExec }
-        )
-        #expect(result?.path == expectedRebased.path)
-    }
-
-    @Test func resolveBundleExecutableURLResolvesXPCAndAppExtensionCandidates() throws {
-        let tempDir = try makeTempDir()
-        let fm = FileManager.default
-
-        let xpcURL = tempDir.appendingPathComponent("Foo.xpc", isDirectory: true)
-        try fm.createDirectory(at: xpcURL, withIntermediateDirectories: true)
-        let xpcExec = xpcURL.appendingPathComponent("Foo", isDirectory: false)
-        fm.createFile(atPath: xpcExec.path, contents: Data())
-
-        let xpcResolved = resolveBundleExecutableURL(
-            xpcURL,
-            fileManager: fm,
-            bundleExecutableURL: { _ in nil }
-        )
-        #expect(xpcResolved?.path == xpcExec.path)
-
-        let appexURL = tempDir.appendingPathComponent("Bar.appex", isDirectory: true)
-        try fm.createDirectory(at: appexURL, withIntermediateDirectories: true)
-        let appexExec = appexURL.appendingPathComponent("Bar", isDirectory: false)
-        fm.createFile(atPath: appexExec.path, contents: Data())
-
-        let appexResolved = resolveBundleExecutableURL(
-            appexURL,
-            fileManager: fm,
-            bundleExecutableURL: { _ in nil }
-        )
-        #expect(appexResolved?.path == appexExec.path)
-    }
-
-    @Test func isSaneObjCTypeNameRejectsReplacementAndControl() {
-        #expect(isSaneObjCTypeName("ASAuthorization") == true)
-        #expect(isSaneObjCTypeName("") == false)
-        #expect(isSaneObjCTypeName("Bad\u{000C}") == false)
-        #expect(isSaneObjCTypeName("\u{FFFD}") == false)
-    }
-
-    @Test func sharedCachePathUsesInjectedFileManager() {
-        let runtimeRoot = "/Runtime"
-        let simCache = "/Runtime/System/Library/Caches/com.apple.dyld/dyld_sim_shared_cache_arm64e"
-        let fake = FakeFileManager(existing: [simCache])
-        let resolved = withEnvironment(["PH_RUNTIME_ROOT": runtimeRoot]) {
-            sharedCachePath(fileManager: fake)
-        }
-        #expect(resolved == simCache)
-
-        let empty = FakeFileManager(existing: [])
-        let fallback = withEnvironment(["PH_RUNTIME_ROOT": nil]) {
-            sharedCachePath(fileManager: empty)
-        }
-        #expect(fallback == "/System/Library/Caches/com.apple.dyld/dyld_shared_cache_arm64e")
     }
 
     @Test func resolveBundleExecutableURLUsesInjectedFileManager() {
@@ -616,6 +253,20 @@ struct HeaderDumpCLITests {
         #expect(resolvedExplicit?.path == explicit.path)
     }
 
+    @Test func resolveBundleExecutableURLRebasesBundleExecutableWhenPossible() {
+        let bundleURL = URL(fileURLWithPath: "/System/Library/Frameworks/SafariServices.framework", isDirectory: true)
+        let resolvedExec = URL(fileURLWithPath: "/System/Cryptexes/OS/System/Library/Frameworks/SafariServices.framework/SafariServices")
+        let expectedRebased = bundleURL.appendingPathComponent("SafariServices")
+        let fake = FakeFileManager(existing: [expectedRebased.path])
+
+        let result = resolveBundleExecutableURL(
+            bundleURL,
+            fileManager: fake,
+            bundleExecutableURL: { _ in resolvedExec }
+        )
+        #expect(result?.path == expectedRebased.path)
+    }
+
     @Test func resolveBundleExecutableURLFallsBackToCanonicalPathForCacheOnlyBundles() {
         let bundleURL = URL(fileURLWithPath: "/tmp/Foo.framework", isDirectory: true)
         let fake = FakeFileManager(existing: [])
@@ -629,14 +280,46 @@ struct HeaderDumpCLITests {
         #expect(resolved?.path == "/tmp/Foo.framework/Foo")
     }
 
+    @Test func resolveBundleExecutableURLResolvesXPCAndAppExtensionCandidates() throws {
+        let dirs = try makeTemporaryTestDirectories()
+
+        let xpcURL = dirs.root.appendingPathComponent("Foo.xpc", isDirectory: true)
+        try FileManager.default.createDirectory(at: xpcURL, withIntermediateDirectories: true)
+        _ = FileManager.default.createFile(atPath: xpcURL.appendingPathComponent("Foo").path, contents: Data())
+
+        let xpcResolved = resolveBundleExecutableURL(
+            xpcURL,
+            fileManager: FileManager.default,
+            bundleExecutableURL: { _ in nil }
+        )
+        #expect(xpcResolved?.path == xpcURL.appendingPathComponent("Foo").path)
+
+        let appexURL = dirs.root.appendingPathComponent("Bar.appex", isDirectory: true)
+        try FileManager.default.createDirectory(at: appexURL, withIntermediateDirectories: true)
+        _ = FileManager.default.createFile(atPath: appexURL.appendingPathComponent("Bar").path, contents: Data())
+
+        let appexResolved = resolveBundleExecutableURL(
+            appexURL,
+            fileManager: FileManager.default,
+            bundleExecutableURL: { _ in nil }
+        )
+        #expect(appexResolved?.path == appexURL.appendingPathComponent("Bar").path)
+    }
+}
+
+@Suite
+struct HeaderDumpObjCHeaderNameTests {
+    @Test func isSaneObjCTypeNameRejectsReplacementAndControl() {
+        #expect(isSaneObjCTypeName("ASAuthorization") == true)
+        #expect(isSaneObjCTypeName("") == false)
+        #expect(isSaneObjCTypeName("Bad\u{000C}") == false)
+        #expect(isSaneObjCTypeName("\u{FFFD}") == false)
+    }
+
     @Test func resolveObjCHeaderEntriesLeavesNonCollidingNamesUnchanged() {
         let options = DumpOptions(outputDir: URL(fileURLWithPath: "/tmp/out"))
         let entries = [
-            ObjCHeaderEntry(
-                symbolKind: .class,
-                baseName: "FooHeader",
-                headerString: "@interface FooHeader\n@end\n"
-            )
+            ObjCHeaderEntry(symbolKind: .class, baseName: "FooHeader", headerString: "@interface FooHeader\n@end\n")
         ]
 
         let resolved = resolveObjCHeaderEntries(entries, options: options)
@@ -649,16 +332,8 @@ struct HeaderDumpCLITests {
     @Test func resolveObjCHeaderEntriesDisambiguatesCaseOnlyCollisions() {
         let options = DumpOptions(outputDir: URL(fileURLWithPath: "/tmp/out"))
         let entries = [
-            ObjCHeaderEntry(
-                symbolKind: .class,
-                baseName: "MTRBaseClusterWakeOnLAN",
-                headerString: "@interface MTRBaseClusterWakeOnLAN\n@end\n"
-            ),
-            ObjCHeaderEntry(
-                symbolKind: .class,
-                baseName: "MTRBaseClusterWakeOnLan",
-                headerString: "@interface MTRBaseClusterWakeOnLan\n@end\n"
-            )
+            ObjCHeaderEntry(symbolKind: .class, baseName: "MTRBaseClusterWakeOnLAN", headerString: "@interface A\n@end\n"),
+            ObjCHeaderEntry(symbolKind: .class, baseName: "MTRBaseClusterWakeOnLan", headerString: "@interface B\n@end\n")
         ]
 
         let resolved = resolveObjCHeaderEntries(entries, options: options)
@@ -673,16 +348,8 @@ struct HeaderDumpCLITests {
     @Test func resolveObjCHeaderEntriesDisambiguatesAcrossSymbolKinds() {
         let options = DumpOptions(outputDir: URL(fileURLWithPath: "/tmp/out"))
         let entries = [
-            ObjCHeaderEntry(
-                symbolKind: .class,
-                baseName: "SharedHeaderName",
-                headerString: "@interface SharedHeaderName\n@end\n"
-            ),
-            ObjCHeaderEntry(
-                symbolKind: .protocol,
-                baseName: "SharedHeaderName",
-                headerString: "@protocol SharedHeaderName\n@end\n"
-            )
+            ObjCHeaderEntry(symbolKind: .class, baseName: "SharedHeaderName", headerString: "@interface SharedHeaderName\n@end\n"),
+            ObjCHeaderEntry(symbolKind: .protocol, baseName: "SharedHeaderName", headerString: "@protocol SharedHeaderName\n@end\n")
         ]
 
         let resolved = resolveObjCHeaderEntries(entries, options: options)
@@ -698,16 +365,8 @@ struct HeaderDumpCLITests {
         let options = DumpOptions(outputDir: URL(fileURLWithPath: "/tmp/out"))
         let longBaseName = String(repeating: "VeryLongHeaderName", count: 20)
         let entries = [
-            ObjCHeaderEntry(
-                symbolKind: .class,
-                baseName: longBaseName,
-                headerString: "@interface LongHeader\n@end\n"
-            ),
-            ObjCHeaderEntry(
-                symbolKind: .protocol,
-                baseName: longBaseName,
-                headerString: "@protocol LongHeader\n@end\n"
-            )
+            ObjCHeaderEntry(symbolKind: .class, baseName: longBaseName, headerString: "@interface LongHeader\n@end\n"),
+            ObjCHeaderEntry(symbolKind: .protocol, baseName: longBaseName, headerString: "@protocol LongHeader\n@end\n")
         ]
 
         let resolved = resolveObjCHeaderEntries(entries, options: options)
@@ -720,21 +379,9 @@ struct HeaderDumpCLITests {
     @Test func resolveObjCHeaderEntriesIsStableAcrossRuns() {
         let options = DumpOptions(outputDir: URL(fileURLWithPath: "/tmp/out"))
         let entries = [
-            ObjCHeaderEntry(
-                symbolKind: .protocol,
-                baseName: "SharedHeaderName",
-                headerString: "@protocol SharedHeaderName\n@end\n"
-            ),
-            ObjCHeaderEntry(
-                symbolKind: .class,
-                baseName: "MTRBaseClusterWakeOnLan",
-                headerString: "@interface MTRBaseClusterWakeOnLan\n@end\n"
-            ),
-            ObjCHeaderEntry(
-                symbolKind: .class,
-                baseName: "MTRBaseClusterWakeOnLAN",
-                headerString: "@interface MTRBaseClusterWakeOnLAN\n@end\n"
-            )
+            ObjCHeaderEntry(symbolKind: .protocol, baseName: "SharedHeaderName", headerString: "@protocol SharedHeaderName\n@end\n"),
+            ObjCHeaderEntry(symbolKind: .class, baseName: "MTRBaseClusterWakeOnLan", headerString: "@interface MTRBaseClusterWakeOnLan\n@end\n"),
+            ObjCHeaderEntry(symbolKind: .class, baseName: "MTRBaseClusterWakeOnLAN", headerString: "@interface MTRBaseClusterWakeOnLAN\n@end\n")
         ]
 
         let first = resolveObjCHeaderEntries(entries, options: options)
@@ -742,102 +389,82 @@ struct HeaderDumpCLITests {
 
         #expect(first == second)
     }
+}
 
-#if os(macOS)
-    @Test func dumpSwiftSkipsExistingFile() async throws {
-        let tempDir = try makeTempDir()
-        let dylibURL = try buildSwiftFixture(in: tempDir, moduleName: "FixtureSkip")
-        let machO = try loadMachO(at: dylibURL)
-        let outputDir = tempDir.appendingPathComponent("out")
+@Suite
+struct HeaderDumpSwiftInterfaceTests {
+    @Test func dumpSwiftInterfaceSkipsExistingFileWithoutBuilding() async throws {
+        let dirs = try makeTemporaryTestDirectories()
+        let outputDir = dirs.root.appendingPathComponent("out", isDirectory: true)
         try FileManager.default.createDirectory(at: outputDir, withIntermediateDirectories: true)
-
-        let outputURL = outputDir.appendingPathComponent("\(dylibURL.lastPathComponent).swiftinterface")
+        let outputURL = outputDir.appendingPathComponent("FixtureSkip.swiftinterface")
         try "sentinel".write(to: outputURL, atomically: true, encoding: .utf8)
 
         var options = DumpOptions(outputDir: outputDir)
         options.skipExisting = true
+        var buildCount = 0
 
-        let builder = RecordingBuilder(output: "public struct Foo {}")
-        let factory = RecordingFactory(builder: builder)
-
-        try await dumpSwift(
-            machO: machO,
-            imagePath: dylibURL.path,
+        try await dumpSwiftInterface(
+            imagePath: "/tmp/FixtureSkip",
             outputDir: outputDir,
             options: options,
-            interfaceBuilderFactory: factory,
-            fileManager: FileManager.default
+            fileManager: FileManager.default,
+            buildInterface: {
+                buildCount += 1
+                return "public struct Foo {}"
+            }
         )
 
-        #expect(factory.makeCount == 0)
-        let contents = try String(contentsOf: outputURL, encoding: .utf8)
-        #expect(contents == "sentinel")
+        #expect(buildCount == 0)
+        #expect(try String(contentsOf: outputURL, encoding: .utf8) == "sentinel")
     }
 
-    @Test func dumpSwiftSkipsEmptyOutput() async throws {
-        let tempDir = try makeTempDir()
-        let dylibURL = try buildSwiftFixture(in: tempDir, moduleName: "FixtureEmpty")
-        let machO = try loadMachO(at: dylibURL)
-        let outputDir = tempDir.appendingPathComponent("out")
-
+    @Test func dumpSwiftInterfaceSkipsEmptyOutput() async throws {
+        let dirs = try makeTemporaryTestDirectories()
+        let outputDir = dirs.root.appendingPathComponent("out", isDirectory: true)
         var options = DumpOptions(outputDir: outputDir)
         options.skipExisting = false
 
-        let builder = RecordingBuilder(output: " \n")
-        let factory = RecordingFactory(builder: builder)
-
-        try await dumpSwift(
-            machO: machO,
-            imagePath: dylibURL.path,
+        try await dumpSwiftInterface(
+            imagePath: "/tmp/FixtureEmpty",
             outputDir: outputDir,
             options: options,
-            interfaceBuilderFactory: factory,
-            fileManager: FileManager.default
+            fileManager: FileManager.default,
+            buildInterface: { " \n" }
         )
 
-        let outputURL = outputDir.appendingPathComponent("\(dylibURL.lastPathComponent).swiftinterface")
+        let outputURL = outputDir.appendingPathComponent("FixtureEmpty.swiftinterface")
         #expect(FileManager.default.fileExists(atPath: outputURL.path) == false)
-        #expect(factory.makeCount == 1)
     }
 
-    @Test func dumpSwiftWritesOutput() async throws {
-        let tempDir = try makeTempDir()
-        let dylibURL = try buildSwiftFixture(in: tempDir, moduleName: "FixtureWrite")
-        let machO = try loadMachO(at: dylibURL)
-        let outputDir = tempDir.appendingPathComponent("out")
+    @Test func dumpSwiftInterfaceWritesOutput() async throws {
+        let dirs = try makeTemporaryTestDirectories()
+        let outputDir = dirs.root.appendingPathComponent("out", isDirectory: true)
+        let options = DumpOptions(outputDir: outputDir)
 
-        var options = DumpOptions(outputDir: outputDir)
-        options.skipExisting = false
-
-        let builder = RecordingBuilder(output: "public struct Foo {}")
-        let factory = RecordingFactory(builder: builder)
-
-        try await dumpSwift(
-            machO: machO,
-            imagePath: dylibURL.path,
+        try await dumpSwiftInterface(
+            imagePath: "/tmp/FixtureWrite",
             outputDir: outputDir,
             options: options,
-            interfaceBuilderFactory: factory,
-            fileManager: FileManager.default
+            fileManager: FileManager.default,
+            buildInterface: { "public struct Foo {}" }
         )
 
-        let outputURL = outputDir.appendingPathComponent("\(dylibURL.lastPathComponent).swiftinterface")
+        let outputURL = outputDir.appendingPathComponent("FixtureWrite.swiftinterface")
         #expect(FileManager.default.fileExists(atPath: outputURL.path) == true)
-        let contents = try String(contentsOf: outputURL, encoding: .utf8)
-        #expect(contents == "public struct Foo {}")
+        #expect(try String(contentsOf: outputURL, encoding: .utf8) == "public struct Foo {}")
     }
+}
 
-    @Test func endToEndWritesSwiftInterface() async throws {
-        let tempDir = try makeTempDir()
-        let dylibURL = try buildSwiftFixture(in: tempDir, moduleName: "FixtureE2E")
-        let outputDir = tempDir.appendingPathComponent("out")
-        let options = DumpOptions(outputDir: outputDir)
-        let parsed = ParsedArguments(options: options, inputPath: dylibURL.path)
-
-        try await run(parsed: parsed)
-
-        let outputURL = outputDir.appendingPathComponent("\(dylibURL.lastPathComponent).swiftinterface")
-        #expect(FileManager.default.fileExists(atPath: outputURL.path) == true)
+@Suite
+struct HeaderDumpRuntimeInspectorTests {
+    #if canImport(ObjectiveC) && canImport(HeaderDumpRuntimeObjC)
+    @Test func runtimeInspectorBuildsNSObjectSnapshot() {
+        var failedStage: NSString?
+        let snapshot = PHRuntimeObjCInspector.snapshot(for: NSObject.self, failedStage: &failedStage)
+        #expect(snapshot != nil)
+        #expect(failedStage == nil)
+        #expect(snapshot?.name == "NSObject")
     }
-#endif
+    #endif
 }

--- a/Tests/PrivateHeaderKitDumpTests/PrivateHeaderKitDumpTests.swift
+++ b/Tests/PrivateHeaderKitDumpTests/PrivateHeaderKitDumpTests.swift
@@ -3,39 +3,7 @@ import Testing
 
 @testable import PrivateHeaderKitDump
 import PrivateHeaderKitTooling
-
-private final class StubCommandRunner: CommandRunning {
-    private var captureOutputs: [String: String] = [:]
-
-    var capturedRunCaptureCommands: [[String]] = []
-    var capturedRunSimpleCommands: [[String]] = []
-    var capturedRunStreamingCommands: [[String]] = []
-
-    func setCaptureOutput(_ output: String, for command: [String]) {
-        captureOutputs[key(for: command)] = output
-    }
-
-    func runCapture(_ command: [String], env _: [String: String]?, cwd _: URL?) throws -> String {
-        capturedRunCaptureCommands.append(command)
-        guard let output = captureOutputs[key(for: command)] else {
-            throw ToolingError.message("unexpected runCapture command: \(command.joined(separator: " "))")
-        }
-        return output
-    }
-
-    func runSimple(_ command: [String], env _: [String: String]?, cwd _: URL?) throws {
-        capturedRunSimpleCommands.append(command)
-    }
-
-    func runStreaming(_ command: [String], env _: [String: String]?, cwd _: URL?) throws -> StreamingCommandResult {
-        capturedRunStreamingCommands.append(command)
-        return StreamingCommandResult(status: 0, wasKilled: false, lastLines: [])
-    }
-
-    private func key(for command: [String]) -> String {
-        command.joined(separator: "\u{1f}")
-    }
-}
+import PrivateHeaderKitTestSupport
 
 private func makeRuntimeInfo(
     version: String = "26.2",
@@ -65,19 +33,24 @@ private func makeDeviceInfo(name: String, udid: String, state: String) throws ->
     return try JSONDecoder().decode(DeviceInfo.self, from: Data(payload.utf8))
 }
 
-private func makeContext(outDir: URL, layout: String = "headers") -> Context {
+private func makeContext(
+    dirs: TestDirectories,
+    layout: String = "headers",
+    platform: TargetPlatform = .macos,
+    execMode: ExecMode = .host
+) throws -> Context {
     Context(
-        platform: .ios,
-        execMode: .host,
-        headerdumpBin: URL(fileURLWithPath: "/usr/bin/true"),
+        platform: platform,
+        execMode: execMode,
+        headerdumpBin: URL(fileURLWithPath: "/test/headerdump"),
         osVersionLabel: "26.3.1",
-        systemRoot: "/tmp/runtime",
-        runtimeId: nil,
+        systemRoot: dirs.runtimeRoot.path,
+        runtimeId: platform == .ios ? "com.apple.CoreSimulator.SimRuntime.iOS-26-2" : nil,
         runtimeBuild: nil,
-        macOSBuildVersion: nil,
-        device: nil,
-        outDir: outDir,
-        stageDir: outDir.appendingPathComponent(".tmp-stage", isDirectory: true),
+        macOSBuildVersion: platform == .macos ? "23C54" : nil,
+        device: execMode == .simulator ? try makeDeviceInfo(name: "iPhone 17", udid: "SIM-UDID", state: "Booted") : nil,
+        outDir: dirs.outDir,
+        stageDir: dirs.stageDir,
         skipExisting: true,
         useSharedCache: true,
         verbose: false,
@@ -88,72 +61,8 @@ private func makeContext(outDir: URL, layout: String = "headers") -> Context {
     )
 }
 
-private func makeFakeHeaderdumpScript(
-    at url: URL,
-    invocationLog: URL,
-    nestedFailureToggle: URL? = nil,
-    failingNestedSuffix: String? = nil
-) throws {
-    let toggleCheck: String
-    if let nestedFailureToggle, let failingNestedSuffix {
-        toggleCheck = """
-        if [[ -f "\(nestedFailureToggle.path)" && "$source_path" == *"\(failingNestedSuffix)" ]]; then
-          print -u2 -- "simulated failure for $source_path"
-          exit 1
-        fi
-        """
-    } else {
-        toggleCheck = ""
-    }
-
-    let script = """
-    #!/bin/zsh
-    set -euo pipefail
-
-    stage_dir=""
-    source_path=""
-    while [[ $# -gt 0 ]]; do
-      case "$1" in
-        -o)
-          stage_dir="$2"
-          shift 2
-          ;;
-        -r)
-          source_path="$2"
-          shift 2
-          ;;
-        -b|-h|-s|-R|-c|-D)
-          shift
-          ;;
-        *)
-          if [[ -z "$source_path" ]]; then
-            source_path="$1"
-          fi
-          shift
-          ;;
-      esac
-    done
-
-    print -r -- "$source_path" >> "\(invocationLog.path)"
-    \(toggleCheck)
-    relative_path="${source_path#*/System/Library/}"
-    output_dir="$stage_dir/System/Library/$relative_path/Headers"
-    mkdir -p "$output_dir"
-    print -r -- "// generated: $relative_path" > "$output_dir/Generated.h"
-    """
-
-    try script.write(to: url, atomically: true, encoding: .utf8)
-    try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: url.path)
-}
-
-private func invocationLines(at url: URL) throws -> [String] {
-    guard FileManager.default.fileExists(atPath: url.path) else { return [] }
-    return try String(contentsOf: url, encoding: .utf8)
-        .split(separator: "\n")
-        .map(String.init)
-}
-
-@Suite struct PrivateHeaderKitDumpTests {
+@Suite
+struct DumpSelectionTests {
     @Test func targetFrameworkOnlySelectsFrameworks() throws {
         var args = DumpArguments()
         args.targets = ["SafariShared"]
@@ -220,6 +129,33 @@ private func invocationLines(at url: URL) throws -> [String] {
         #expect(selection.usrLibDylibs == ["libobjc.A.dylib"])
     }
 
+    @Test func systemLibraryTargetRejectsDotDotComponents() {
+        let targets = [
+            "../Foo.bundle",
+            "PreferenceBundles/../Foo.bundle",
+            "./Foo.bundle",
+            "PreferenceBundles/./Foo.bundle",
+        ]
+        for target in targets {
+            var args = DumpArguments()
+            args.targets = [target]
+            do {
+                _ = try buildDumpSelection(args)
+                Issue.record("expected invalidArgument for \(target)")
+            } catch let error as ToolingError {
+                guard case .invalidArgument = error else {
+                    Issue.record("unexpected error: \(error)")
+                    continue
+                }
+            } catch {
+                Issue.record("unexpected error: \(error)")
+            }
+        }
+    }
+}
+
+@Suite
+struct DumpFallbackTests {
     @Test func launchFailureFromSimctlFallsBackToHost() {
         let error = ToolingError.processLaunchFailed(
             command: ["xcrun", "simctl", "spawn", "UDID", "/tmp/headerdump-sim"],
@@ -237,31 +173,249 @@ private func invocationLines(at url: URL) throws -> [String] {
 
         #expect(shouldFallbackToHost(error) == false)
     }
+}
 
-    @Test func systemLibraryTargetRejectsDotDotComponents() {
-        let targets = [
-            "../Foo.bundle",
-            "PreferenceBundles/../Foo.bundle",
-            "./Foo.bundle",
-            "PreferenceBundles/./Foo.bundle",
-        ]
-        for target in targets {
-            var args = DumpArguments()
-            args.targets = [target]
-            do {
-                _ = try buildDumpSelection(args)
-                #expect(Bool(false))
-            } catch let error as ToolingError {
-                guard case .invalidArgument = error else {
-                    #expect(Bool(false))
-                    continue
-                }
-            } catch {
-                #expect(Bool(false))
-            }
-        }
+@Suite
+struct DumpCompletionMarkerTests {
+    @Test func existingFrameworksRequireCompletionMarkerAndHeaderArtifact() throws {
+        let dirs = try makeTemporaryTestDirectories()
+        let ctx = try makeContext(dirs: dirs)
+
+        let completeDir = frameworkOutputDir(ctx: ctx, category: "Frameworks", frameworkName: "Complete.framework")
+        let partialDir = frameworkOutputDir(ctx: ctx, category: "Frameworks", frameworkName: "Partial.framework")
+        let markerOnlyDir = frameworkOutputDir(ctx: ctx, category: "Frameworks", frameworkName: "MarkerOnly.framework")
+        try FileManager.default.createDirectory(at: completeDir.appendingPathComponent("Headers", isDirectory: true), withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: partialDir.appendingPathComponent("Headers", isDirectory: true), withIntermediateDirectories: true)
+        try Data("ok".utf8).write(to: completeDir.appendingPathComponent("Headers/Complete.h"))
+        try Data("ok".utf8).write(to: partialDir.appendingPathComponent("Headers/Partial.h"))
+        try FileManager.default.createDirectory(at: markerOnlyDir, withIntermediateDirectories: true)
+        try writeCompletionMarker(in: completeDir, imagePath: "Frameworks/Complete.framework", layout: ctx.layout)
+        try writeCompletionMarker(in: markerOnlyDir, imagePath: "Frameworks/MarkerOnly.framework", layout: ctx.layout)
+
+        let existing = existingFrameworksInCategory(
+            ctx: ctx,
+            category: "Frameworks",
+            frameworks: Set(["complete.framework", "partial.framework", "markeronly.framework"])
+        )
+        #expect(existing == Set(["complete.framework"]))
     }
 
+    @Test func writeCompletionMarkerCreatesExpectedMetadataWithInjectedDate() throws {
+        let dirs = try makeTemporaryTestDirectories()
+        let fixedDate = Date(timeIntervalSince1970: 1_700_000_000)
+
+        try writeCompletionMarker(
+            in: dirs.outDir,
+            imagePath: "usr/lib/libobjc.A.dylib",
+            layout: "headers",
+            date: fixedDate
+        )
+
+        let data = try Data(contentsOf: completionMarkerURL(for: dirs.outDir))
+        let marker = try JSONDecoder().decode(CompletionMarker.self, from: data)
+        #expect(marker.tool == "privateheaderkit-dump")
+        #expect(marker.imagePath == "usr/lib/libobjc.A.dylib")
+        #expect(marker.layout == "headers")
+        #expect(marker.completedAt == "2023-11-14T22:13:20Z")
+        #expect(hasCompletionMarker(in: dirs.outDir))
+    }
+}
+
+@Suite
+struct DumpFrameworkOrchestrationTests {
+    @Test func splitFrameworkRerunsMarkerlessPartialAndSkipsCompletedFramework() throws {
+        let dirs = try makeTemporaryTestDirectories()
+        _ = try dirs.createFramework("Foo.framework")
+
+        let headerdump = HeaderdumpFixtureRunner()
+        let runner = RecordingCommandRunner()
+        runner.streamingHandler = headerdump.handle(command:env:cwd:)
+
+        var ctx = try makeContext(dirs: dirs, layout: "headers")
+        ctx.skipExisting = true
+
+        let outputDir = frameworkOutputDir(ctx: ctx, category: "Frameworks", frameworkName: "Foo.framework")
+        let staleHeader = outputDir.appendingPathComponent("Headers/PartialOnly.h", isDirectory: false)
+        try FileManager.default.createDirectory(at: staleHeader.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try Data("stale".utf8).write(to: staleHeader)
+
+        try FileOps.resetStageDir(ctx.stageDir)
+        let hadFailures = try dumpCategorySplit(category: "Frameworks", ctx: ctx, runner: runner)
+        #expect(hadFailures == false)
+        #expect(FileManager.default.fileExists(atPath: outputDir.appendingPathComponent("Headers/Generated.h").path))
+        #expect(!FileManager.default.fileExists(atPath: staleHeader.path))
+        #expect(hasCompletionMarker(in: outputDir))
+        #expect(headerdump.sourcePaths.count == 1)
+
+        let firstCommand = try #require(runner.streamingCommands.first)
+        #expect(firstCommand.command.contains("-R"))
+        #expect(firstCommand.command.contains("-c"))
+        #expect(firstCommand.env == nil)
+
+        try FileOps.resetStageDir(ctx.stageDir)
+        let hadFailuresOnSecondRun = try dumpCategorySplit(category: "Frameworks", ctx: ctx, runner: runner)
+        #expect(hadFailuresOnSecondRun == false)
+        #expect(headerdump.sourcePaths.count == 1)
+    }
+
+    @Test func splitFrameworkSkipsMarkerUntilNestedFailureIsRecovered() throws {
+        let dirs = try makeTemporaryTestDirectories()
+        _ = try dirs.createFramework("Foo.framework")
+            .appendingPathComponent("XPCServices/Bad.xpc", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: dirs.runtimeRoot.appendingPathComponent("System/Library/Frameworks/Foo.framework/XPCServices/Bad.xpc", isDirectory: true),
+            withIntermediateDirectories: true
+        )
+
+        let headerdump = HeaderdumpFixtureRunner(failingSourceSuffixes: ["XPCServices/Bad.xpc"])
+        let runner = RecordingCommandRunner()
+        runner.streamingHandler = headerdump.handle(command:env:cwd:)
+
+        var ctx = try makeContext(dirs: dirs, layout: "headers")
+        ctx.nestedEnabled = true
+
+        let outputDir = frameworkOutputDir(ctx: ctx, category: "Frameworks", frameworkName: "Foo.framework")
+
+        try FileOps.resetStageDir(ctx.stageDir)
+        let firstHadFailures = try dumpCategorySplit(category: "Frameworks", ctx: ctx, runner: runner)
+        #expect(firstHadFailures == true)
+        #expect(!hasCompletionMarker(in: outputDir))
+        let failuresText = try String(contentsOf: dirs.outDir.appendingPathComponent("_failures.txt"), encoding: .utf8)
+        #expect(failuresText.contains("Frameworks/Foo.framework/XPCServices/Bad.xpc"))
+        #expect(headerdump.sourcePaths.count == 2)
+
+        headerdump.failingSourceSuffixes = []
+        try FileOps.resetStageDir(ctx.stageDir)
+        let secondHadFailures = try dumpCategorySplit(category: "Frameworks", ctx: ctx, runner: runner)
+        #expect(secondHadFailures == false)
+        #expect(hasCompletionMarker(in: outputDir))
+        #expect(FileManager.default.fileExists(atPath: outputDir.appendingPathComponent("Headers/Generated.h").path))
+        #expect(headerdump.sourcePaths.count == 4)
+    }
+
+    @Test func splitFrameworkSkipsCompletedAlternateLayoutWithoutRedump() throws {
+        let dirs = try makeTemporaryTestDirectories()
+        _ = try dirs.createFramework("Foo.framework")
+
+        let headerdump = HeaderdumpFixtureRunner()
+        let runner = RecordingCommandRunner()
+        runner.streamingHandler = headerdump.handle(command:env:cwd:)
+
+        var ctx = try makeContext(dirs: dirs, layout: "headers")
+        ctx.skipExisting = true
+
+        let alternateLayoutDir = dirs.outDir.appendingPathComponent("Frameworks/Foo.framework", isDirectory: true)
+        let normalizedDir = frameworkOutputDir(ctx: ctx, category: "Frameworks", frameworkName: "Foo.framework")
+        try FileManager.default.createDirectory(at: alternateLayoutDir.appendingPathComponent("Headers", isDirectory: true), withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: normalizedDir.appendingPathComponent("Headers", isDirectory: true), withIntermediateDirectories: true)
+        try Data("ok".utf8).write(to: alternateLayoutDir.appendingPathComponent("Headers/Generated.h"))
+        try Data("stale".utf8).write(to: normalizedDir.appendingPathComponent("Headers/Stale.h"))
+        try writeCompletionMarker(in: alternateLayoutDir, imagePath: "Frameworks/Foo.framework", layout: "bundle")
+
+        try FileOps.resetStageDir(ctx.stageDir)
+        let hadFailures = try dumpCategorySplit(category: "Frameworks", ctx: ctx, runner: runner)
+
+        #expect(hadFailures == false)
+        #expect(FileManager.default.fileExists(atPath: normalizedDir.appendingPathComponent("Headers/Generated.h").path))
+        #expect(!FileManager.default.fileExists(atPath: normalizedDir.appendingPathComponent("Headers/Stale.h").path))
+        #expect(hasCompletionMarker(in: normalizedDir))
+        #expect(headerdump.sourcePaths.isEmpty)
+    }
+}
+
+@Suite
+struct DumpSystemLibraryOrchestrationTests {
+    @Test func systemLibraryBundleLayoutRemovesStaleHeadersLayoutDirectory() throws {
+        let dirs = try makeTemporaryTestDirectories()
+        _ = try dirs.createSystemLibraryBundle("PreferenceBundles/Foo.bundle")
+
+        let headerdump = HeaderdumpFixtureRunner()
+        let runner = RecordingCommandRunner()
+        runner.streamingHandler = headerdump.handle(command:env:cwd:)
+
+        var ctx = try makeContext(dirs: dirs, layout: "bundle")
+        ctx.skipExisting = false
+
+        let staleHeadersLayoutDir = dirs.outDir.appendingPathComponent("SystemLibrary/PreferenceBundles/Foo", isDirectory: true)
+        try FileManager.default.createDirectory(at: staleHeadersLayoutDir.appendingPathComponent("Headers", isDirectory: true), withIntermediateDirectories: true)
+        try Data("stale".utf8).write(to: staleHeadersLayoutDir.appendingPathComponent("Headers/Old.h"))
+        try writeCompletionMarker(in: staleHeadersLayoutDir, imagePath: "SystemLibrary/PreferenceBundles/Foo.bundle", layout: "headers")
+
+        try FileOps.resetStageDir(ctx.stageDir)
+        let hadFailures = try dumpSystemLibraryItems(
+            ctx: ctx,
+            items: ["PreferenceBundles/Foo.bundle"],
+            runner: runner
+        )
+
+        let bundleOutputDir = systemLibraryOutputDir(ctx: ctx, relativePath: "PreferenceBundles/Foo.bundle")
+        #expect(hadFailures == false)
+        #expect(!FileManager.default.fileExists(atPath: staleHeadersLayoutDir.path))
+        #expect(FileManager.default.fileExists(atPath: bundleOutputDir.appendingPathComponent("Headers/Generated.h").path))
+        #expect(hasCompletionMarker(in: bundleOutputDir))
+        #expect(headerdump.sourcePaths.count == 1)
+    }
+
+    @Test func systemLibrarySkipsCompletedAlternateLayoutWithoutRedump() throws {
+        let dirs = try makeTemporaryTestDirectories()
+        _ = try dirs.createSystemLibraryBundle("PreferenceBundles/Foo.bundle")
+
+        let headerdump = HeaderdumpFixtureRunner()
+        let runner = RecordingCommandRunner()
+        runner.streamingHandler = headerdump.handle(command:env:cwd:)
+
+        var ctx = try makeContext(dirs: dirs, layout: "headers")
+        ctx.skipExisting = true
+
+        let alternateLayoutDir = dirs.outDir.appendingPathComponent("SystemLibrary/PreferenceBundles/Foo.bundle", isDirectory: true)
+        let normalizedDir = systemLibraryOutputDir(ctx: ctx, relativePath: "PreferenceBundles/Foo.bundle")
+        try FileManager.default.createDirectory(at: alternateLayoutDir.appendingPathComponent("Headers", isDirectory: true), withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: normalizedDir.appendingPathComponent("Headers", isDirectory: true), withIntermediateDirectories: true)
+        try Data("ok".utf8).write(to: alternateLayoutDir.appendingPathComponent("Headers/Generated.h"))
+        try Data("stale".utf8).write(to: normalizedDir.appendingPathComponent("Headers/Stale.h"))
+        try writeCompletionMarker(in: alternateLayoutDir, imagePath: "SystemLibrary/PreferenceBundles/Foo.bundle", layout: "bundle")
+
+        try FileOps.resetStageDir(ctx.stageDir)
+        let hadFailures = try dumpSystemLibraryItems(
+            ctx: ctx,
+            items: ["PreferenceBundles/Foo.bundle"],
+            runner: runner
+        )
+
+        #expect(hadFailures == false)
+        #expect(FileManager.default.fileExists(atPath: normalizedDir.appendingPathComponent("Headers/Generated.h").path))
+        #expect(!FileManager.default.fileExists(atPath: normalizedDir.appendingPathComponent("Headers/Stale.h").path))
+        #expect(hasCompletionMarker(in: normalizedDir))
+        #expect(headerdump.sourcePaths.isEmpty)
+    }
+
+    @Test func simulatorCommandUsesSimctlAndChildEnvironment() throws {
+        let dirs = try makeTemporaryTestDirectories()
+        let headerdump = HeaderdumpFixtureRunner()
+        let runner = RecordingCommandRunner()
+        runner.streamingHandler = headerdump.handle(command:env:cwd:)
+
+        var ctx = try makeContext(dirs: dirs, layout: "headers", platform: .ios, execMode: .simulator)
+        ctx.skipExisting = false
+
+        try FileOps.resetStageDir(ctx.stageDir)
+        let hadFailures = try dumpSystemLibraryItems(
+            ctx: ctx,
+            items: ["PreferenceBundles/Foo.bundle"],
+            runner: runner
+        )
+
+        let command = try #require(runner.streamingCommands.first)
+        #expect(hadFailures == false)
+        #expect(Array(command.command.prefix(4)) == ["xcrun", "simctl", "spawn", "SIM-UDID"])
+        #expect(command.command.contains("/System/Library/PreferenceBundles/Foo.bundle"))
+        #expect(command.env?["SIMCTL_CHILD_PH_RUNTIME_ROOT"] == dirs.runtimeRoot.path)
+        #expect(command.env?["SIMCTL_CHILD_DYLD_ROOT_PATH"] == dirs.runtimeRoot.path)
+    }
+}
+
+@Suite
+struct DumpSimctlDeviceSelectionTests {
     @Test func pickDefaultDevicePrefersShutdownDevice() throws {
         let devices = [
             try makeDeviceInfo(name: "iPhone 17", udid: "BOOTED", state: "Booted"),
@@ -289,11 +443,11 @@ private func invocationLines(at url: URL) throws -> [String] {
             try makeDeviceInfo(name: "iPhone 17", udid: "BOOTED", state: "Booted"),
             try makeDeviceInfo(name: cloneName, udid: "CLONE", state: "Shutdown"),
         ]
-        let runner = StubCommandRunner()
+        let runner = RecordingCommandRunner()
 
         let picked = try Simctl.resolveDefaultDevice(runtime: runtime, devices: devices, runner: runner)
         #expect(picked.udid == "CLONE")
-        #expect(runner.capturedRunCaptureCommands.isEmpty)
+        #expect(runner.captureCommands.isEmpty)
     }
 
     @Test func resolveDefaultDeviceSkipsCloneForBootedBaseDevice() throws {
@@ -301,11 +455,11 @@ private func invocationLines(at url: URL) throws -> [String] {
         let devices = [
             try makeDeviceInfo(name: "iPhone 17", udid: "BOOTED", state: "Booted")
         ]
-        let runner = StubCommandRunner()
+        let runner = RecordingCommandRunner()
 
         let picked = try Simctl.resolveDefaultDevice(runtime: runtime, devices: devices, runner: runner)
         #expect(picked.udid == "BOOTED")
-        #expect(runner.capturedRunCaptureCommands.isEmpty)
+        #expect(runner.captureCommands.isEmpty)
     }
 
     @Test func resolveDefaultDeviceClonesFromShutdownBaseDevice() throws {
@@ -314,304 +468,12 @@ private func invocationLines(at url: URL) throws -> [String] {
             try makeDeviceInfo(name: "iPhone 17", udid: "SHUTDOWN", state: "Shutdown")
         ]
         let cloneName = Simctl.defaultCloneName(version: runtime.version)
-        let runner = StubCommandRunner()
+        let runner = RecordingCommandRunner()
         runner.setCaptureOutput("CLONED-UDID\n", for: ["xcrun", "simctl", "clone", "SHUTDOWN", cloneName])
 
         let picked = try Simctl.resolveDefaultDevice(runtime: runtime, devices: devices, runner: runner)
         #expect(picked.name == cloneName)
         #expect(picked.udid == "CLONED-UDID")
-        #expect(runner.capturedRunCaptureCommands.count == 1)
-    }
-
-    @Test func existingFrameworksRequireCompletionMarker() throws {
-        let outDir = FileManager.default.temporaryDirectory
-            .appendingPathComponent(UUID().uuidString, isDirectory: true)
-        try FileManager.default.createDirectory(at: outDir, withIntermediateDirectories: true)
-        let ctx = makeContext(outDir: outDir)
-
-        let completeDir = frameworkOutputDir(ctx: ctx, category: "Frameworks", frameworkName: "Complete.framework")
-        let partialDir = frameworkOutputDir(ctx: ctx, category: "Frameworks", frameworkName: "Partial.framework")
-        let markerOnlyDir = frameworkOutputDir(ctx: ctx, category: "Frameworks", frameworkName: "MarkerOnly.framework")
-        try FileManager.default.createDirectory(at: completeDir.appendingPathComponent("Headers", isDirectory: true), withIntermediateDirectories: true)
-        try FileManager.default.createDirectory(at: partialDir.appendingPathComponent("Headers", isDirectory: true), withIntermediateDirectories: true)
-        try Data("ok".utf8).write(to: completeDir.appendingPathComponent("Headers/Complete.h"))
-        try Data("ok".utf8).write(to: partialDir.appendingPathComponent("Headers/Partial.h"))
-        try FileManager.default.createDirectory(at: markerOnlyDir, withIntermediateDirectories: true)
-        try writeCompletionMarker(in: completeDir, imagePath: "Frameworks/Complete.framework", layout: ctx.layout)
-        try writeCompletionMarker(in: markerOnlyDir, imagePath: "Frameworks/MarkerOnly.framework", layout: ctx.layout)
-
-        let existing = existingFrameworksInCategory(
-            ctx: ctx,
-            category: "Frameworks",
-            frameworks: Set(["complete.framework", "partial.framework", "markeronly.framework"])
-        )
-        #expect(existing == Set(["complete.framework"]))
-    }
-
-    @Test func writeCompletionMarkerCreatesExpectedMetadata() throws {
-        let outDir = FileManager.default.temporaryDirectory
-            .appendingPathComponent(UUID().uuidString, isDirectory: true)
-        try FileManager.default.createDirectory(at: outDir, withIntermediateDirectories: true)
-
-        try writeCompletionMarker(
-            in: outDir,
-            imagePath: "usr/lib/libobjc.A.dylib",
-            layout: "headers"
-        )
-
-        let data = try Data(contentsOf: completionMarkerURL(for: outDir))
-        let marker = try JSONDecoder().decode(CompletionMarker.self, from: data)
-        #expect(marker.tool == "privateheaderkit-dump")
-        #expect(marker.imagePath == "usr/lib/libobjc.A.dylib")
-        #expect(marker.layout == "headers")
-        #expect(!marker.completedAt.isEmpty)
-        #expect(hasCompletionMarker(in: outDir))
-    }
-
-    @Test func splitFrameworkRerunsMarkerlessPartialAndSkipsCompletedFramework() throws {
-        let tempDir = FileManager.default.temporaryDirectory
-            .appendingPathComponent(UUID().uuidString, isDirectory: true)
-        let runtimeRoot = tempDir.appendingPathComponent("RuntimeRoot", isDirectory: true)
-        let outDir = tempDir.appendingPathComponent("Out", isDirectory: true)
-        let frameworkDir = runtimeRoot
-            .appendingPathComponent("System/Library/Frameworks/Foo.framework", isDirectory: true)
-        let invocationLog = tempDir.appendingPathComponent("invocations.log", isDirectory: false)
-        let scriptURL = tempDir.appendingPathComponent("fake-headerdump.zsh", isDirectory: false)
-
-        try FileManager.default.createDirectory(at: frameworkDir, withIntermediateDirectories: true)
-        try FileManager.default.createDirectory(at: outDir, withIntermediateDirectories: true)
-        try makeFakeHeaderdumpScript(at: scriptURL, invocationLog: invocationLog)
-
-        var ctx = makeContext(outDir: outDir)
-        ctx.platform = .macos
-        ctx.systemRoot = runtimeRoot.path
-        ctx.headerdumpBin = scriptURL
-        ctx.stageDir = tempDir.appendingPathComponent(".tmp-stage", isDirectory: true)
-        ctx.categories = ["Frameworks"]
-        ctx.skipExisting = true
-        ctx.layout = "headers"
-
-        let outputDir = frameworkOutputDir(ctx: ctx, category: "Frameworks", frameworkName: "Foo.framework")
-        let staleHeader = outputDir.appendingPathComponent("Headers/PartialOnly.h", isDirectory: false)
-        try FileManager.default.createDirectory(at: staleHeader.deletingLastPathComponent(), withIntermediateDirectories: true)
-        try Data("stale".utf8).write(to: staleHeader)
-
-        try FileOps.resetStageDir(ctx.stageDir)
-        let hadFailures = try dumpCategorySplit(category: "Frameworks", ctx: ctx, runner: StubCommandRunner())
-        #expect(hadFailures == false)
-        #expect(FileManager.default.fileExists(atPath: outputDir.appendingPathComponent("Headers/Generated.h").path))
-        #expect(!FileManager.default.fileExists(atPath: staleHeader.path))
-        #expect(hasCompletionMarker(in: outputDir))
-        #expect(try invocationLines(at: invocationLog).count == 1)
-
-        try FileOps.resetStageDir(ctx.stageDir)
-        let hadFailuresOnSecondRun = try dumpCategorySplit(category: "Frameworks", ctx: ctx, runner: StubCommandRunner())
-        #expect(hadFailuresOnSecondRun == false)
-        #expect(try invocationLines(at: invocationLog).count == 1)
-    }
-
-    @Test func splitFrameworkSkipsMarkerUntilNestedFailureIsRecovered() throws {
-        let tempDir = FileManager.default.temporaryDirectory
-            .appendingPathComponent(UUID().uuidString, isDirectory: true)
-        let runtimeRoot = tempDir.appendingPathComponent("RuntimeRoot", isDirectory: true)
-        let outDir = tempDir.appendingPathComponent("Out", isDirectory: true)
-        let frameworkDir = runtimeRoot
-            .appendingPathComponent("System/Library/Frameworks/Foo.framework/XPCServices/Bad.xpc", isDirectory: true)
-        let invocationLog = tempDir.appendingPathComponent("invocations.log", isDirectory: false)
-        let failureToggle = tempDir.appendingPathComponent("fail-nested", isDirectory: false)
-        let scriptURL = tempDir.appendingPathComponent("fake-headerdump.zsh", isDirectory: false)
-
-        try FileManager.default.createDirectory(at: frameworkDir, withIntermediateDirectories: true)
-        try FileManager.default.createDirectory(at: outDir, withIntermediateDirectories: true)
-        try Data().write(to: failureToggle)
-        try makeFakeHeaderdumpScript(
-            at: scriptURL,
-            invocationLog: invocationLog,
-            nestedFailureToggle: failureToggle,
-            failingNestedSuffix: "XPCServices/Bad.xpc"
-        )
-
-        var ctx = makeContext(outDir: outDir)
-        ctx.platform = .macos
-        ctx.systemRoot = runtimeRoot.path
-        ctx.headerdumpBin = scriptURL
-        ctx.stageDir = tempDir.appendingPathComponent(".tmp-stage", isDirectory: true)
-        ctx.categories = ["Frameworks"]
-        ctx.skipExisting = true
-        ctx.layout = "headers"
-        ctx.nestedEnabled = true
-
-        let outputDir = frameworkOutputDir(ctx: ctx, category: "Frameworks", frameworkName: "Foo.framework")
-
-        try FileOps.resetStageDir(ctx.stageDir)
-        let firstHadFailures = try dumpCategorySplit(category: "Frameworks", ctx: ctx, runner: StubCommandRunner())
-        #expect(firstHadFailures == true)
-        #expect(!hasCompletionMarker(in: outputDir))
-        let failuresPath = outDir.appendingPathComponent("_failures.txt", isDirectory: false)
-        let failuresText = try String(contentsOf: failuresPath, encoding: .utf8)
-        #expect(failuresText.contains("Frameworks/Foo.framework/XPCServices/Bad.xpc"))
-        #expect(try invocationLines(at: invocationLog).count == 2)
-
-        try FileManager.default.removeItem(at: failureToggle)
-        try FileOps.resetStageDir(ctx.stageDir)
-        let secondHadFailures = try dumpCategorySplit(category: "Frameworks", ctx: ctx, runner: StubCommandRunner())
-        #expect(secondHadFailures == false)
-        #expect(hasCompletionMarker(in: outputDir))
-        #expect(FileManager.default.fileExists(atPath: outputDir.appendingPathComponent("Headers/Generated.h").path))
-        #expect(try invocationLines(at: invocationLog).count == 4)
-    }
-
-    @Test func systemLibraryBundleLayoutRemovesStaleHeadersLayoutDirectory() throws {
-        let tempDir = FileManager.default.temporaryDirectory
-            .appendingPathComponent(UUID().uuidString, isDirectory: true)
-        let runtimeRoot = tempDir.appendingPathComponent("RuntimeRoot", isDirectory: true)
-        let outDir = tempDir.appendingPathComponent("Out", isDirectory: true)
-        let bundleDir = runtimeRoot
-            .appendingPathComponent("System/Library/PreferenceBundles/Foo.bundle", isDirectory: true)
-        let invocationLog = tempDir.appendingPathComponent("invocations.log", isDirectory: false)
-        let scriptURL = tempDir.appendingPathComponent("fake-headerdump.zsh", isDirectory: false)
-
-        try FileManager.default.createDirectory(at: bundleDir, withIntermediateDirectories: true)
-        try FileManager.default.createDirectory(at: outDir, withIntermediateDirectories: true)
-        try makeFakeHeaderdumpScript(at: scriptURL, invocationLog: invocationLog)
-
-        var ctx = makeContext(outDir: outDir, layout: "bundle")
-        ctx.platform = .macos
-        ctx.systemRoot = runtimeRoot.path
-        ctx.headerdumpBin = scriptURL
-        ctx.stageDir = tempDir.appendingPathComponent(".tmp-stage", isDirectory: true)
-        ctx.skipExisting = false
-
-        let staleHeadersLayoutDir = outDir
-            .appendingPathComponent("SystemLibrary/PreferenceBundles/Foo", isDirectory: true)
-        try FileManager.default.createDirectory(
-            at: staleHeadersLayoutDir.appendingPathComponent("Headers", isDirectory: true),
-            withIntermediateDirectories: true
-        )
-        try Data("stale".utf8).write(to: staleHeadersLayoutDir.appendingPathComponent("Headers/Old.h"))
-        try writeCompletionMarker(
-            in: staleHeadersLayoutDir,
-            imagePath: "SystemLibrary/PreferenceBundles/Foo.bundle",
-            layout: "headers"
-        )
-
-        try FileOps.resetStageDir(ctx.stageDir)
-        let hadFailures = try dumpSystemLibraryItems(
-            ctx: ctx,
-            items: ["PreferenceBundles/Foo.bundle"],
-            runner: StubCommandRunner()
-        )
-
-        let bundleOutputDir = systemLibraryOutputDir(ctx: ctx, relativePath: "PreferenceBundles/Foo.bundle")
-        #expect(hadFailures == false)
-        #expect(!FileManager.default.fileExists(atPath: staleHeadersLayoutDir.path))
-        #expect(FileManager.default.fileExists(atPath: bundleOutputDir.appendingPathComponent("Headers/Generated.h").path))
-        #expect(hasCompletionMarker(in: bundleOutputDir))
-        #expect(try invocationLines(at: invocationLog).count == 1)
-    }
-
-    @Test func splitFrameworkSkipsCompletedAlternateLayoutWithoutRedump() throws {
-        let tempDir = FileManager.default.temporaryDirectory
-            .appendingPathComponent(UUID().uuidString, isDirectory: true)
-        let runtimeRoot = tempDir.appendingPathComponent("RuntimeRoot", isDirectory: true)
-        let outDir = tempDir.appendingPathComponent("Out", isDirectory: true)
-        let frameworkDir = runtimeRoot
-            .appendingPathComponent("System/Library/Frameworks/Foo.framework", isDirectory: true)
-        let invocationLog = tempDir.appendingPathComponent("invocations.log", isDirectory: false)
-        let scriptURL = tempDir.appendingPathComponent("fake-headerdump.zsh", isDirectory: false)
-
-        try FileManager.default.createDirectory(at: frameworkDir, withIntermediateDirectories: true)
-        try FileManager.default.createDirectory(at: outDir, withIntermediateDirectories: true)
-        try makeFakeHeaderdumpScript(at: scriptURL, invocationLog: invocationLog)
-
-        var ctx = makeContext(outDir: outDir, layout: "headers")
-        ctx.platform = .macos
-        ctx.systemRoot = runtimeRoot.path
-        ctx.headerdumpBin = scriptURL
-        ctx.stageDir = tempDir.appendingPathComponent(".tmp-stage", isDirectory: true)
-        ctx.categories = ["Frameworks"]
-        ctx.skipExisting = true
-
-        let alternateLayoutDir = outDir
-            .appendingPathComponent("Frameworks/Foo.framework", isDirectory: true)
-        let normalizedDir = frameworkOutputDir(ctx: ctx, category: "Frameworks", frameworkName: "Foo.framework")
-        try FileManager.default.createDirectory(
-            at: alternateLayoutDir.appendingPathComponent("Headers", isDirectory: true),
-            withIntermediateDirectories: true
-        )
-        try FileManager.default.createDirectory(
-            at: normalizedDir.appendingPathComponent("Headers", isDirectory: true),
-            withIntermediateDirectories: true
-        )
-        try Data("ok".utf8).write(to: alternateLayoutDir.appendingPathComponent("Headers/Generated.h"))
-        try Data("stale".utf8).write(to: normalizedDir.appendingPathComponent("Headers/Stale.h"))
-        try writeCompletionMarker(
-            in: alternateLayoutDir,
-            imagePath: "Frameworks/Foo.framework",
-            layout: "bundle"
-        )
-
-        try FileOps.resetStageDir(ctx.stageDir)
-        let hadFailures = try dumpCategorySplit(category: "Frameworks", ctx: ctx, runner: StubCommandRunner())
-
-        #expect(hadFailures == false)
-        #expect(FileManager.default.fileExists(atPath: normalizedDir.appendingPathComponent("Headers/Generated.h").path))
-        #expect(!FileManager.default.fileExists(atPath: normalizedDir.appendingPathComponent("Headers/Stale.h").path))
-        #expect(hasCompletionMarker(in: normalizedDir))
-        #expect(try invocationLines(at: invocationLog).isEmpty)
-    }
-
-    @Test func systemLibrarySkipsCompletedAlternateLayoutWithoutRedump() throws {
-        let tempDir = FileManager.default.temporaryDirectory
-            .appendingPathComponent(UUID().uuidString, isDirectory: true)
-        let runtimeRoot = tempDir.appendingPathComponent("RuntimeRoot", isDirectory: true)
-        let outDir = tempDir.appendingPathComponent("Out", isDirectory: true)
-        let bundleDir = runtimeRoot
-            .appendingPathComponent("System/Library/PreferenceBundles/Foo.bundle", isDirectory: true)
-        let invocationLog = tempDir.appendingPathComponent("invocations.log", isDirectory: false)
-        let scriptURL = tempDir.appendingPathComponent("fake-headerdump.zsh", isDirectory: false)
-
-        try FileManager.default.createDirectory(at: bundleDir, withIntermediateDirectories: true)
-        try FileManager.default.createDirectory(at: outDir, withIntermediateDirectories: true)
-        try makeFakeHeaderdumpScript(at: scriptURL, invocationLog: invocationLog)
-
-        var ctx = makeContext(outDir: outDir, layout: "headers")
-        ctx.platform = .macos
-        ctx.systemRoot = runtimeRoot.path
-        ctx.headerdumpBin = scriptURL
-        ctx.stageDir = tempDir.appendingPathComponent(".tmp-stage", isDirectory: true)
-        ctx.skipExisting = true
-
-        let alternateLayoutDir = outDir
-            .appendingPathComponent("SystemLibrary/PreferenceBundles/Foo.bundle", isDirectory: true)
-        let normalizedDir = systemLibraryOutputDir(ctx: ctx, relativePath: "PreferenceBundles/Foo.bundle")
-        try FileManager.default.createDirectory(
-            at: alternateLayoutDir.appendingPathComponent("Headers", isDirectory: true),
-            withIntermediateDirectories: true
-        )
-        try FileManager.default.createDirectory(
-            at: normalizedDir.appendingPathComponent("Headers", isDirectory: true),
-            withIntermediateDirectories: true
-        )
-        try Data("ok".utf8).write(to: alternateLayoutDir.appendingPathComponent("Headers/Generated.h"))
-        try Data("stale".utf8).write(to: normalizedDir.appendingPathComponent("Headers/Stale.h"))
-        try writeCompletionMarker(
-            in: alternateLayoutDir,
-            imagePath: "SystemLibrary/PreferenceBundles/Foo.bundle",
-            layout: "bundle"
-        )
-
-        try FileOps.resetStageDir(ctx.stageDir)
-        let hadFailures = try dumpSystemLibraryItems(
-            ctx: ctx,
-            items: ["PreferenceBundles/Foo.bundle"],
-            runner: StubCommandRunner()
-        )
-
-        #expect(hadFailures == false)
-        #expect(FileManager.default.fileExists(atPath: normalizedDir.appendingPathComponent("Headers/Generated.h").path))
-        #expect(!FileManager.default.fileExists(atPath: normalizedDir.appendingPathComponent("Headers/Stale.h").path))
-        #expect(hasCompletionMarker(in: normalizedDir))
-        #expect(try invocationLines(at: invocationLog).isEmpty)
+        #expect(runner.captureCommands.count == 1)
     }
 }

--- a/Tests/PrivateHeaderKitInstallTests/PrivateHeaderKitInstallTests.swift
+++ b/Tests/PrivateHeaderKitInstallTests/PrivateHeaderKitInstallTests.swift
@@ -1,0 +1,137 @@
+import Foundation
+import Testing
+
+@testable import PrivateHeaderKitInstall
+import PrivateHeaderKitTestSupport
+
+@Suite
+struct InstallOptionTests {
+    @Test func parseOptionsUsesEnvironmentDefaultsAndCliOverrides() throws {
+        let envOptions = try parseOptions(["privateheaderkit-install"], environment: [
+            "PREFIX": "/env/prefix",
+            "BINDIR": "/env/bin",
+        ])
+        #expect(envOptions.prefix == "/env/prefix")
+        #expect(envOptions.bindir == "/env/bin")
+        #expect(envOptions.dryRun == false)
+
+        let cliOptions = try parseOptions(
+            ["privateheaderkit-install", "--prefix", "/cli/prefix", "--dry-run"],
+            environment: ["BINDIR": "/env/bin"]
+        )
+        #expect(cliOptions.prefix == "/cli/prefix")
+        #expect(cliOptions.bindir == nil)
+        #expect(cliOptions.dryRun == true)
+
+        let bindirOptions = try parseOptions(
+            ["privateheaderkit-install", "--prefix", "/cli/prefix", "--bindir", "/cli/bin"],
+            environment: [:]
+        )
+        #expect(bindirOptions.prefix == "/cli/prefix")
+        #expect(bindirOptions.bindir == "/cli/bin")
+    }
+
+    @Test func parseOptionsRejectsUnknownOptions() {
+        do {
+            _ = try parseOptions(["privateheaderkit-install", "--wat"], environment: [:])
+            Issue.record("expected parse failure")
+        } catch let error as InstallError {
+            #expect(error.description == "unknown option: --wat")
+        } catch {
+            Issue.record("unexpected error: \(error)")
+        }
+    }
+
+    @Test func resolveBinDirPrefersBindirOverPrefix() {
+        #expect(resolveBinDir(prefix: "/prefix", bindir: "/custom/bin").path == "/custom/bin")
+        #expect(resolveBinDir(prefix: "/prefix", bindir: nil).path == "/prefix/bin")
+    }
+}
+
+@Suite
+struct InstallCommandResolutionTests {
+    @Test func repositoryRootFindsBuildAncestor() {
+        let executable = URL(fileURLWithPath: "/repo/.build/arm64-apple-macosx/release/privateheaderkit-install")
+        #expect(repositoryRoot(from: executable)?.path == "/repo")
+    }
+
+    @Test func looksLikePrivateHeaderKitRepoRequiresBothMarkers() throws {
+        let dirs = try makeTemporaryTestDirectories()
+        let repoRoot = dirs.root.appendingPathComponent("Repo", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: repoRoot.appendingPathComponent("Sources/HeaderDumpCore", isDirectory: true),
+            withIntermediateDirectories: true
+        )
+        try Data().write(to: repoRoot.appendingPathComponent("Sources/HeaderDumpCore/HeaderDumpMain.swift"))
+        #expect(looksLikePrivateHeaderKitRepo(repoRoot, fileManager: .default) == false)
+
+        try FileManager.default.createDirectory(
+            at: repoRoot.appendingPathComponent("Sources/HeaderDumpCLI", isDirectory: true),
+            withIntermediateDirectories: true
+        )
+        try Data().write(to: repoRoot.appendingPathComponent("Sources/HeaderDumpCLI/HeaderDumpMain.swift"))
+        #expect(looksLikePrivateHeaderKitRepo(repoRoot, fileManager: .default) == true)
+    }
+
+    @Test func buildProductsRecordsReleaseBuildCommands() throws {
+        let dirs = try makeTemporaryTestDirectories()
+        let runner = RecordingCommandRunner()
+
+        try buildProducts(["privateheaderkit-dump", "headerdump"], in: dirs.root, runner: runner)
+
+        #expect(runner.simpleCommands.map(\.command) == [
+            ["swift", "build", "-c", "release", "--product", "privateheaderkit-dump"],
+            ["swift", "build", "-c", "release", "--product", "headerdump"],
+        ])
+        #expect(runner.simpleCommands.allSatisfy { $0.cwd == dirs.root })
+    }
+
+    @Test func resolveSwiftBinDirUsesLastNonEmptyOutputLine() throws {
+        let dirs = try makeTemporaryTestDirectories()
+        let runner = RecordingCommandRunner()
+        runner.setCaptureOutput(
+            "\nignored\n\(dirs.root.appendingPathComponent(".build/release").path)\n",
+            for: ["swift", "build", "-c", "release", "--show-bin-path"]
+        )
+
+        let binDir = resolveSwiftBinDir(repoRoot: dirs.root, runner: runner)
+
+        #expect(binDir?.path == dirs.root.appendingPathComponent(".build/release").path)
+    }
+
+    @Test func resolveXcodeSchemePrefersConfiguredSchemeWhenPresent() throws {
+        let dirs = try makeTemporaryTestDirectories()
+        let runner = RecordingCommandRunner()
+        runner.setCaptureOutput(
+            """
+            preface
+            {"project":{"schemes":["PrivateHeaderKit","CustomScheme"]}}
+            tail
+            """,
+            for: ["xcodebuild", "-list", "-json"]
+        )
+
+        let scheme = try resolveXcodeScheme(
+            repoRoot: dirs.root,
+            runner: runner,
+            environment: ["PH_XCODE_SCHEME": "CustomScheme"]
+        )
+
+        #expect(scheme == "CustomScheme")
+    }
+
+    @Test func resolveXcodeSchemePrefersHeaderdumpScheme() throws {
+        let dirs = try makeTemporaryTestDirectories()
+        let runner = RecordingCommandRunner()
+        runner.setCaptureOutput(
+            """
+            {"workspace":{"schemes":["Other","headerdump"]}}
+            """,
+            for: ["xcodebuild", "-list", "-json"]
+        )
+
+        let scheme = try resolveXcodeScheme(repoRoot: dirs.root, runner: runner, environment: [:])
+
+        #expect(scheme == "headerdump")
+    }
+}

--- a/Tests/PrivateHeaderKitTestSupport/TestSupport.swift
+++ b/Tests/PrivateHeaderKitTestSupport/TestSupport.swift
@@ -1,0 +1,181 @@
+import Foundation
+import PrivateHeaderKitTooling
+
+public struct RecordedCommand: Equatable {
+    public let command: [String]
+    public let env: [String: String]?
+    public let cwd: URL?
+
+    public init(command: [String], env: [String: String]?, cwd: URL?) {
+        self.command = command
+        self.env = env
+        self.cwd = cwd
+    }
+}
+
+public final class RecordingCommandRunner: CommandRunning {
+    public private(set) var captureCommands: [RecordedCommand] = []
+    public private(set) var simpleCommands: [RecordedCommand] = []
+    public private(set) var streamingCommands: [RecordedCommand] = []
+
+    public var captureOutputs: [String: String] = [:]
+    public var simpleHandler: (([String], [String: String]?, URL?) throws -> Void)?
+    public var streamingHandler: (([String], [String: String]?, URL?) throws -> StreamingCommandResult)?
+
+    public init() {}
+
+    public func setCaptureOutput(_ output: String, for command: [String]) {
+        captureOutputs[key(for: command)] = output
+    }
+
+    public func runCapture(_ command: [String], env: [String: String]?, cwd: URL?) throws -> String {
+        captureCommands.append(RecordedCommand(command: command, env: env, cwd: cwd))
+        guard let output = captureOutputs[key(for: command)] else {
+            throw ToolingError.message("unexpected runCapture command: \(command.joined(separator: " "))")
+        }
+        return output
+    }
+
+    public func runSimple(_ command: [String], env: [String: String]?, cwd: URL?) throws {
+        simpleCommands.append(RecordedCommand(command: command, env: env, cwd: cwd))
+        try simpleHandler?(command, env, cwd)
+    }
+
+    public func runStreaming(_ command: [String], env: [String: String]?, cwd: URL?) throws -> StreamingCommandResult {
+        streamingCommands.append(RecordedCommand(command: command, env: env, cwd: cwd))
+        if let streamingHandler {
+            return try streamingHandler(command, env, cwd)
+        }
+        return StreamingCommandResult(status: 0, wasKilled: false, lastLines: [])
+    }
+
+    private func key(for command: [String]) -> String {
+        command.joined(separator: "\u{1f}")
+    }
+}
+
+public struct TestDirectories {
+    public let root: URL
+    public let runtimeRoot: URL
+    public let outDir: URL
+    public let stageDir: URL
+
+    public init(root: URL) {
+        self.root = root
+        self.runtimeRoot = root.appendingPathComponent("RuntimeRoot", isDirectory: true)
+        self.outDir = root.appendingPathComponent("Out", isDirectory: true)
+        self.stageDir = root.appendingPathComponent(".tmp-stage", isDirectory: true)
+    }
+
+    public func create() throws {
+        try FileManager.default.createDirectory(at: runtimeRoot, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: outDir, withIntermediateDirectories: true)
+    }
+
+    public func createFramework(_ name: String, category: String = "Frameworks") throws -> URL {
+        let url = runtimeRoot
+            .appendingPathComponent("System/Library", isDirectory: true)
+            .appendingPathComponent(category, isDirectory: true)
+            .appendingPathComponent(name, isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    public func createSystemLibraryBundle(_ relativePath: String) throws -> URL {
+        let url = appending(relativePath, to: runtimeRoot.appendingPathComponent("System/Library", isDirectory: true))
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    public func createUsrLibDylib(_ name: String) throws -> URL {
+        let url = runtimeRoot
+            .appendingPathComponent("usr", isDirectory: true)
+            .appendingPathComponent("lib", isDirectory: true)
+            .appendingPathComponent(name, isDirectory: false)
+        try FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        _ = FileManager.default.createFile(atPath: url.path, contents: Data())
+        return url
+    }
+}
+
+public func makeTemporaryTestDirectories() throws -> TestDirectories {
+    let root = FileManager.default.temporaryDirectory
+        .appendingPathComponent("PrivateHeaderKitTests-\(UUID().uuidString)", isDirectory: true)
+    let dirs = TestDirectories(root: root)
+    try dirs.create()
+    return dirs
+}
+
+public final class HeaderdumpFixtureRunner {
+    public private(set) var sourcePaths: [String] = []
+    public var failingSourceSuffixes: Set<String>
+
+    public init(failingSourceSuffixes: Set<String> = []) {
+        self.failingSourceSuffixes = failingSourceSuffixes
+    }
+
+    public func handle(command: [String], env _: [String: String]?, cwd _: URL?) throws -> StreamingCommandResult {
+        let parsed = try parseHeaderdumpCommand(command)
+        sourcePaths.append(parsed.sourcePath)
+
+        if failingSourceSuffixes.contains(where: { parsed.sourcePath.hasSuffix($0) }) {
+            return StreamingCommandResult(
+                status: 1,
+                wasKilled: false,
+                lastLines: ["simulated failure for \(parsed.sourcePath)"]
+            )
+        }
+
+        let outputDir = outputDirectory(stageDir: parsed.stageDir, sourcePath: parsed.sourcePath)
+        try FileManager.default.createDirectory(at: outputDir, withIntermediateDirectories: true)
+        try Data("// generated: \(parsed.sourcePath)\n".utf8)
+            .write(to: outputDir.appendingPathComponent("Generated.h", isDirectory: false))
+        return StreamingCommandResult(status: 0, wasKilled: false, lastLines: [])
+    }
+
+    private func parseHeaderdumpCommand(_ command: [String]) throws -> (stageDir: URL, sourcePath: String) {
+        guard let outIndex = command.firstIndex(of: "-o"), outIndex + 1 < command.count else {
+            throw ToolingError.message("headerdump command missing -o: \(command.joined(separator: " "))")
+        }
+        let stageDir = URL(fileURLWithPath: command[outIndex + 1], isDirectory: true)
+        let tail = Array(command.dropFirst(outIndex + 2))
+        let sourcePath: String
+        if let recursiveIndex = tail.firstIndex(of: "-r"), recursiveIndex + 1 < tail.count {
+            sourcePath = tail[recursiveIndex + 1]
+        } else if let firstPath = tail.first(where: { !$0.hasPrefix("-") }) {
+            sourcePath = firstPath
+        } else {
+            throw ToolingError.message("headerdump command missing source path: \(command.joined(separator: " "))")
+        }
+        return (stageDir, sourcePath)
+    }
+
+    private func outputDirectory(stageDir: URL, sourcePath: String) -> URL {
+        if let range = sourcePath.range(of: "/System/Library/") {
+            let relativePath = String(sourcePath[range.upperBound...])
+            return appending(relativePath, to: stageDir.appendingPathComponent("System/Library", isDirectory: true))
+                .appendingPathComponent("Headers", isDirectory: true)
+        }
+
+        if let range = sourcePath.range(of: "/usr/lib/") {
+            let relativePath = String(sourcePath[range.upperBound...])
+            return stageDir
+                .appendingPathComponent("usr", isDirectory: true)
+                .appendingPathComponent("lib", isDirectory: true)
+                .appendingPathComponent(relativePath, isDirectory: true)
+                .appendingPathComponent("Headers", isDirectory: true)
+        }
+
+        return stageDir
+            .appendingPathComponent(sourcePath.trimmingCharacters(in: CharacterSet(charactersIn: "/")), isDirectory: true)
+            .appendingPathComponent("Headers", isDirectory: true)
+    }
+}
+
+private func appending(_ relativePath: String, to base: URL) -> URL {
+    var url = base
+    for part in relativePath.split(separator: "/").map(String.init) {
+        url.appendPathComponent(part, isDirectory: true)
+    }
+    return url
+}

--- a/Tests/PrivateHeaderKitToolingTests/StreamingProcessRunnerTests.swift
+++ b/Tests/PrivateHeaderKitToolingTests/StreamingProcessRunnerTests.swift
@@ -201,17 +201,5 @@ private func runHelper(_ arguments: [String]) throws -> (status: Int32, stdout: 
             #expect(error.description.contains("failed to launch process: /usr/bin/true"))
         }
     }
-
-    @Test func runStreamingHandlesRepeatedShortLivedProcesses() throws {
-        for _ in 0..<200 {
-            let result = try runStreamingSubprocess(
-                ["/usr/bin/true"],
-                streamOutput: false,
-                passthrough: { _ in }
-            )
-            #expect(result.status == 0)
-            #expect(result.wasKilled == false)
-        }
-    }
 }
 #endif

--- a/Tests/PrivateHeaderKitToolingTests/ToolingDeterministicTests.swift
+++ b/Tests/PrivateHeaderKitToolingTests/ToolingDeterministicTests.swift
@@ -1,0 +1,138 @@
+import Foundation
+import Testing
+@testable import PrivateHeaderKitTooling
+import PrivateHeaderKitTestSupport
+
+@Suite
+struct FileOpsDeterministicTests {
+    @Test func buildStageDirUsesInjectedPidDateAndTimeZone() {
+        let outDir = URL(fileURLWithPath: "/tmp/out", isDirectory: true)
+        let date = Date(timeIntervalSince1970: 1_700_000_000)
+        let stageDir = FileOps.buildStageDir(
+            outDir: outDir,
+            pid: 42,
+            date: date,
+            timeZone: TimeZone(secondsFromGMT: 0)!
+        )
+
+        #expect(stageDir.path == "/tmp/out/.tmp-42-20231114221320")
+    }
+
+    @Test func normalizeAndDenormalizeBundleDirsHandleConflictsDeterministically() throws {
+        let dirs = try makeTemporaryTestDirectories()
+        let parent = dirs.root.appendingPathComponent("Bundles", isDirectory: true)
+        let bundle = parent.appendingPathComponent("Foo.bundle", isDirectory: true)
+        let normalized = parent.appendingPathComponent("Foo", isDirectory: true)
+        try FileManager.default.createDirectory(at: bundle, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: normalized, withIntermediateDirectories: true)
+        try Data("bundle".utf8).write(to: bundle.appendingPathComponent("Bundle.h"))
+        try Data("normalized".utf8).write(to: normalized.appendingPathComponent("Normalized.h"))
+
+        let result = try FileOps.normalizeBundleDir(
+            bundle,
+            allowedExtensions: ["bundle"],
+            overwrite: false,
+            fileManager: .default
+        )
+
+        #expect(result.path == normalized.path)
+        #expect(FileManager.default.fileExists(atPath: normalized.appendingPathComponent("Bundle.h").path))
+        #expect(FileManager.default.fileExists(atPath: normalized.appendingPathComponent("Normalized.h").path))
+
+        let denormalized = try FileOps.denormalizeBundleDir(
+            normalized,
+            bundleExtension: "bundle",
+            overwrite: true,
+            fileManager: .default
+        )
+
+        #expect(denormalized.lastPathComponent == "Foo.bundle")
+        #expect(FileManager.default.fileExists(atPath: denormalized.appendingPathComponent("Bundle.h").path))
+    }
+}
+
+@Suite
+struct PathAndVersionTests {
+    @Test func versionKeyParsesNumericComponents() {
+        #expect(VersionUtils.versionKey("26.10.1") == [26, 10, 1])
+        #expect(VersionUtils.versionKey("26.beta.3") == [26, 0, 3])
+    }
+
+    @Test func whichFindsExecutableFromInjectedPath() throws {
+        let dirs = try makeTemporaryTestDirectories()
+        let binDir = dirs.root.appendingPathComponent("bin", isDirectory: true)
+        try FileManager.default.createDirectory(at: binDir, withIntermediateDirectories: true)
+        let executable = binDir.appendingPathComponent("tool", isDirectory: false)
+        try Data("#!/bin/sh\n".utf8).write(to: executable)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: executable.path)
+
+        let found = Which.find("tool", environment: ["PATH": binDir.path])
+        #expect(found?.path == executable.path)
+        #expect(Which.find("missing", environment: ["PATH": binDir.path]) == nil)
+    }
+}
+
+@Suite
+struct SimctlDeterministicTests {
+    @Test func listRuntimesParsesAvailableIOSRuntimesInVersionOrder() throws {
+        let runner = RecordingCommandRunner()
+        runner.setCaptureOutput(
+            """
+            {
+              "runtimes": [
+                {"name": "iOS 26.10", "version": "26.10", "identifier": "ios-26-10", "runtimeRoot": "/runtimes/26.10", "isAvailable": true, "buildversion": "23Z1"},
+                {"name": "iOS 26.2", "version": "26.2", "identifier": "ios-26-2", "runtimeRoot": "/runtimes/26.2", "isAvailable": true, "buildversion": "23C54"},
+                {"name": "iOS 25.0", "version": "25.0", "identifier": "ios-25-0", "runtimeRoot": "/runtimes/25.0", "isAvailable": false},
+                {"name": "watchOS 26.0", "version": "26.0", "identifier": "watch-26-0", "runtimeRoot": "/runtimes/watch", "isAvailable": true}
+              ]
+            }
+            """,
+            for: ["xcrun", "simctl", "list", "runtimes", "-j"]
+        )
+
+        let runtimes = try Simctl.listRuntimes(runner: runner)
+
+        #expect(runtimes.map(\.version) == ["26.2", "26.10"])
+        #expect(runtimes.first?.build == "23C54")
+        #expect(runner.captureCommands.map(\.command) == [["xcrun", "simctl", "list", "runtimes", "-j"]])
+    }
+
+    @Test func listDevicesParsesDevicesForRuntime() throws {
+        let runner = RecordingCommandRunner()
+        runner.setCaptureOutput(
+            """
+            {
+              "devices": {
+                "ios-26-2": [
+                  {"name": "iPhone 17", "udid": "A", "state": "Shutdown"},
+                  {"name": "iPhone 17 Pro", "udid": "B", "state": "Booted"}
+                ],
+                "other": [
+                  {"name": "Other", "udid": "C", "state": "Shutdown"}
+                ]
+              }
+            }
+            """,
+            for: ["xcrun", "simctl", "list", "devices", "-j"]
+        )
+
+        let devices = try Simctl.listDevices(runtimeId: "ios-26-2", runner: runner)
+
+        #expect(devices.map(\.udid) == ["A", "B"])
+        #expect(devices.map(\.state) == ["Shutdown", "Booted"])
+    }
+
+    @Test func ensureDeviceBootedSkipsBootedDeviceUnlessForced() throws {
+        let runner = RecordingCommandRunner()
+        var booted = DeviceInfo(name: "iPhone", udid: "BOOTED", state: "Booted")
+
+        try Simctl.ensureDeviceBooted(&booted, runner: runner, force: false)
+        #expect(runner.simpleCommands.isEmpty)
+
+        try Simctl.ensureDeviceBooted(&booted, runner: runner, force: true)
+        #expect(runner.simpleCommands.map(\.command) == [
+            ["xcrun", "simctl", "boot", "BOOTED"],
+            ["xcrun", "simctl", "bootstatus", "BOOTED", "-b"],
+        ])
+    }
+}


### PR DESCRIPTION
Purpose
- Rebuild PrivateHeaderKit tests so default `swift test` uses deterministic fixtures, injected dependencies, and stub runners instead of host-specific tooling.

Changes
- Add test seams for command running, environment/date/file existence, Swift interface output policy, and install command resolution.
- Replace HeaderDump, dump orchestration, tooling, and install tests with deterministic unit coverage and shared test support.
- Remove flaky process stress coverage and document default test boundaries plus opt-in integration expectations.
- Preserve Swift interface builder failure behavior while keeping skip-existing work avoided.

Testing
- `swift test --filter HeaderDump`
- `swift test --filter PrivateHeaderKitDumpTests`
- `swift test --filter PrivateHeaderKitToolingTests`
- `swift test --filter PrivateHeaderKitInstallTests`
- `swift test`
- `git diff --check`
- `git diff --check HEAD~7..HEAD`
- `codex-review --base main` (clean)