### PR TITLE
feat(core): add target query resolver

### DIFF
--- a/Sources/PrivateHeaderKitCore/PrivateHeaderGenerationTargetResolver.swift
+++ b/Sources/PrivateHeaderKitCore/PrivateHeaderGenerationTargetResolver.swift
@@ -1,0 +1,222 @@
+import Foundation
+
+public extension PrivateHeaderGeneration {
+    enum TargetKind: String, CaseIterable, Hashable, Sendable {
+        case framework
+        case privateFramework
+        case systemBundle
+        case usrLibDylib
+        case nestedBundle
+        case other
+    }
+
+    struct TargetCandidate: Hashable, Sendable {
+        public let identifier: String
+        public let displayName: String
+        public let kind: TargetKind
+        public let aliases: [String]
+
+        public init(
+            identifier: String,
+            displayName: String,
+            kind: TargetKind,
+            aliases: [String] = []
+        ) throws {
+            try Self.validateNonEmpty(identifier, field: "identifier")
+            try Self.validateNonEmpty(displayName, field: "displayName")
+            self.identifier = identifier
+            self.displayName = displayName
+            self.kind = kind
+            self.aliases = aliases.filter { !$0.isEmpty }
+        }
+
+        var searchableNames: [String] {
+            [displayName] + aliases
+        }
+
+        private static func validateNonEmpty(_ value: String, field: String) throws {
+            guard !value.isEmpty else {
+                throw ValidationError.emptyComponent(field: field)
+            }
+        }
+    }
+
+    enum TargetSelection: Hashable, Sendable {
+        case allAvailable
+        case targets([TargetCandidate])
+    }
+
+    struct TargetQuery: Hashable, Sendable {
+        public let rawValue: String
+        public let terms: [String]
+
+        public init(commaSeparated rawValue: String) throws {
+            let terms = rawValue
+                .split(separator: ",", omittingEmptySubsequences: false)
+                .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            try Self.validate(terms: terms)
+            self.rawValue = rawValue
+            self.terms = terms
+        }
+
+        public var requestsAllAvailableTargets: Bool {
+            terms.count == 1 && Self.allAvailableTerms.contains(Self.normalize(terms[0]))
+        }
+
+        private static let allAvailableTerms: Set<String> = [
+            "all",
+            "@all",
+            "すべて",
+        ]
+
+        private static func validate(terms: [String]) throws {
+            guard !terms.isEmpty else {
+                throw ValidationError.emptyComponent(field: "query")
+            }
+
+            var requestedAll = false
+            for term in terms {
+                guard !term.isEmpty else {
+                    throw ValidationError.emptyComponent(field: "query")
+                }
+                let normalizedTerm = normalize(term)
+                if allAvailableTerms.contains(normalizedTerm) {
+                    requestedAll = true
+                    continue
+                }
+                guard term != ".", term != "..", !term.contains(".."), !term.contains("/"), !term.contains("\0") else {
+                    throw ValidationError.invalidPathComponent(field: "query", value: term)
+                }
+            }
+
+            if requestedAll && terms.count > 1 {
+                throw ValidationError.invalidAllTargetsCombination
+            }
+        }
+
+        private static func normalize(_ value: String) -> String {
+            value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        }
+    }
+
+    struct TargetResolver: Hashable, Sendable {
+        public let candidates: [TargetCandidate]
+
+        public init(candidates: [TargetCandidate]) {
+            self.candidates = candidates
+        }
+
+        public func resolve(_ query: TargetQuery) -> TargetResolution {
+            if query.requestsAllAvailableTargets {
+                return .selected(.allAvailable)
+            }
+
+            var selected: [TargetCandidate] = []
+            var selectedIDs: Set<String> = []
+            var ambiguities: [TargetResolution.Ambiguity] = []
+            var failures: [TargetResolution.Failure] = []
+
+            for term in query.terms {
+                let matches = matches(for: term)
+                switch matches.count {
+                case 0:
+                    failures.append(
+                        TargetResolution.Failure(
+                            query: term,
+                            reason: .noMatch
+                        )
+                    )
+                case 1:
+                    let candidate = matches[0]
+                    if selectedIDs.insert(candidate.identifier).inserted {
+                        selected.append(candidate)
+                    }
+                default:
+                    ambiguities.append(
+                        TargetResolution.Ambiguity(
+                            query: term,
+                            candidates: matches
+                        )
+                    )
+                }
+            }
+
+            if !ambiguities.isEmpty, !failures.isEmpty {
+                return .unresolved(ambiguities: ambiguities, failures: failures)
+            }
+            if !failures.isEmpty {
+                return .failed(failures)
+            }
+            if !ambiguities.isEmpty {
+                return .needsDisambiguation(ambiguities)
+            }
+            return .selected(.targets(selected))
+        }
+
+        private func matches(for term: String) -> [TargetCandidate] {
+            let normalizedTerm = Self.normalize(term)
+            let exactMatches = candidates.filter { candidate in
+                candidate.searchableNames.contains { Self.normalize($0) == normalizedTerm }
+            }
+            if !exactMatches.isEmpty {
+                return exactMatches
+            }
+
+            return candidates.filter { candidate in
+                candidate.searchableNames.contains { Self.normalize($0).contains(normalizedTerm) }
+            }
+        }
+
+        private static func normalize(_ value: String) -> String {
+            value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        }
+    }
+
+    enum TargetResolution: Hashable, Sendable {
+        case selected(TargetSelection)
+        case needsDisambiguation([Ambiguity])
+        case failed([Failure])
+        case unresolved(ambiguities: [Ambiguity], failures: [Failure])
+
+        public struct Ambiguity: Hashable, Sendable {
+            public let query: String
+            public let candidates: [TargetCandidate]
+
+            public init(query: String, candidates: [TargetCandidate]) {
+                self.query = query
+                self.candidates = candidates
+            }
+        }
+
+        public struct Failure: Hashable, Sendable {
+            public let query: String
+            public let reason: FailureReason
+
+            public init(query: String, reason: FailureReason) {
+                self.query = query
+                self.reason = reason
+            }
+        }
+
+        public enum FailureReason: String, Hashable, Sendable {
+            case noMatch
+        }
+    }
+
+    enum ValidationError: Error, Equatable, CustomStringConvertible, Sendable {
+        case emptyComponent(field: String)
+        case invalidPathComponent(field: String, value: String)
+        case invalidAllTargetsCombination
+
+        public var description: String {
+            switch self {
+            case .emptyComponent(let field):
+                "\(field) must not be empty"
+            case .invalidPathComponent(let field, let value):
+                "\(field) is not safe as a path component: \(value)"
+            case .invalidAllTargetsCombination:
+                "all available targets cannot be combined with explicit target queries"
+            }
+        }
+    }
+}

