### PR TITLE
feat(core): add state manifest models

### DIFF
--- a/Sources/PrivateHeaderKitCore/PrivateHeaderGenerationState.swift
+++ b/Sources/PrivateHeaderKitCore/PrivateHeaderGenerationState.swift
@@ -1,0 +1,376 @@
+import Foundation
+
+public extension PrivateHeaderGeneration {
+    enum Layout: String, Codable, CaseIterable, Hashable, Sendable {
+        case headers
+        case bundle
+    }
+
+    enum TargetStatus: String, Codable, CaseIterable, Hashable, Sendable {
+        case completed
+        case partial
+        case failed
+        case interrupted
+        case commitFailed
+        case stale
+    }
+
+    enum RunTargetStatus: String, Codable, CaseIterable, Hashable, Sendable {
+        case pending
+        case running
+        case skipped
+        case completed
+        case partial
+        case failed
+        case interrupted
+        case commitFailed
+    }
+
+    enum PhaseStatus: String, Codable, CaseIterable, Hashable, Sendable {
+        case pending
+        case running
+        case completed
+        case failed
+        case skipped
+    }
+
+    struct ArtifactPath: Codable, CustomStringConvertible, Hashable, Sendable {
+        public let rawValue: String
+
+        public init(_ rawValue: String) throws {
+            try Self.validate(rawValue)
+            self.rawValue = rawValue
+        }
+
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.singleValueContainer()
+            let rawValue = try container.decode(String.self)
+            try Self.validate(rawValue)
+            self.rawValue = rawValue
+        }
+
+        public func encode(to encoder: Encoder) throws {
+            var container = encoder.singleValueContainer()
+            try container.encode(rawValue)
+        }
+
+        public var description: String {
+            rawValue
+        }
+
+        private static func validate(_ rawValue: String) throws {
+            guard !rawValue.isEmpty else {
+                throw StateValidationError.emptyArtifactPath
+            }
+            guard !rawValue.hasPrefix("/") else {
+                throw StateValidationError.absoluteArtifactPath(rawValue)
+            }
+            guard !rawValue.contains("\0") else {
+                throw StateValidationError.invalidArtifactPath(rawValue)
+            }
+
+            let components = rawValue.split(separator: "/", omittingEmptySubsequences: false)
+            guard components.allSatisfy({ !$0.isEmpty && $0 != "." && $0 != ".." }) else {
+                throw StateValidationError.invalidArtifactPath(rawValue)
+            }
+        }
+    }
+
+    enum StateValidationError: Error, Equatable, CustomStringConvertible, Sendable {
+        case emptyArtifactPath
+        case absoluteArtifactPath(String)
+        case invalidArtifactPath(String)
+
+        public var description: String {
+            switch self {
+            case .emptyArtifactPath:
+                "artifact path must not be empty"
+            case .absoluteArtifactPath(let path):
+                "artifact path must be relative: \(path)"
+            case .invalidArtifactPath(let path):
+                "artifact path is not safe: \(path)"
+            }
+        }
+    }
+}
+
+public extension PrivateHeaderGeneration {
+    struct Manifest: Codable, Equatable, Sendable {
+        public let schemaVersion: Int
+        public let toolVersion: String
+        public let source: SourceRecord
+        public let output: OutputRecord
+        public let layout: Layout
+        public let latestRunID: String?
+        public let targets: [TargetRecord]
+        public let updatedAt: Date
+
+        public init(
+            schemaVersion: Int,
+            toolVersion: String,
+            source: SourceRecord,
+            output: OutputRecord,
+            layout: Layout,
+            latestRunID: String?,
+            targets: [TargetRecord],
+            updatedAt: Date
+        ) {
+            self.schemaVersion = schemaVersion
+            self.toolVersion = toolVersion
+            self.source = source
+            self.output = output
+            self.layout = layout
+            self.latestRunID = latestRunID
+            self.targets = targets
+            self.updatedAt = updatedAt
+        }
+    }
+
+    struct SourceRecord: Codable, Equatable, Sendable {
+        public let platform: Source.Platform
+        public let version: String
+        public let build: String?
+        public let displayName: String
+        public let directoryName: String
+
+        public init(source: Source) {
+            self.platform = source.platform
+            self.version = source.version
+            self.build = source.build
+            self.displayName = source.label.displayName
+            self.directoryName = source.label.directoryName
+        }
+    }
+
+    struct OutputRecord: Codable, Equatable, Sendable {
+        public let baseDirectory: String
+        public let artifactDirectory: String
+        public let stateDirectory: String
+
+        public init(
+            baseDirectory: String,
+            artifactDirectory: String,
+            stateDirectory: String
+        ) {
+            self.baseDirectory = baseDirectory
+            self.artifactDirectory = artifactDirectory
+            self.stateDirectory = stateDirectory
+        }
+
+        public init(plan: Plan, baseDirectory: URL) {
+            self.init(
+                baseDirectory: baseDirectory.path,
+                artifactDirectory: plan.artifactDirectory.path,
+                stateDirectory: plan.stateDirectory.path
+            )
+        }
+    }
+
+    struct TargetRecord: Codable, Equatable, Sendable {
+        public let id: String
+        public let displayName: String
+        public let kind: String
+        public let status: TargetStatus
+        public let phases: [PhaseRecord]
+        public let artifacts: [ArtifactPath]
+        public let lastRunID: String?
+        public let updatedAt: Date
+        public let failureSummary: String?
+
+        public init(
+            id: String,
+            displayName: String,
+            kind: String,
+            status: TargetStatus,
+            phases: [PhaseRecord],
+            artifacts: [ArtifactPath],
+            lastRunID: String?,
+            updatedAt: Date,
+            failureSummary: String?
+        ) {
+            self.id = id
+            self.displayName = displayName
+            self.kind = kind
+            self.status = status
+            self.phases = phases
+            self.artifacts = artifacts
+            self.lastRunID = lastRunID
+            self.updatedAt = updatedAt
+            self.failureSummary = failureSummary
+        }
+    }
+
+    struct PhaseRecord: Codable, Equatable, Sendable {
+        public let name: String
+        public let status: PhaseStatus
+        public let failureSummary: String?
+
+        public init(name: String, status: PhaseStatus, failureSummary: String? = nil) {
+            self.name = name
+            self.status = status
+            self.failureSummary = failureSummary
+        }
+    }
+}
+
+public extension PrivateHeaderGeneration {
+    struct RunRecord: Codable, Equatable, Sendable {
+        public let runID: String
+        public let schemaVersion: Int
+        public let toolVersion: String
+        public let plan: RunPlanRecord
+        public let startedAt: Date
+        public let endedAt: Date?
+        public let status: RunTargetStatus
+        public let targetResults: [RunTargetRecord]
+        public let attemptedArtifacts: [ArtifactPath]
+        public let logs: [RunLogRecord]
+
+        public init(
+            runID: String,
+            schemaVersion: Int,
+            toolVersion: String,
+            plan: RunPlanRecord,
+            startedAt: Date,
+            endedAt: Date?,
+            status: RunTargetStatus,
+            targetResults: [RunTargetRecord],
+            attemptedArtifacts: [ArtifactPath],
+            logs: [RunLogRecord]
+        ) {
+            self.runID = runID
+            self.schemaVersion = schemaVersion
+            self.toolVersion = toolVersion
+            self.plan = plan
+            self.startedAt = startedAt
+            self.endedAt = endedAt
+            self.status = status
+            self.targetResults = targetResults
+            self.attemptedArtifacts = attemptedArtifacts
+            self.logs = logs
+        }
+    }
+
+    struct RunPlanRecord: Codable, Equatable, Sendable {
+        public let source: SourceRecord
+        public let output: OutputRecord
+        public let layout: Layout
+        public let targetIDs: [String]
+
+        public init(
+            source: SourceRecord,
+            output: OutputRecord,
+            layout: Layout,
+            targetIDs: [String]
+        ) {
+            self.source = source
+            self.output = output
+            self.layout = layout
+            self.targetIDs = targetIDs
+        }
+    }
+
+    struct RunTargetRecord: Codable, Equatable, Sendable {
+        public let targetID: String
+        public let status: RunTargetStatus
+        public let phases: [PhaseRecord]
+        public let artifacts: [ArtifactPath]
+        public let attemptedArtifacts: [ArtifactPath]
+        public let failureSummary: String?
+
+        public init(
+            targetID: String,
+            status: RunTargetStatus,
+            phases: [PhaseRecord],
+            artifacts: [ArtifactPath],
+            attemptedArtifacts: [ArtifactPath],
+            failureSummary: String?
+        ) {
+            self.targetID = targetID
+            self.status = status
+            self.phases = phases
+            self.artifacts = artifacts
+            self.attemptedArtifacts = attemptedArtifacts
+            self.failureSummary = failureSummary
+        }
+    }
+
+    struct RunLogRecord: Codable, Equatable, Sendable {
+        public let kind: String
+        public let relativePath: ArtifactPath
+
+        public init(kind: String, relativePath: ArtifactPath) {
+            self.kind = kind
+            self.relativePath = relativePath
+        }
+    }
+}
+
+public extension PrivateHeaderGeneration {
+    enum StateJSON {
+        public static func encode<Value: Encodable>(_ value: Value) throws -> Data {
+            try encoder().encode(value)
+        }
+
+        public static func decode<Value: Decodable>(_ type: Value.Type, from data: Data) throws -> Value {
+            try decoder().decode(type, from: data)
+        }
+
+        public static func write<Value: Encodable>(_ value: Value, to url: URL) throws {
+            let data = try encode(value)
+            try data.write(to: url, options: [.atomic])
+        }
+
+        public static func read<Value: Decodable>(_ type: Value.Type, from url: URL) throws -> Value {
+            let data = try Data(contentsOf: url)
+            return try decode(type, from: data)
+        }
+
+        private static func encoder() -> JSONEncoder {
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+            encoder.dateEncodingStrategy = .iso8601
+            return encoder
+        }
+
+        private static func decoder() -> JSONDecoder {
+            let decoder = JSONDecoder()
+            decoder.dateDecodingStrategy = .iso8601
+            return decoder
+        }
+    }
+
+    struct RunSummary: Hashable, Sendable {
+        public let runID: String
+        public let startedAt: Date
+
+        public init(runID: String, startedAt: Date) {
+            self.runID = runID
+            self.startedAt = startedAt
+        }
+    }
+
+    enum RunHistoryRetention {
+        public static func retainedRunIDs(
+            from runs: [RunSummary],
+            limit: Int = 10
+        ) -> [String] {
+            guard limit > 0 else {
+                return []
+            }
+
+            return runs
+                .sorted {
+                    if $0.startedAt == $1.startedAt {
+                        $0.runID > $1.runID
+                    } else {
+                        $0.startedAt > $1.startedAt
+                    }
+                }
+                .prefix(limit)
+                .map(\.runID)
+        }
+    }
+}
+
+extension PrivateHeaderGeneration.Source.Platform: Codable {}

