### PR TITLE
Add private header generation core skeleton

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -8,6 +8,7 @@ let package = Package(
         .iOS(.v17),
     ],
     products: [
+        .library(name: "PrivateHeaderKitCore", targets: ["PrivateHeaderKitCore"]),
         .executable(name: "headerdump", targets: ["HeaderDumpCLI"]),
         .executable(name: "privateheaderkit-dump", targets: ["PrivateHeaderKitDump"]),
         .executable(name: "privateheaderkit-install", targets: ["PrivateHeaderKitInstall"]),
@@ -56,6 +57,10 @@ let package = Package(
             name: "PrivateHeaderKitTooling",
             dependencies: []
         ),
+        .target(
+            name: "PrivateHeaderKitCore",
+            dependencies: []
+        ),
         .executableTarget(
             name: "HeaderDumpCLI",
             dependencies: [
@@ -99,6 +104,12 @@ let package = Package(
                     condition: .when(platforms: [.macOS, .iOS])
                 ),
                 .product(name: "MachOKit", package: "MachOKit"),
+            ]
+        ),
+        .testTarget(
+            name: "PrivateHeaderKitCoreTests",
+            dependencies: [
+                "PrivateHeaderKitCore",
             ]
         ),
         .testTarget(

--- a/Sources/PrivateHeaderKitCore/PrivateHeaderGeneration.swift
+++ b/Sources/PrivateHeaderKitCore/PrivateHeaderGeneration.swift
@@ -3,25 +3,25 @@ import Foundation
 public enum PrivateHeaderGeneration {
     public static func makePlan(
         source: Source,
-        artifactRootDirectory: URL,
+        output: Output,
         options: Options = Options()
     ) -> Plan {
         Plan(
             source: source,
-            artifactRootDirectory: artifactRootDirectory,
+            output: output,
             options: options
         )
     }
 
     public static func generatePrivateHeaders(
         source: Source,
-        artifactRootDirectory: URL,
+        output: Output,
         options: Options = Options()
     ) async throws -> Result {
         throw GenerationError.notImplemented(
             plan: makePlan(
                 source: source,
-                artifactRootDirectory: artifactRootDirectory,
+                output: output,
                 options: options
             )
         )
@@ -99,9 +99,29 @@ public extension PrivateHeaderGeneration {
         public init() {}
     }
 
+    struct Output: Hashable, Sendable {
+        public let artifactBaseDirectory: URL
+        public let stateBaseDirectory: URL
+
+        public init(
+            artifactBaseDirectory: URL,
+            stateBaseDirectory: URL
+        ) {
+            self.artifactBaseDirectory = artifactBaseDirectory
+            self.stateBaseDirectory = stateBaseDirectory
+        }
+
+        public init(baseDirectory: URL) {
+            self.init(
+                artifactBaseDirectory: baseDirectory,
+                stateBaseDirectory: baseDirectory.appendingPathComponent(".state", isDirectory: true)
+            )
+        }
+    }
+
     struct Plan: Hashable, Sendable {
         public let source: Source
-        public let artifactRootDirectory: URL
+        public let output: Output
         public let artifactDirectory: URL
         public let stateDirectory: URL
         public let target: Target
@@ -109,19 +129,20 @@ public extension PrivateHeaderGeneration {
 
         public init(
             source: Source,
-            artifactRootDirectory: URL,
+            output: Output,
             options: Options = Options()
         ) {
             let label = source.label
             self.source = source
-            self.artifactRootDirectory = artifactRootDirectory
-            self.artifactDirectory = artifactRootDirectory.appendingPathComponent(
+            self.output = output
+            self.artifactDirectory = output.artifactBaseDirectory.appendingPathComponent(
                 label.directoryName,
                 isDirectory: true
             )
-            self.stateDirectory = artifactRootDirectory
-                .appendingPathComponent(".state", isDirectory: true)
-                .appendingPathComponent(label.directoryName, isDirectory: true)
+            self.stateDirectory = output.stateBaseDirectory.appendingPathComponent(
+                label.directoryName,
+                isDirectory: true
+            )
             self.target = .allAvailable
             self.options = options
         }

--- a/Sources/PrivateHeaderKitCore/PrivateHeaderGeneration.swift
+++ b/Sources/PrivateHeaderKitCore/PrivateHeaderGeneration.swift
@@ -34,19 +34,47 @@ public extension PrivateHeaderGeneration {
         public let version: String
         public let build: String?
 
-        public init(platform: Platform, version: String, build: String? = nil) {
+        public init(platform: Platform, version: String, build: String? = nil) throws {
+            try Self.validatePathComponent(version, field: "version")
+            let build = build.flatMap { $0.isEmpty ? nil : $0 }
+            if let build {
+                try Self.validatePathComponent(build, field: "build")
+            }
             self.platform = platform
             self.version = version
-            self.build = build.flatMap { $0.isEmpty ? nil : $0 }
+            self.build = build
         }
 
         public var label: Label {
             Label(platform: platform, version: version, build: build)
         }
+
+        private static func validatePathComponent(_ value: String, field: String) throws {
+            guard !value.isEmpty else {
+                throw ValidationError.emptyComponent(field: field)
+            }
+            guard value != ".", value != "..", !value.contains("/"), !value.contains("\0") else {
+                throw ValidationError.invalidPathComponent(field: field, value: value)
+            }
+        }
     }
 }
 
 public extension PrivateHeaderGeneration.Source {
+    enum ValidationError: Error, Equatable, CustomStringConvertible, Sendable {
+        case emptyComponent(field: String)
+        case invalidPathComponent(field: String, value: String)
+
+        public var description: String {
+            switch self {
+            case .emptyComponent(let field):
+                "\(field) must not be empty"
+            case .invalidPathComponent(let field, let value):
+                "\(field) is not safe as a path component: \(value)"
+            }
+        }
+    }
+
     enum Platform: String, CaseIterable, Hashable, Sendable {
         case iOS = "iOS"
         case macOS = "macOS"

--- a/Sources/PrivateHeaderKitCore/PrivateHeaderGeneration.swift
+++ b/Sources/PrivateHeaderKitCore/PrivateHeaderGeneration.swift
@@ -1,0 +1,152 @@
+import Foundation
+
+public enum PrivateHeaderGeneration {
+    public static func makePlan(
+        source: Source,
+        artifactRootDirectory: URL,
+        options: Options = Options()
+    ) -> Plan {
+        Plan(
+            source: source,
+            artifactRootDirectory: artifactRootDirectory,
+            options: options
+        )
+    }
+
+    public static func generatePrivateHeaders(
+        source: Source,
+        artifactRootDirectory: URL,
+        options: Options = Options()
+    ) async throws -> Result {
+        throw GenerationError.notImplemented(
+            plan: makePlan(
+                source: source,
+                artifactRootDirectory: artifactRootDirectory,
+                options: options
+            )
+        )
+    }
+}
+
+public extension PrivateHeaderGeneration {
+    struct Source: Hashable, Sendable {
+        public let platform: Platform
+        public let version: String
+        public let build: String?
+
+        public init(platform: Platform, version: String, build: String? = nil) {
+            self.platform = platform
+            self.version = version
+            self.build = build.flatMap { $0.isEmpty ? nil : $0 }
+        }
+
+        public var label: Label {
+            Label(platform: platform, version: version, build: build)
+        }
+    }
+}
+
+public extension PrivateHeaderGeneration.Source {
+    enum Platform: String, CaseIterable, Hashable, Sendable {
+        case iOS = "iOS"
+        case macOS = "macOS"
+
+        public var displayName: String {
+            rawValue
+        }
+    }
+
+    struct Label: CustomStringConvertible, Hashable, Sendable {
+        public let displayName: String
+        public let directoryName: String
+
+        init(platform: Platform, version: String, build: String?) {
+            let baseName = "\(platform.displayName) \(version)"
+            let directoryBaseName = "\(platform.displayName)\(version)"
+            if let build {
+                self.displayName = "\(baseName) (\(build))"
+                self.directoryName = "\(directoryBaseName)(\(build))"
+            } else {
+                self.displayName = baseName
+                self.directoryName = directoryBaseName
+            }
+        }
+
+        public var description: String {
+            displayName
+        }
+    }
+}
+
+public extension PrivateHeaderGeneration {
+    struct Target: CustomStringConvertible, Hashable, Sendable {
+        public static let allAvailable = Target(identifier: "allAvailable")
+
+        private let identifier: String
+
+        private init(identifier: String) {
+            self.identifier = identifier
+        }
+
+        public var description: String {
+            identifier
+        }
+    }
+}
+
+public extension PrivateHeaderGeneration {
+    struct Options: Hashable, Sendable {
+        public init() {}
+    }
+
+    struct Plan: Hashable, Sendable {
+        public let source: Source
+        public let artifactRootDirectory: URL
+        public let artifactDirectory: URL
+        public let stateDirectory: URL
+        public let target: Target
+        public let options: Options
+
+        public init(
+            source: Source,
+            artifactRootDirectory: URL,
+            options: Options = Options()
+        ) {
+            let label = source.label
+            self.source = source
+            self.artifactRootDirectory = artifactRootDirectory
+            self.artifactDirectory = artifactRootDirectory.appendingPathComponent(
+                label.directoryName,
+                isDirectory: true
+            )
+            self.stateDirectory = artifactRootDirectory
+                .appendingPathComponent(".state", isDirectory: true)
+                .appendingPathComponent(label.directoryName, isDirectory: true)
+            self.target = .allAvailable
+            self.options = options
+        }
+    }
+
+    struct Result: Hashable, Sendable {
+        public let plan: Plan
+        public let artifactDirectory: URL
+        public let generatedTargets: [Target]
+
+        init(plan: Plan, generatedTargets: [Target]) {
+            self.plan = plan
+            self.artifactDirectory = plan.artifactDirectory
+            self.generatedTargets = generatedTargets
+        }
+    }
+
+    enum GenerationError: Error, Equatable, CustomStringConvertible, Sendable {
+        case notImplemented(plan: Plan)
+
+        public var description: String {
+            switch self {
+            case .notImplemented(let plan):
+                "private header generation is not implemented for \(plan.source.label.displayName)"
+            }
+        }
+    }
+}

--- a/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationTests.swift
+++ b/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationTests.swift
@@ -1,0 +1,90 @@
+import Foundation
+import Testing
+
+import PrivateHeaderKitCore
+
+@Suite
+struct PrivateHeaderGenerationLabelTests {
+    @Test func iOSSourceLabelUsesUserFacingDisplayAndCompactDirectoryNames() {
+        let source = PrivateHeaderGeneration.Source(
+            platform: .iOS,
+            version: "27.0",
+            build: "24A5355q"
+        )
+
+        #expect(source.label.displayName == "iOS 27.0 (24A5355q)")
+        #expect(source.label.directoryName == "iOS27.0(24A5355q)")
+        #expect(source.label.description == "iOS 27.0 (24A5355q)")
+    }
+
+    @Test func macOSSourceLabelUsesUserFacingDisplayAndCompactDirectoryNames() {
+        let source = PrivateHeaderGeneration.Source(
+            platform: .macOS,
+            version: "16.0",
+            build: "25A5279m"
+        )
+
+        #expect(source.label.displayName == "macOS 16.0 (25A5279m)")
+        #expect(source.label.directoryName == "macOS16.0(25A5279m)")
+    }
+
+    @Test func sourceLabelOmitsEmptyBuild() {
+        let source = PrivateHeaderGeneration.Source(
+            platform: .iOS,
+            version: "27.0",
+            build: ""
+        )
+
+        #expect(source.label.displayName == "iOS 27.0")
+        #expect(source.label.directoryName == "iOS27.0")
+    }
+}
+
+@Suite
+struct PrivateHeaderGenerationPlanTests {
+    @Test func planKeepsStateOutsideArtifactDirectoryAndUsesSourceLabelAsResumeKey() {
+        let source = PrivateHeaderGeneration.Source(
+            platform: .iOS,
+            version: "27.0",
+            build: "24A5355q"
+        )
+        let root = URL(fileURLWithPath: "/tmp/PrivateHeaderKit", isDirectory: true)
+
+        let plan = PrivateHeaderGeneration.makePlan(
+            source: source,
+            artifactRootDirectory: root
+        )
+
+        #expect(plan.source == source)
+        #expect(plan.artifactRootDirectory == root)
+        #expect(plan.artifactDirectory.path == "/tmp/PrivateHeaderKit/iOS27.0(24A5355q)")
+        #expect(plan.stateDirectory.path == "/tmp/PrivateHeaderKit/.state/iOS27.0(24A5355q)")
+        #expect(plan.target == .allAvailable)
+    }
+
+    @Test func generatePrivateHeadersThrowsExplicitUnimplementedError() async throws {
+        let source = PrivateHeaderGeneration.Source(
+            platform: .macOS,
+            version: "16.0",
+            build: "25A5279m"
+        )
+        let root = URL(fileURLWithPath: "/tmp/PrivateHeaderKit", isDirectory: true)
+
+        do {
+            _ = try await PrivateHeaderGeneration.generatePrivateHeaders(
+                source: source,
+                artifactRootDirectory: root
+            )
+            Issue.record("generatePrivateHeaders unexpectedly returned a result")
+        } catch let error as PrivateHeaderGeneration.GenerationError {
+            #expect(
+                error == .notImplemented(
+                    plan: PrivateHeaderGeneration.makePlan(
+                        source: source,
+                        artifactRootDirectory: root
+                    )
+                )
+            )
+        }
+    }
+}

--- a/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationTests.swift
+++ b/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationTests.swift
@@ -42,24 +42,46 @@ struct PrivateHeaderGenerationLabelTests {
 
 @Suite
 struct PrivateHeaderGenerationPlanTests {
-    @Test func planKeepsStateOutsideArtifactDirectoryAndUsesSourceLabelAsResumeKey() {
+    @Test func customOutputBaseKeepsStateOutsideArtifactDirectoryAndUsesSourceLabelAsResumeKey() {
         let source = PrivateHeaderGeneration.Source(
             platform: .iOS,
             version: "27.0",
             build: "24A5355q"
         )
         let root = URL(fileURLWithPath: "/tmp/PrivateHeaderKit", isDirectory: true)
+        let output = PrivateHeaderGeneration.Output(baseDirectory: root)
 
         let plan = PrivateHeaderGeneration.makePlan(
             source: source,
-            artifactRootDirectory: root
+            output: output
         )
 
         #expect(plan.source == source)
-        #expect(plan.artifactRootDirectory == root)
+        #expect(plan.output == output)
         #expect(plan.artifactDirectory.path == "/tmp/PrivateHeaderKit/iOS27.0(24A5355q)")
         #expect(plan.stateDirectory.path == "/tmp/PrivateHeaderKit/.state/iOS27.0(24A5355q)")
         #expect(plan.target == .allAvailable)
+    }
+
+    @Test func defaultOutputCanSeparateArtifactAndStateBases() {
+        let source = PrivateHeaderGeneration.Source(
+            platform: .iOS,
+            version: "27.0",
+            build: "24A5355q"
+        )
+        let root = URL(fileURLWithPath: "/tmp/PrivateHeaderKit", isDirectory: true)
+        let output = PrivateHeaderGeneration.Output(
+            artifactBaseDirectory: root.appendingPathComponent("generated-headers", isDirectory: true),
+            stateBaseDirectory: root.appendingPathComponent(".state", isDirectory: true)
+        )
+
+        let plan = PrivateHeaderGeneration.makePlan(
+            source: source,
+            output: output
+        )
+
+        #expect(plan.artifactDirectory.path == "/tmp/PrivateHeaderKit/generated-headers/iOS27.0(24A5355q)")
+        #expect(plan.stateDirectory.path == "/tmp/PrivateHeaderKit/.state/iOS27.0(24A5355q)")
     }
 
     @Test func generatePrivateHeadersThrowsExplicitUnimplementedError() async throws {
@@ -68,12 +90,14 @@ struct PrivateHeaderGenerationPlanTests {
             version: "16.0",
             build: "25A5279m"
         )
-        let root = URL(fileURLWithPath: "/tmp/PrivateHeaderKit", isDirectory: true)
+        let output = PrivateHeaderGeneration.Output(
+            baseDirectory: URL(fileURLWithPath: "/tmp/PrivateHeaderKit", isDirectory: true)
+        )
 
         do {
             _ = try await PrivateHeaderGeneration.generatePrivateHeaders(
                 source: source,
-                artifactRootDirectory: root
+                output: output
             )
             Issue.record("generatePrivateHeaders unexpectedly returned a result")
         } catch let error as PrivateHeaderGeneration.GenerationError {
@@ -81,7 +105,7 @@ struct PrivateHeaderGenerationPlanTests {
                 error == .notImplemented(
                     plan: PrivateHeaderGeneration.makePlan(
                         source: source,
-                        artifactRootDirectory: root
+                        output: output
                     )
                 )
             )

--- a/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationTests.swift
+++ b/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationTests.swift
@@ -5,8 +5,8 @@ import PrivateHeaderKitCore
 
 @Suite
 struct PrivateHeaderGenerationLabelTests {
-    @Test func iOSSourceLabelUsesUserFacingDisplayAndCompactDirectoryNames() {
-        let source = PrivateHeaderGeneration.Source(
+    @Test func iOSSourceLabelUsesUserFacingDisplayAndCompactDirectoryNames() throws {
+        let source = try PrivateHeaderGeneration.Source(
             platform: .iOS,
             version: "27.0",
             build: "24A5355q"
@@ -17,8 +17,8 @@ struct PrivateHeaderGenerationLabelTests {
         #expect(source.label.description == "iOS 27.0 (24A5355q)")
     }
 
-    @Test func macOSSourceLabelUsesUserFacingDisplayAndCompactDirectoryNames() {
-        let source = PrivateHeaderGeneration.Source(
+    @Test func macOSSourceLabelUsesUserFacingDisplayAndCompactDirectoryNames() throws {
+        let source = try PrivateHeaderGeneration.Source(
             platform: .macOS,
             version: "16.0",
             build: "25A5279m"
@@ -28,8 +28,8 @@ struct PrivateHeaderGenerationLabelTests {
         #expect(source.label.directoryName == "macOS16.0(25A5279m)")
     }
 
-    @Test func sourceLabelOmitsEmptyBuild() {
-        let source = PrivateHeaderGeneration.Source(
+    @Test func sourceLabelOmitsEmptyBuild() throws {
+        let source = try PrivateHeaderGeneration.Source(
             platform: .iOS,
             version: "27.0",
             build: ""
@@ -38,12 +38,30 @@ struct PrivateHeaderGenerationLabelTests {
         #expect(source.label.displayName == "iOS 27.0")
         #expect(source.label.directoryName == "iOS27.0")
     }
+
+    @Test func sourceRejectsPathUnsafeVersionAndBuildComponents() throws {
+        #expect(throws: PrivateHeaderGeneration.Source.ValidationError.self) {
+            _ = try PrivateHeaderGeneration.Source(
+                platform: .iOS,
+                version: "../27.0",
+                build: "24A5355q"
+            )
+        }
+
+        #expect(throws: PrivateHeaderGeneration.Source.ValidationError.self) {
+            _ = try PrivateHeaderGeneration.Source(
+                platform: .iOS,
+                version: "27.0",
+                build: "24A/5355q"
+            )
+        }
+    }
 }
 
 @Suite
 struct PrivateHeaderGenerationPlanTests {
-    @Test func customOutputBaseKeepsStateOutsideArtifactDirectoryAndUsesSourceLabelAsResumeKey() {
-        let source = PrivateHeaderGeneration.Source(
+    @Test func customOutputBaseKeepsStateOutsideArtifactDirectoryAndUsesSourceLabelAsResumeKey() throws {
+        let source = try PrivateHeaderGeneration.Source(
             platform: .iOS,
             version: "27.0",
             build: "24A5355q"
@@ -63,8 +81,8 @@ struct PrivateHeaderGenerationPlanTests {
         #expect(plan.target == .allAvailable)
     }
 
-    @Test func defaultOutputCanSeparateArtifactAndStateBases() {
-        let source = PrivateHeaderGeneration.Source(
+    @Test func defaultOutputCanSeparateArtifactAndStateBases() throws {
+        let source = try PrivateHeaderGeneration.Source(
             platform: .iOS,
             version: "27.0",
             build: "24A5355q"
@@ -85,7 +103,7 @@ struct PrivateHeaderGenerationPlanTests {
     }
 
     @Test func generatePrivateHeadersThrowsExplicitUnimplementedError() async throws {
-        let source = PrivateHeaderGeneration.Source(
+        let source = try PrivateHeaderGeneration.Source(
             platform: .macOS,
             version: "16.0",
             build: "25A5279m"


### PR DESCRIPTION
Purpose

Create the first rewrite ownership boundary so follow-up work can happen in separate modules and worktrees without editing the legacy dump entry point.

Changes

- Add the `PrivateHeaderKitCore` library product/target.
- Add the `PrivateHeaderGeneration` namespace and initial value types for source labels, output roots, plans, targets, options, results, and the intentionally unimplemented generation entry point.
- Add tests for display vs directory source labels, default/custom artifact-state base separation, path-unsafe source rejection, and the unimplemented entry point.

Testing

- `git diff --check`
- `swift build --target PrivateHeaderKitCoreTests --skip-update --force-resolved-versions`
- `rm -rf .build && swift test`
- `swift test`
- `codex-review` against `main`: no findings