--- a/Sources/PrivateHeaderKitCore/PrivateHeaderGenerationTargetResolver.swift
+++ b/Sources/PrivateHeaderKitCore/PrivateHeaderGenerationTargetResolver.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public extension PrivateHeaderGeneration {
+extension PrivateHeaderGeneration {
     enum TargetKind: String, CaseIterable, Hashable, Sendable {
         case framework
         case privateFramework
@@ -11,12 +11,12 @@ public extension PrivateHeaderGeneration {
     }
 
     struct TargetCandidate: Hashable, Sendable {
-        public let identifier: String
-        public let displayName: String
-        public let kind: TargetKind
-        public let aliases: [String]
+        let identifier: String
+        let displayName: String
+        let kind: TargetKind
+        let aliases: [String]
 
-        public init(
+        init(
             identifier: String,
             displayName: String,
             kind: TargetKind,
@@ -56,10 +56,10 @@ public extension PrivateHeaderGeneration {
     }
 
     struct TargetQuery: Hashable, Sendable {
-        public let rawValue: String
-        public let terms: [String]
+        let rawValue: String
+        let terms: [String]
 
-        public init(commaSeparated rawValue: String) throws {
+        init(commaSeparated rawValue: String) throws {
             let terms = rawValue
                 .split(separator: ",", omittingEmptySubsequences: false)
                 .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
@@ -68,7 +68,7 @@ public extension PrivateHeaderGeneration {
             self.terms = terms
         }
 
-        public var requestsAllAvailableTargets: Bool {
+        var requestsAllAvailableTargets: Bool {
             terms.count == 1 && Self.allAvailableTerms.contains(Self.normalize(terms[0]))
         }
 
@@ -146,13 +146,13 @@ public extension PrivateHeaderGeneration {
     }
 
     struct TargetResolver: Hashable, Sendable {
-        public let candidates: [TargetCandidate]
+        let candidates: [TargetCandidate]
 
-        public init(candidates: [TargetCandidate]) {
+        init(candidates: [TargetCandidate]) {
             self.candidates = candidates
         }
 
-        public func resolve(_ query: TargetQuery) -> TargetResolution {
+        func resolve(_ query: TargetQuery) -> TargetResolution {
             if query.requestsAllAvailableTargets {
                 return .selected(.allAvailable)
             }
@@ -224,27 +224,27 @@ public extension PrivateHeaderGeneration {
         case failed([Failure])
         case unresolved(ambiguities: [Ambiguity], failures: [Failure])
 
-        public struct Ambiguity: Hashable, Sendable {
-            public let query: String
-            public let candidates: [TargetCandidate]
+        struct Ambiguity: Hashable, Sendable {
+            let query: String
+            let candidates: [TargetCandidate]
 
-            public init(query: String, candidates: [TargetCandidate]) {
+            init(query: String, candidates: [TargetCandidate]) {
                 self.query = query
                 self.candidates = candidates
             }
         }
 
-        public struct Failure: Hashable, Sendable {
-            public let query: String
-            public let reason: FailureReason
+        struct Failure: Hashable, Sendable {
+            let query: String
+            let reason: FailureReason
 
-            public init(query: String, reason: FailureReason) {
+            init(query: String, reason: FailureReason) {
                 self.query = query
                 self.reason = reason
             }
         }
 
-        public enum FailureReason: String, Hashable, Sendable {
+        enum FailureReason: String, Hashable, Sendable {
             case noMatch
         }
     }
@@ -254,7 +254,7 @@ public extension PrivateHeaderGeneration {
         case invalidPathComponent(field: String, value: String)
         case invalidAllTargetsCombination
 
-        public var description: String {
+        var description: String {
             switch self {
             case .emptyComponent(let field):
                 "\(field) must not be empty"

--- a/Sources/PrivateHeaderKitCore/PrivateHeaderGenerationTargetResolver.swift
+++ b/Sources/PrivateHeaderKitCore/PrivateHeaderGenerationTargetResolver.swift
@@ -31,12 +31,21 @@ public extension PrivateHeaderGeneration {
         }
 
         var searchableNames: [String] {
-            [displayName] + aliases
+            [displayName] + inferredAliases + aliases
         }
 
         private static func validateNonEmpty(_ value: String, field: String) throws {
             guard !value.isEmpty else {
                 throw ValidationError.emptyComponent(field: field)
+            }
+        }
+
+        private var inferredAliases: [String] {
+            switch kind {
+            case .usrLibDylib where !displayName.hasPrefix("/"):
+                ["/usr/lib/\(displayName)"]
+            default:
+                []
             }
         }
     }
@@ -84,7 +93,7 @@ public extension PrivateHeaderGeneration {
                     requestedAll = true
                     continue
                 }
-                guard term != ".", term != "..", !term.contains(".."), !term.contains("/"), !term.contains("\0") else {
+                guard isSafeTargetSelector(term) else {
                     throw ValidationError.invalidPathComponent(field: "query", value: term)
                 }
             }
@@ -96,6 +105,32 @@ public extension PrivateHeaderGeneration {
 
         private static func normalize(_ value: String) -> String {
             value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        }
+
+        private static func isSafeTargetSelector(_ value: String) -> Bool {
+            guard !value.contains("\0") else { return false }
+            if value.hasPrefix("/usr/lib/") {
+                return isValidUsrLibDylibSelector(value)
+            }
+            if value.hasPrefix("/") {
+                return false
+            }
+            let components = value.split(separator: "/", omittingEmptySubsequences: false).map(String.init)
+            return components.allSatisfy(isSafeRelativePathComponent)
+        }
+
+        private static func isValidUsrLibDylibSelector(_ value: String) -> Bool {
+            let name = String(value.dropFirst("/usr/lib/".count))
+            return isSafeRelativePathComponent(name)
+                && !name.contains("/")
+                && name.lowercased().hasSuffix(".dylib")
+        }
+
+        private static func isSafeRelativePathComponent(_ component: String) -> Bool {
+            !component.isEmpty
+                && component != "."
+                && component != ".."
+                && !component.contains("..")
         }
     }
 

--- a/Sources/PrivateHeaderKitCore/PrivateHeaderGenerationTargetResolver.swift
+++ b/Sources/PrivateHeaderKitCore/PrivateHeaderGenerationTargetResolver.swift
@@ -77,6 +77,8 @@ public extension PrivateHeaderGeneration {
             "@all",
             "すべて",
         ]
+        private static let systemLibraryPrefix = "/System/Library/"
+        private static let usrLibPrefix = "/usr/lib/"
 
         private static func validate(terms: [String]) throws {
             guard !terms.isEmpty else {
@@ -109,7 +111,10 @@ public extension PrivateHeaderGeneration {
 
         private static func isSafeTargetSelector(_ value: String) -> Bool {
             guard !value.contains("\0") else { return false }
-            if value.hasPrefix("/usr/lib/") {
+            if value.hasPrefix(systemLibraryPrefix) {
+                return isValidSystemLibrarySelector(value)
+            }
+            if value.hasPrefix(usrLibPrefix) {
                 return isValidUsrLibDylibSelector(value)
             }
             if value.hasPrefix("/") {
@@ -119,8 +124,14 @@ public extension PrivateHeaderGeneration {
             return components.allSatisfy(isSafeRelativePathComponent)
         }
 
+        private static func isValidSystemLibrarySelector(_ value: String) -> Bool {
+            let relativePath = String(value.dropFirst(systemLibraryPrefix.count))
+            let components = relativePath.split(separator: "/", omittingEmptySubsequences: false).map(String.init)
+            return components.allSatisfy(isSafeRelativePathComponent)
+        }
+
         private static func isValidUsrLibDylibSelector(_ value: String) -> Bool {
-            let name = String(value.dropFirst("/usr/lib/".count))
+            let name = String(value.dropFirst(usrLibPrefix.count))
             return isSafeRelativePathComponent(name)
                 && !name.contains("/")
                 && name.lowercased().hasSuffix(".dylib")

--- a/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationTargetResolverTests.swift
+++ b/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationTargetResolverTests.swift
@@ -1,6 +1,6 @@
 import Testing
 
-import PrivateHeaderKitCore
+@testable import PrivateHeaderKitCore
 
 @Suite
 struct PrivateHeaderGenerationTargetResolverTests {

--- a/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationTargetResolverTests.swift
+++ b/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationTargetResolverTests.swift
@@ -149,11 +149,41 @@ struct PrivateHeaderGenerationTargetResolverTests {
         }
 
         #expect(throws: PrivateHeaderGeneration.ValidationError.self) {
-            _ = try PrivateHeaderGeneration.TargetQuery(commaSeparated: "/usr/lib/libobjc.A.dylib")
+            _ = try PrivateHeaderGeneration.TargetQuery(commaSeparated: "/tmp/libobjc.A.dylib")
+        }
+
+        #expect(throws: PrivateHeaderGeneration.ValidationError.self) {
+            _ = try PrivateHeaderGeneration.TargetQuery(commaSeparated: "PreferenceBundles/./Foo.bundle")
+        }
+
+        #expect(throws: PrivateHeaderGeneration.ValidationError.self) {
+            _ = try PrivateHeaderGeneration.TargetQuery(commaSeparated: "/usr/lib/subdir/libobjc.A.dylib")
         }
     }
 
-    @Test func candidatesKeepKindMetadataOutOfMatchingRequirements() throws {
+    @Test func relativeSystemLibraryPathSelectorCanResolveCandidate() throws {
+        let candidate = try candidate(
+            "PreferenceBundles/Foo.bundle",
+            kind: .systemBundle
+        )
+        let resolver = PrivateHeaderGeneration.TargetResolver(candidates: [candidate])
+        let query = try PrivateHeaderGeneration.TargetQuery(commaSeparated: "PreferenceBundles/Foo.bundle")
+
+        #expect(resolver.resolve(query) == .selected(.targets([candidate])))
+    }
+
+    @Test func usrLibDylibPathSelectorCanResolveByInferredAlias() throws {
+        let candidate = try candidate(
+            "libobjc.A.dylib",
+            kind: .usrLibDylib
+        )
+        let resolver = PrivateHeaderGeneration.TargetResolver(candidates: [candidate])
+        let query = try PrivateHeaderGeneration.TargetQuery(commaSeparated: "/usr/lib/libobjc.A.dylib")
+
+        #expect(resolver.resolve(query) == .selected(.targets([candidate])))
+    }
+
+    @Test func candidatesKeepKindMetadataOutOfUserFacingSelectionRequirements() throws {
         let resolver = PrivateHeaderGeneration.TargetResolver(
             candidates: try [
                 candidate(

--- a/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationTargetResolverTests.swift
+++ b/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationTargetResolverTests.swift
@@ -153,6 +153,12 @@ struct PrivateHeaderGenerationTargetResolverTests {
         }
 
         #expect(throws: PrivateHeaderGeneration.ValidationError.self) {
+            _ = try PrivateHeaderGeneration.TargetQuery(
+                commaSeparated: "/System/Library/PreferenceBundles/../Foo.bundle"
+            )
+        }
+
+        #expect(throws: PrivateHeaderGeneration.ValidationError.self) {
             _ = try PrivateHeaderGeneration.TargetQuery(commaSeparated: "PreferenceBundles/./Foo.bundle")
         }
 
@@ -168,6 +174,20 @@ struct PrivateHeaderGenerationTargetResolverTests {
         )
         let resolver = PrivateHeaderGeneration.TargetResolver(candidates: [candidate])
         let query = try PrivateHeaderGeneration.TargetQuery(commaSeparated: "PreferenceBundles/Foo.bundle")
+
+        #expect(resolver.resolve(query) == .selected(.targets([candidate])))
+    }
+
+    @Test func absoluteSystemLibraryPathAliasCanResolveCandidate() throws {
+        let candidate = try candidate(
+            "PreferenceBundles/Foo.bundle",
+            kind: .systemBundle,
+            aliases: ["/System/Library/PreferenceBundles/Foo.bundle"]
+        )
+        let resolver = PrivateHeaderGeneration.TargetResolver(candidates: [candidate])
+        let query = try PrivateHeaderGeneration.TargetQuery(
+            commaSeparated: "/System/Library/PreferenceBundles/Foo.bundle"
+        )
 
         #expect(resolver.resolve(query) == .selected(.targets([candidate])))
     }

--- a/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationTargetResolverTests.swift
+++ b/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationTargetResolverTests.swift
@@ -1,0 +1,195 @@
+import Testing
+
+import PrivateHeaderKitCore
+
+@Suite
+struct PrivateHeaderGenerationTargetResolverTests {
+    @Test func commaSeparatedQueryResolvesTargetsInStableDeduplicatedOrder() throws {
+        let resolver = PrivateHeaderGeneration.TargetResolver(
+            candidates: try [
+                candidate("UIKitCore", kind: .framework),
+                candidate("SwiftUI", kind: .framework),
+                candidate("SafariShared", kind: .privateFramework),
+            ]
+        )
+        let query = try PrivateHeaderGeneration.TargetQuery(
+            commaSeparated: "SwiftUI, UIKitCore, SwiftUI"
+        )
+
+        #expect(
+            resolver.resolve(query) == .selected(
+                .targets(
+                    try [
+                        candidate("SwiftUI", kind: .framework),
+                        candidate("UIKitCore", kind: .framework),
+                    ]
+                )
+            )
+        )
+    }
+
+    @Test func exactMatchWinsOverPartialMatches() throws {
+        let exact = try candidate("UIKit", kind: .framework)
+        let resolver = PrivateHeaderGeneration.TargetResolver(
+            candidates: try [
+                candidate("UIKitCore", kind: .framework),
+                exact,
+                candidate("UIKitServices", kind: .privateFramework),
+            ]
+        )
+        let query = try PrivateHeaderGeneration.TargetQuery(commaSeparated: "UIKit")
+
+        #expect(resolver.resolve(query) == .selected(.targets([exact])))
+    }
+
+    @Test func partialMatchCanResolveSingleCandidate() throws {
+        let candidate = try candidate("SafariShared", kind: .privateFramework)
+        let resolver = PrivateHeaderGeneration.TargetResolver(
+            candidates: [
+                candidate,
+            ]
+        )
+        let query = try PrivateHeaderGeneration.TargetQuery(commaSeparated: "safari")
+
+        #expect(resolver.resolve(query) == .selected(.targets([candidate])))
+    }
+
+    @Test func ambiguousPartialMatchReturnsCandidatesForUISelection() throws {
+        let candidates = try [
+            candidate("UIKitCore", kind: .framework),
+            candidate("UIKitServices", kind: .privateFramework),
+        ]
+        let resolver = PrivateHeaderGeneration.TargetResolver(candidates: candidates)
+        let query = try PrivateHeaderGeneration.TargetQuery(commaSeparated: "UIKit")
+
+        #expect(
+            resolver.resolve(query) == .needsDisambiguation(
+                [
+                    PrivateHeaderGeneration.TargetResolution.Ambiguity(
+                        query: "UIKit",
+                        candidates: candidates
+                    ),
+                ]
+            )
+        )
+    }
+
+    @Test func noMatchReturnsStructuredFailure() throws {
+        let resolver = PrivateHeaderGeneration.TargetResolver(
+            candidates: try [
+                candidate("SwiftUI", kind: .framework),
+            ]
+        )
+        let query = try PrivateHeaderGeneration.TargetQuery(commaSeparated: "NoSuchTarget")
+
+        #expect(
+            resolver.resolve(query) == .failed(
+                [
+                    PrivateHeaderGeneration.TargetResolution.Failure(
+                        query: "NoSuchTarget",
+                        reason: .noMatch
+                    ),
+                ]
+            )
+        )
+    }
+
+    @Test func mixedAmbiguousAndMissingTermsKeepBothStructuredResults() throws {
+        let ambiguousCandidates = try [
+            candidate("UIKitCore", kind: .framework),
+            candidate("UIKitServices", kind: .privateFramework),
+        ]
+        let resolver = PrivateHeaderGeneration.TargetResolver(candidates: ambiguousCandidates)
+        let query = try PrivateHeaderGeneration.TargetQuery(commaSeparated: "UIKit, NoSuchTarget")
+
+        #expect(
+            resolver.resolve(query) == .unresolved(
+                ambiguities: [
+                    PrivateHeaderGeneration.TargetResolution.Ambiguity(
+                        query: "UIKit",
+                        candidates: ambiguousCandidates
+                    ),
+                ],
+                failures: [
+                    PrivateHeaderGeneration.TargetResolution.Failure(
+                        query: "NoSuchTarget",
+                        reason: .noMatch
+                    ),
+                ]
+            )
+        )
+    }
+
+    @Test func allAvailableQuerySupportsEnglishAndJapaneseAliases() throws {
+        let resolver = PrivateHeaderGeneration.TargetResolver(candidates: [])
+
+        #expect(
+            resolver.resolve(try PrivateHeaderGeneration.TargetQuery(commaSeparated: "all"))
+                == .selected(.allAvailable)
+        )
+        #expect(
+            resolver.resolve(try PrivateHeaderGeneration.TargetQuery(commaSeparated: "すべて"))
+                == .selected(.allAvailable)
+        )
+        #expect(
+            resolver.resolve(try PrivateHeaderGeneration.TargetQuery(commaSeparated: "@all"))
+                == .selected(.allAvailable)
+        )
+    }
+
+    @Test func allAvailableCannotBeMixedWithExplicitQueries() throws {
+        #expect(throws: PrivateHeaderGeneration.ValidationError.self) {
+            _ = try PrivateHeaderGeneration.TargetQuery(commaSeparated: "all, UIKitCore")
+        }
+    }
+
+    @Test func queryRejectsPathUnsafeTerms() throws {
+        #expect(throws: PrivateHeaderGeneration.ValidationError.self) {
+            _ = try PrivateHeaderGeneration.TargetQuery(commaSeparated: "../UIKitCore")
+        }
+
+        #expect(throws: PrivateHeaderGeneration.ValidationError.self) {
+            _ = try PrivateHeaderGeneration.TargetQuery(commaSeparated: "/usr/lib/libobjc.A.dylib")
+        }
+    }
+
+    @Test func candidatesKeepKindMetadataOutOfMatchingRequirements() throws {
+        let resolver = PrivateHeaderGeneration.TargetResolver(
+            candidates: try [
+                candidate(
+                    "libobjc.A.dylib",
+                    kind: .usrLibDylib,
+                    aliases: ["objc runtime"]
+                ),
+            ]
+        )
+        let query = try PrivateHeaderGeneration.TargetQuery(commaSeparated: "objc runtime")
+
+        #expect(
+            resolver.resolve(query) == .selected(
+                .targets(
+                    try [
+                        candidate(
+                            "libobjc.A.dylib",
+                            kind: .usrLibDylib,
+                            aliases: ["objc runtime"]
+                        ),
+                    ]
+                )
+            )
+        )
+    }
+}
+
+private func candidate(
+    _ displayName: String,
+    kind: PrivateHeaderGeneration.TargetKind,
+    aliases: [String] = []
+) throws -> PrivateHeaderGeneration.TargetCandidate {
+    try PrivateHeaderGeneration.TargetCandidate(
+        identifier: "target.\(displayName)",
+        displayName: displayName,
+        kind: kind,
+        aliases: aliases
+    )
+}


### PR DESCRIPTION
## Summary

Adds the rewrite target query/resolver foundation in `PrivateHeaderKitCore` without wiring it into the legacy CLI.

## Changes

- Add internal `PrivateHeaderGeneration` target resolver types for rewrite selection flow.
- Parse comma-separated target input with stable de-duping.
- Prefer exact matches over partial matches.
- Return structured no-match, ambiguity, and mixed unresolved results for UI disambiguation.
- Represent `all`, `@all`, and `すべて` as `TargetSelection.allAvailable`.
- Reject path-unsafe selectors while allowing safe documented target selectors such as `PreferenceBundles/Foo.bundle`, `/System/Library/...`, and `/usr/lib/<name>.dylib`.
- Preserve target kind metadata internally without exposing category selection as a user-facing requirement.

## Validation

- `git diff --check`
- `swift test`
- `codex-review` with base `main`: no findings

## Notes

This PR intentionally does not perform runtime filesystem discovery and does not connect the resolver to the legacy `--target` implementation.