--- a/Sources/PrivateHeaderKitCore/PrivateHeaderGenerationState.swift
+++ b/Sources/PrivateHeaderKitCore/PrivateHeaderGenerationState.swift
@@ -329,14 +329,39 @@ public extension PrivateHeaderGeneration {
         private static func encoder() -> JSONEncoder {
             let encoder = JSONEncoder()
             encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
-            encoder.dateEncodingStrategy = .iso8601
+            encoder.dateEncodingStrategy = .custom { date, encoder in
+                var container = encoder.singleValueContainer()
+                try container.encode(fractionalSecondsFormatter().string(from: date))
+            }
             return encoder
         }
 
         private static func decoder() -> JSONDecoder {
             let decoder = JSONDecoder()
-            decoder.dateDecodingStrategy = .iso8601
+            decoder.dateDecodingStrategy = .custom { decoder in
+                let container = try decoder.singleValueContainer()
+                let value = try container.decode(String.self)
+                if let date = fractionalSecondsFormatter().date(from: value) ?? wholeSecondsFormatter().date(from: value) {
+                    return date
+                }
+                throw DecodingError.dataCorruptedError(
+                    in: container,
+                    debugDescription: "Invalid ISO 8601 date: \(value)"
+                )
+            }
             return decoder
+        }
+
+        private static func fractionalSecondsFormatter() -> ISO8601DateFormatter {
+            let formatter = ISO8601DateFormatter()
+            formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+            return formatter
+        }
+
+        private static func wholeSecondsFormatter() -> ISO8601DateFormatter {
+            let formatter = ISO8601DateFormatter()
+            formatter.formatOptions = [.withInternetDateTime]
+            return formatter
         }
     }
 

--- a/Sources/PrivateHeaderKitCore/PrivateHeaderGenerationState.swift
+++ b/Sources/PrivateHeaderKitCore/PrivateHeaderGenerationState.swift
@@ -331,7 +331,7 @@ public extension PrivateHeaderGeneration {
             encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
             encoder.dateEncodingStrategy = .custom { date, encoder in
                 var container = encoder.singleValueContainer()
-                try container.encode(fractionalSecondsFormatter().string(from: date))
+                try container.encode(date.timeIntervalSinceReferenceDate)
             }
             return encoder
         }
@@ -340,6 +340,9 @@ public extension PrivateHeaderGeneration {
             let decoder = JSONDecoder()
             decoder.dateDecodingStrategy = .custom { decoder in
                 let container = try decoder.singleValueContainer()
+                if let value = try? container.decode(Double.self) {
+                    return Date(timeIntervalSinceReferenceDate: value)
+                }
                 let value = try container.decode(String.self)
                 if let date = fractionalSecondsFormatter().date(from: value) ?? wholeSecondsFormatter().date(from: value) {
                     return date

--- a/Sources/PrivateHeaderKitCore/PrivateHeaderGenerationState.swift
+++ b/Sources/PrivateHeaderKitCore/PrivateHeaderGenerationState.swift
@@ -124,6 +124,29 @@ public extension PrivateHeaderGeneration {
             self.targets = targets
             self.updatedAt = updatedAt
         }
+
+        public func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode(schemaVersion, forKey: .schemaVersion)
+            try container.encode(toolVersion, forKey: .toolVersion)
+            try container.encode(source, forKey: .source)
+            try container.encode(output, forKey: .output)
+            try container.encode(layout, forKey: .layout)
+            try container.encodeRequired(latestRunID, forKey: .latestRunID)
+            try container.encode(targets, forKey: .targets)
+            try container.encode(updatedAt, forKey: .updatedAt)
+        }
+
+        private enum CodingKeys: String, CodingKey {
+            case schemaVersion
+            case toolVersion
+            case source
+            case output
+            case layout
+            case latestRunID
+            case targets
+            case updatedAt
+        }
     }
 
     struct SourceRecord: Codable, Equatable, Sendable {
@@ -139,6 +162,23 @@ public extension PrivateHeaderGeneration {
             self.build = source.build
             self.displayName = source.label.displayName
             self.directoryName = source.label.directoryName
+        }
+
+        public func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode(platform, forKey: .platform)
+            try container.encode(version, forKey: .version)
+            try container.encodeRequired(build, forKey: .build)
+            try container.encode(displayName, forKey: .displayName)
+            try container.encode(directoryName, forKey: .directoryName)
+        }
+
+        private enum CodingKeys: String, CodingKey {
+            case platform
+            case version
+            case build
+            case displayName
+            case directoryName
         }
     }
 
@@ -198,6 +238,31 @@ public extension PrivateHeaderGeneration {
             self.updatedAt = updatedAt
             self.failureSummary = failureSummary
         }
+
+        public func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode(id, forKey: .id)
+            try container.encode(displayName, forKey: .displayName)
+            try container.encode(kind, forKey: .kind)
+            try container.encode(status, forKey: .status)
+            try container.encode(phases, forKey: .phases)
+            try container.encode(artifacts, forKey: .artifacts)
+            try container.encodeRequired(lastRunID, forKey: .lastRunID)
+            try container.encode(updatedAt, forKey: .updatedAt)
+            try container.encodeRequired(failureSummary, forKey: .failureSummary)
+        }
+
+        private enum CodingKeys: String, CodingKey {
+            case id
+            case displayName
+            case kind
+            case status
+            case phases
+            case artifacts
+            case lastRunID
+            case updatedAt
+            case failureSummary
+        }
     }
 
     struct PhaseRecord: Codable, Equatable, Sendable {
@@ -209,6 +274,19 @@ public extension PrivateHeaderGeneration {
             self.name = name
             self.status = status
             self.failureSummary = failureSummary
+        }
+
+        public func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode(name, forKey: .name)
+            try container.encode(status, forKey: .status)
+            try container.encodeRequired(failureSummary, forKey: .failureSummary)
+        }
+
+        private enum CodingKeys: String, CodingKey {
+            case name
+            case status
+            case failureSummary
         }
     }
 }
@@ -248,6 +326,33 @@ public extension PrivateHeaderGeneration {
             self.targetResults = targetResults
             self.attemptedArtifacts = attemptedArtifacts
             self.logs = logs
+        }
+
+        public func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode(runID, forKey: .runID)
+            try container.encode(schemaVersion, forKey: .schemaVersion)
+            try container.encode(toolVersion, forKey: .toolVersion)
+            try container.encode(plan, forKey: .plan)
+            try container.encode(startedAt, forKey: .startedAt)
+            try container.encodeRequired(endedAt, forKey: .endedAt)
+            try container.encode(status, forKey: .status)
+            try container.encode(targetResults, forKey: .targetResults)
+            try container.encode(attemptedArtifacts, forKey: .attemptedArtifacts)
+            try container.encode(logs, forKey: .logs)
+        }
+
+        private enum CodingKeys: String, CodingKey {
+            case runID
+            case schemaVersion
+            case toolVersion
+            case plan
+            case startedAt
+            case endedAt
+            case status
+            case targetResults
+            case attemptedArtifacts
+            case logs
         }
     }
 
@@ -292,6 +397,25 @@ public extension PrivateHeaderGeneration {
             self.artifacts = artifacts
             self.attemptedArtifacts = attemptedArtifacts
             self.failureSummary = failureSummary
+        }
+
+        public func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode(targetID, forKey: .targetID)
+            try container.encode(status, forKey: .status)
+            try container.encode(phases, forKey: .phases)
+            try container.encode(artifacts, forKey: .artifacts)
+            try container.encode(attemptedArtifacts, forKey: .attemptedArtifacts)
+            try container.encodeRequired(failureSummary, forKey: .failureSummary)
+        }
+
+        private enum CodingKeys: String, CodingKey {
+            case targetID
+            case status
+            case phases
+            case artifacts
+            case attemptedArtifacts
+            case failureSummary
         }
     }
 
@@ -402,3 +526,13 @@ public extension PrivateHeaderGeneration {
 }
 
 extension PrivateHeaderGeneration.Source.Platform: Codable {}
+
+private extension KeyedEncodingContainer {
+    mutating func encodeRequired<Value: Encodable>(_ value: Value?, forKey key: Key) throws {
+        if let value {
+            try encode(value, forKey: key)
+        } else {
+            try encodeNil(forKey: key)
+        }
+    }
+}

--- a/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationStateTests.swift
+++ b/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationStateTests.swift
@@ -41,7 +41,8 @@ struct PrivateHeaderGenerationManifestTests {
     }
 
     @Test func stateJSONPreservesFractionalSecondDates() throws {
-        let manifest = try makeManifest(updatedAt: Date(timeIntervalSince1970: 1_000.123))
+        let updatedAt = Date(timeIntervalSinceReferenceDate: .pi)
+        let manifest = try makeManifest(updatedAt: updatedAt)
 
         let data = try PrivateHeaderGeneration.StateJSON.encode(manifest)
         let json = try #require(String(data: data, encoding: .utf8))
@@ -51,7 +52,7 @@ struct PrivateHeaderGenerationManifestTests {
         )
 
         #expect(decoded.updatedAt == manifest.updatedAt)
-        #expect(json.contains("\"updatedAt\" : \"1970-01-01T00:16:40.123Z\""))
+        #expect(json.contains("\"updatedAt\" : 3.141592653589793"))
     }
 
     @Test func artifactPathRejectsAbsoluteTraversalAndEmptyPaths() {

--- a/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationStateTests.swift
+++ b/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationStateTests.swift
@@ -55,6 +55,58 @@ struct PrivateHeaderGenerationManifestTests {
         #expect(json.contains("\"updatedAt\" : 3.141592653589793"))
     }
 
+    @Test func manifestEncodingKeepsRequiredNullFields() throws {
+        let source = try PrivateHeaderGeneration.Source(
+            platform: .iOS,
+            version: "27.0",
+            build: nil
+        )
+        let updatedAt = Date(timeIntervalSinceReferenceDate: 42)
+        let manifest = PrivateHeaderGeneration.Manifest(
+            schemaVersion: 1,
+            toolVersion: "0.1.0",
+            source: PrivateHeaderGeneration.SourceRecord(source: source),
+            output: PrivateHeaderGeneration.OutputRecord(
+                baseDirectory: "/tmp/PrivateHeaderKit",
+                artifactDirectory: "/tmp/PrivateHeaderKit/generated-headers",
+                stateDirectory: "/tmp/PrivateHeaderKit/.state"
+            ),
+            layout: .headers,
+            latestRunID: nil,
+            targets: [
+                PrivateHeaderGeneration.TargetRecord(
+                    id: "framework:Foo",
+                    displayName: "Foo.framework",
+                    kind: "framework",
+                    status: .completed,
+                    phases: [
+                        PrivateHeaderGeneration.PhaseRecord(name: "static ObjC", status: .completed),
+                    ],
+                    artifacts: [
+                        try PrivateHeaderGeneration.ArtifactPath("Frameworks/Foo/Foo.h"),
+                    ],
+                    lastRunID: nil,
+                    updatedAt: updatedAt,
+                    failureSummary: nil
+                ),
+            ],
+            updatedAt: updatedAt
+        )
+
+        let data = try PrivateHeaderGeneration.StateJSON.encode(manifest)
+        let json = try #require(String(data: data, encoding: .utf8))
+        let decoded = try PrivateHeaderGeneration.StateJSON.decode(
+            PrivateHeaderGeneration.Manifest.self,
+            from: data
+        )
+
+        #expect(decoded == manifest)
+        #expect(json.contains("\"build\" : null"))
+        #expect(json.contains("\"latestRunID\" : null"))
+        #expect(json.contains("\"lastRunID\" : null"))
+        #expect(json.contains("\"failureSummary\" : null"))
+    }
+
     @Test func artifactPathRejectsAbsoluteTraversalAndEmptyPaths() {
         #expect(throws: PrivateHeaderGeneration.StateValidationError.self) {
             _ = try PrivateHeaderGeneration.ArtifactPath("/System/Library/Foo.h")
@@ -93,6 +145,49 @@ struct PrivateHeaderGenerationRunRecordTests {
         #expect(decoded.status == .partial)
         #expect(decoded.targetResults.first?.status == .commitFailed)
         #expect(decoded.attemptedArtifacts.map(\.rawValue) == ["Frameworks/Foo/Foo.h"])
+    }
+
+    @Test func runRecordEncodingKeepsRequiredNullFields() throws {
+        let manifest = try makeManifest()
+        let run = PrivateHeaderGeneration.RunRecord(
+            runID: "run-002",
+            schemaVersion: 1,
+            toolVersion: "0.1.0",
+            plan: PrivateHeaderGeneration.RunPlanRecord(
+                source: manifest.source,
+                output: manifest.output,
+                layout: manifest.layout,
+                targetIDs: ["framework:Foo"]
+            ),
+            startedAt: Date(timeIntervalSinceReferenceDate: 42),
+            endedAt: nil,
+            status: .running,
+            targetResults: [
+                PrivateHeaderGeneration.RunTargetRecord(
+                    targetID: "framework:Foo",
+                    status: .running,
+                    phases: [
+                        PrivateHeaderGeneration.PhaseRecord(name: "static ObjC", status: .running),
+                    ],
+                    artifacts: [],
+                    attemptedArtifacts: [],
+                    failureSummary: nil
+                ),
+            ],
+            attemptedArtifacts: [],
+            logs: []
+        )
+
+        let data = try PrivateHeaderGeneration.StateJSON.encode(run)
+        let json = try #require(String(data: data, encoding: .utf8))
+        let decoded = try PrivateHeaderGeneration.StateJSON.decode(
+            PrivateHeaderGeneration.RunRecord.self,
+            from: data
+        )
+
+        #expect(decoded == run)
+        #expect(json.contains("\"endedAt\" : null"))
+        #expect(json.contains("\"failureSummary\" : null"))
     }
 
     @Test func runHistoryRetentionKeepsLatestTenRuns() {

--- a/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationStateTests.swift
+++ b/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationStateTests.swift
@@ -1,0 +1,208 @@
+import Foundation
+import Testing
+
+import PrivateHeaderKitCore
+
+@Suite
+struct PrivateHeaderGenerationManifestTests {
+    @Test func manifestRoundTripsAsPrettyJSON() throws {
+        let manifest = try makeManifest()
+
+        let data = try PrivateHeaderGeneration.StateJSON.encode(manifest)
+        let json = try #require(String(data: data, encoding: .utf8))
+        let decoded = try PrivateHeaderGeneration.StateJSON.decode(
+            PrivateHeaderGeneration.Manifest.self,
+            from: data
+        )
+
+        #expect(decoded == manifest)
+        #expect(json.contains("\n  \"layout\" : \"headers\""))
+        #expect(json.contains("\"schemaVersion\" : 1"))
+        #expect(json.contains("\"artifacts\" : [\n"))
+    }
+
+    @Test func manifestStoreWritesAndReadsJSON() throws {
+        let manifest = try makeManifest()
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("PrivateHeaderKitStateTests-\(UUID().uuidString)", isDirectory: true)
+        let url = directory.appendingPathComponent("manifest.json")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer {
+            try? FileManager.default.removeItem(at: directory)
+        }
+
+        try PrivateHeaderGeneration.StateJSON.write(manifest, to: url)
+        let decoded = try PrivateHeaderGeneration.StateJSON.read(
+            PrivateHeaderGeneration.Manifest.self,
+            from: url
+        )
+
+        #expect(decoded == manifest)
+    }
+
+    @Test func artifactPathRejectsAbsoluteTraversalAndEmptyPaths() {
+        #expect(throws: PrivateHeaderGeneration.StateValidationError.self) {
+            _ = try PrivateHeaderGeneration.ArtifactPath("/System/Library/Foo.h")
+        }
+        #expect(throws: PrivateHeaderGeneration.StateValidationError.self) {
+            _ = try PrivateHeaderGeneration.ArtifactPath("Frameworks/../Foo.h")
+        }
+        #expect(throws: PrivateHeaderGeneration.StateValidationError.self) {
+            _ = try PrivateHeaderGeneration.ArtifactPath("")
+        }
+    }
+
+    @Test func artifactPathValidationRunsDuringJSONDecode() throws {
+        let data = Data(#""../escape.h""#.utf8)
+
+        #expect(throws: PrivateHeaderGeneration.StateValidationError.self) {
+            _ = try PrivateHeaderGeneration.StateJSON.decode(
+                PrivateHeaderGeneration.ArtifactPath.self,
+                from: data
+            )
+        }
+    }
+}
+
+@Suite
+struct PrivateHeaderGenerationRunRecordTests {
+    @Test func runRecordRoundTripsTargetResultsAndAttemptedArtifacts() throws {
+        let run = try makeRunRecord()
+        let data = try PrivateHeaderGeneration.StateJSON.encode(run)
+        let decoded = try PrivateHeaderGeneration.StateJSON.decode(
+            PrivateHeaderGeneration.RunRecord.self,
+            from: data
+        )
+
+        #expect(decoded == run)
+        #expect(decoded.status == .partial)
+        #expect(decoded.targetResults.first?.status == .commitFailed)
+        #expect(decoded.attemptedArtifacts.map(\.rawValue) == ["Frameworks/Foo/Foo.h"])
+    }
+
+    @Test func runHistoryRetentionKeepsLatestTenRuns() {
+        let base = Date(timeIntervalSince1970: 1_000)
+        let runs = (0..<12).map { index in
+            PrivateHeaderGeneration.RunSummary(
+                runID: "run-\(index)",
+                startedAt: base.addingTimeInterval(TimeInterval(index))
+            )
+        }
+
+        let retained = PrivateHeaderGeneration.RunHistoryRetention.retainedRunIDs(from: runs)
+
+        #expect(retained == [
+            "run-11",
+            "run-10",
+            "run-9",
+            "run-8",
+            "run-7",
+            "run-6",
+            "run-5",
+            "run-4",
+            "run-3",
+            "run-2",
+        ])
+    }
+
+    @Test func runHistoryRetentionUsesRunIDAsStableTieBreaker() {
+        let startedAt = Date(timeIntervalSince1970: 1_000)
+        let runs = [
+            PrivateHeaderGeneration.RunSummary(runID: "run-a", startedAt: startedAt),
+            PrivateHeaderGeneration.RunSummary(runID: "run-c", startedAt: startedAt),
+            PrivateHeaderGeneration.RunSummary(runID: "run-b", startedAt: startedAt),
+        ]
+
+        let retained = PrivateHeaderGeneration.RunHistoryRetention.retainedRunIDs(from: runs, limit: 2)
+
+        #expect(retained == ["run-c", "run-b"])
+    }
+}
+
+private func makeManifest() throws -> PrivateHeaderGeneration.Manifest {
+    let source = try PrivateHeaderGeneration.Source(
+        platform: .iOS,
+        version: "27.0",
+        build: "24A5355q"
+    )
+    let root = URL(fileURLWithPath: "/tmp/PrivateHeaderKit", isDirectory: true)
+    let output = PrivateHeaderGeneration.Output(
+        artifactBaseDirectory: root.appendingPathComponent("generated-headers", isDirectory: true),
+        stateBaseDirectory: root.appendingPathComponent(".state", isDirectory: true)
+    )
+    let plan = PrivateHeaderGeneration.makePlan(source: source, output: output)
+    let updatedAt = Date(timeIntervalSince1970: 1_000)
+
+    return PrivateHeaderGeneration.Manifest(
+        schemaVersion: 1,
+        toolVersion: "0.1.0",
+        source: PrivateHeaderGeneration.SourceRecord(source: source),
+        output: PrivateHeaderGeneration.OutputRecord(plan: plan, baseDirectory: root),
+        layout: .headers,
+        latestRunID: "run-001",
+        targets: [
+            PrivateHeaderGeneration.TargetRecord(
+                id: "framework:Foo",
+                displayName: "Foo.framework",
+                kind: "framework",
+                status: .partial,
+                phases: [
+                    PrivateHeaderGeneration.PhaseRecord(name: "static ObjC", status: .completed),
+                    PrivateHeaderGeneration.PhaseRecord(
+                        name: "Swift interface",
+                        status: .failed,
+                        failureSummary: "swift interface failed"
+                    ),
+                ],
+                artifacts: [
+                    try PrivateHeaderGeneration.ArtifactPath("Frameworks/Foo/Foo.h"),
+                    try PrivateHeaderGeneration.ArtifactPath("Frameworks/Foo/Foo.swiftinterface"),
+                ],
+                lastRunID: "run-001",
+                updatedAt: updatedAt,
+                failureSummary: "swift interface failed"
+            ),
+        ],
+        updatedAt: updatedAt
+    )
+}
+
+private func makeRunRecord() throws -> PrivateHeaderGeneration.RunRecord {
+    let manifest = try makeManifest()
+    let artifact = try PrivateHeaderGeneration.ArtifactPath("Frameworks/Foo/Foo.h")
+    let plan = PrivateHeaderGeneration.RunPlanRecord(
+        source: manifest.source,
+        output: manifest.output,
+        layout: manifest.layout,
+        targetIDs: ["framework:Foo"]
+    )
+
+    return PrivateHeaderGeneration.RunRecord(
+        runID: "run-001",
+        schemaVersion: 1,
+        toolVersion: "0.1.0",
+        plan: plan,
+        startedAt: Date(timeIntervalSince1970: 1_000),
+        endedAt: Date(timeIntervalSince1970: 1_100),
+        status: .partial,
+        targetResults: [
+            PrivateHeaderGeneration.RunTargetRecord(
+                targetID: "framework:Foo",
+                status: .commitFailed,
+                phases: [
+                    PrivateHeaderGeneration.PhaseRecord(name: "commit", status: .failed),
+                ],
+                artifacts: [],
+                attemptedArtifacts: [artifact],
+                failureSummary: "commit failed"
+            ),
+        ],
+        attemptedArtifacts: [artifact],
+        logs: [
+            PrivateHeaderGeneration.RunLogRecord(
+                kind: "stderr",
+                relativePath: try PrivateHeaderGeneration.ArtifactPath("runs/run-001/logs/stderr.log")
+            ),
+        ]
+    )
+}

--- a/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationStateTests.swift
+++ b/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationStateTests.swift
@@ -40,6 +40,20 @@ struct PrivateHeaderGenerationManifestTests {
         #expect(decoded == manifest)
     }
 
+    @Test func stateJSONPreservesFractionalSecondDates() throws {
+        let manifest = try makeManifest(updatedAt: Date(timeIntervalSince1970: 1_000.123))
+
+        let data = try PrivateHeaderGeneration.StateJSON.encode(manifest)
+        let json = try #require(String(data: data, encoding: .utf8))
+        let decoded = try PrivateHeaderGeneration.StateJSON.decode(
+            PrivateHeaderGeneration.Manifest.self,
+            from: data
+        )
+
+        #expect(decoded.updatedAt == manifest.updatedAt)
+        #expect(json.contains("\"updatedAt\" : \"1970-01-01T00:16:40.123Z\""))
+    }
+
     @Test func artifactPathRejectsAbsoluteTraversalAndEmptyPaths() {
         #expect(throws: PrivateHeaderGeneration.StateValidationError.self) {
             _ = try PrivateHeaderGeneration.ArtifactPath("/System/Library/Foo.h")
@@ -119,7 +133,9 @@ struct PrivateHeaderGenerationRunRecordTests {
     }
 }
 
-private func makeManifest() throws -> PrivateHeaderGeneration.Manifest {
+private func makeManifest(
+    updatedAt: Date = Date(timeIntervalSince1970: 1_000)
+) throws -> PrivateHeaderGeneration.Manifest {
     let source = try PrivateHeaderGeneration.Source(
         platform: .iOS,
         version: "27.0",
@@ -131,8 +147,6 @@ private func makeManifest() throws -> PrivateHeaderGeneration.Manifest {
         stateBaseDirectory: root.appendingPathComponent(".state", isDirectory: true)
     )
     let plan = PrivateHeaderGeneration.makePlan(source: source, output: output)
-    let updatedAt = Date(timeIntervalSince1970: 1_000)
-
     return PrivateHeaderGeneration.Manifest(
         schemaVersion: 1,
         toolVersion: "0.1.0",


### PR DESCRIPTION
Purpose

Add the state and manifest foundation for the PrivateHeaderKit rewrite without wiring it into the legacy CLI or dump execution path.

Changes

- Add PrivateHeaderGeneration manifest and run record models for persisted rewrite state.
- Add target, run-local, and phase status enums required by the rewrite flow.
- Add validated relative artifact paths that reject absolute paths, empty paths, and traversal components.
- Add pretty JSON encode/decode/read/write helpers with exact Date round-trip precision.
- Add run history retention logic for keeping the latest 10 runs.
- Cover manifest/run JSON round-trips, Date precision, artifact path validation, store read/write, and retention behavior.

Testing

- git diff --check origin/main...HEAD
- swift test
- codex-review against main: no findings