### PR TITLE
Build rewrite foundation

### DIFF
--- a/Docs/RewriteRequirements.md
+++ b/Docs/RewriteRequirements.md
@@ -1,0 +1,436 @@
+# PrivateHeaderKit Rewrite Requirements
+
+この文書は PrivateHeaderKit を破壊的変更前提で作り直すための要件を固定する。既存 CLI/API 互換より、実行の再現性、resume 可能性、最大情報取得、CI/自動化との相性を優先する。
+
+## Goals
+
+- ユーザーが直接使うコマンド成果物は 1 つにする。
+- iOS simulator runtime から取得できる情報量を最大化するため、内部 helper は維持する。
+- interactive wizard は first-class にする。ただし CI/自動化では interactive を要求しない。
+- dump artifact と管理情報を分離し、通常の `rg` で state/log/manifest が混ざらないようにする。
+- 中断、失敗、partial 成果物を明示的に管理し、build/source 単位で安全に resume できるようにする。
+- SwiftUI/ObservationBridge 風に、公開 API は薄い top-level entry と namespace 型に整理する。
+
+## Non-Goals
+
+- 旧 CLI option の完全互換は目標にしない。
+- `quality` のような情報量を落とす mode は持たない。常に最大取得を試みる。
+- ユーザーに安定 ID や内部 target identity を指定させない。
+- `SystemLibrary` や `/usr/lib dylib` などの内部分類を通常 UI の選択肢として見せない。
+
+## Public Surface
+
+### Command
+
+- 公開する user-facing executable product は 1 つにする。
+- 推奨名は `privateheaderkit`。
+- 旧 `privateheaderkit-dump` / `headerdump` / `headerdump-sim` は公開 surface から外す。
+- simulator 内で動く helper は内部実装として維持する。最大情報取得のため、runtime Objective-C fallback などを担当する。
+
+Breaking changes from current CLI:
+
+- 現行の複数 executable product は 1 つへ統合する。
+- 現行の `privateheaderkit-dump <version>` style は廃止し、source selection は explicit option または wizard で扱う。
+- `--list-runtimes`, `--list-devices`, `--json`, `--platform`, `--out`, `--target` は新 CLI surface として再設計する。
+- legacy `--framework`, `--filter`, `--scope` は互換維持を目的に残さない。必要なら migration note だけ書く。
+- 旧 default scope の Frameworks/PrivateFrameworks only から、新しい `すべて` は SystemLibrary bundles、`/usr/lib` dylibs、nested bundles まで含む。
+
+### Swift API Shape
+
+ObservationBridge のように、公開 API は小さく保つ。
+
+- top-level function: `generatePrivateHeaders(...)`
+- namespace 型: `PrivateHeaderGeneration`
+- nested types: `PrivateHeaderGeneration.Options`, `PrivateHeaderGeneration.Result`, `PrivateHeaderGeneration.Target`, `PrivateHeaderGeneration.Source`
+- long-running operation を公開する必要がある場合は `PrivateHeaderGeneration.Token` を使い、`cancel()` を持たせる。
+- 内部 target は `_PrivateHeaderKit...` prefix で隠す。
+
+## Source Identity
+
+Source は resume と出力ディレクトリの単位になる。
+
+- 表示名: `iOS 27.0 (24A5355q)`
+- ディレクトリ名: `iOS27.0(24A5355q)`
+- macOS も同じ規則にする: `macOS26.5(25F...)`
+- iOS runtime の version/build は `xcrun simctl list runtimes -j` の `version` と `buildversion` を使う。
+- 同じ iOS version でも build が違えば別 source として扱う。
+
+## Output Layout
+
+default:
+
+```text
+~/PrivateHeaderKit/
+  generated-headers/
+    iOS27.0(24A5355q)/
+      ...
+  .state/
+    iOS27.0(24A5355q)/
+      manifest.json
+      runs/
+        <run-id>/
+          run.json
+          logs/
+          staging/
+```
+
+custom output base:
+
+```text
+/Volumes/Data/Headers/
+  iOS27.0(24A5355q)/
+    ...
+  .state/
+    iOS27.0(24A5355q)/
+      manifest.json
+      runs/
+```
+
+Rules:
+
+- `--out` and `PH_OUT_DIR` は artifact root ではなく output base directory として扱う。
+- artifact は常に `<artifact-base>/<source-label>/` に置く。
+- default の artifact base は `~/PrivateHeaderKit/generated-headers`、state base は `~/PrivateHeaderKit/.state` とする。
+- custom output の場合は、artifact base と state base を同じ指定 directory の下に置く。artifact は `<output-base>/<source-label>/`、state は `<output-base>/.state/<source-label>/`。
+- state/log/staging は artifact tree の中に置かない。
+
+## Interactive Flow
+
+Command with no non-interactive target enters wizard.
+
+1. Source selection
+   - available runtimes を表示する。
+   - `iOS 27.0 (24A5355q)` のように space ありで表示する。
+   - Enter default は持たない。空入力は `入力してください` として再入力。
+2. Target selection
+   - `[1] すべて`
+   - `[2] 個別に選ぶ`
+   - `[3] キャンセル`
+3. Individual target input
+   - comma-separated text input。
+   - partial match を許可する。
+   - no match は候補なしとして再入力。
+   - ambiguous match は候補一覧を出し、番号入力で解決する。
+   - 複数候補を選べる。`all` 相当も許可する。
+4. Output plan
+   - source, output path, selected target count を表示する。
+5. Existing state/output check
+   - unfinished compatible run があれば resume screen を出す。
+   - unfinished run がなく、既存 completed artifact があれば existing output screen を出す。
+6. Final confirmation
+   - `すべて` の場合は target count と output path を出して開始確認する。
+   - destructive rebuild の場合は削除対象 target 数を出して明示確認する。
+7. Run progress
+   - current target と phase を表示する。
+   - phase examples: `static ObjC`, `runtime ObjC`, `Swift interface`, `nested bundles`, `commit`
+8. Summary
+   - output path
+   - `Completed`, `Partial`, `Failed`, `Skipped`
+   - first 20 failures
+   - manifest path
+
+Keyboard behavior:
+
+- `Esc` は 1 screen 戻る。
+- first screen での `Esc` は cancel。
+- 戻った場合も入力済み state は保持する。
+- `Ctrl-C` before run は exit。
+- `Ctrl-C` during run は current target を `interrupted` として記録し、次回 resume で target 全体を再実行する。
+
+## Target Semantics
+
+- `すべて` は内部的に current `@all` 相当を意味する。
+- 対象には Frameworks、PrivateFrameworks、SystemLibrary bundles、`/usr/lib` dylibs、nested bundles を含める。
+- ユーザー向け UI では分類を選ばせず、必要なら summary として件数だけ表示する。
+- target identity は内部で安定化するが、ユーザーには名前/partial match で入力させる。
+
+## Non-Interactive Behavior
+
+- CI/script では interactive prompt を出さない。
+- unfinished compatible run がある場合は error にし、明示的な `--resume` を要求する。
+- `--resume` は compatible run の incomplete targets を再実行する。
+- `--fresh` またはそれに相当する explicit option は、選択 target の既存 managed artifacts を消して再作成する。
+- destructive option は non-interactive でも明示されている場合だけ実行する。
+- failures/partials があれば exit code は non-zero。
+
+## Resume Rules
+
+Resume は source label/build 単位で管理する。
+
+Compatible run の条件:
+
+- same source label
+- same output base
+- same selected target set
+- same layout
+- manifest schema が読み取れる
+
+Not compatible:
+
+- runtime build が違う
+- selected target set が違う
+- layout が違う
+- manifest schema がサポート外
+
+Unfinished compatible run screen:
+
+```text
+前回の実行が途中で終了しています。
+
+Source: iOS 27.0 (24A5355q)
+Output: ~/PrivateHeaderKit/generated-headers/iOS27.0(24A5355q)
+Targets: all (1842)
+Started: 2026-06-18 12:25:10
+Updated: 2026-06-18 13:14:02
+Completed: 1310, Partial: 4, Failed: 12, Pending: 516
+
+[1] 続きから実行
+[2] 最初から実行
+[3] キャンセル
+```
+
+Rules:
+
+- completed target は resume で skip する。
+- failed target は resume で retry する。
+- partial target は target 全体を再実行する。
+- interrupted target は target 全体を再実行する。
+- commitFailed target は cleanup して target 全体を再実行する。
+- 「最初から実行」は selected target の managed artifacts と previous staging/log を片付けてから開始する。
+
+Existing completed output screen:
+
+```text
+既存の出力があります。
+
+Source: iOS 27.0 (24A5355q)
+Output: ~/PrivateHeaderKit/generated-headers/iOS27.0(24A5355q)
+Completed: 1842, Partial: 0, Failed: 0
+
+[1] 不足分だけ実行
+[2] 最初から作り直す
+[3] キャンセル
+```
+
+Rules:
+
+- all complete なら `[1]` は no-op summary を出して終了する。
+- `[2]` は selected targets の managed artifacts だけを削除する。
+- unknown user files は削除しない。
+
+## State Files
+
+### `manifest.json`
+
+Pretty JSON で書く。source label 単位の latest state を表す。
+
+Required fields:
+
+- `schemaVersion`
+- `toolVersion`
+- `source`
+  - `platform`
+  - `version`
+  - `build`
+  - `displayName`
+  - `directoryName`
+- `output`
+  - `baseDirectory`
+  - `artifactDirectory`
+  - `stateDirectory`
+- `layout`
+- `latestRunID`
+- `targets`
+- `updatedAt`
+
+Each target entry:
+
+- `id`
+- `displayName`
+- `kind`
+- `status`
+- `phases`
+- `artifacts`
+- `lastRunID`
+- `updatedAt`
+- `failureSummary`
+
+Artifacts:
+
+- all generated `.h` and `.swiftinterface` relative paths are stored.
+- `completed` 判定は manifest entry だけで行わない。manifest-managed artifact の実体が存在し、少なくとも期待される `.h` または `.swiftinterface` があることを確認する。
+- cleanup/recreate only deletes manifest-managed paths.
+- unknown files are preserved.
+- after deleting files, empty parent directories are removed up to artifact root.
+
+### `run.json`
+
+Run 単位の immutable-ish record として扱う。
+
+Required fields:
+
+- `runID`
+- `schemaVersion`
+- `toolVersion`
+- `plan`
+- `startedAt`
+- `endedAt`
+- `status`
+- `targetResults`
+- `attemptedArtifacts`
+- `logs`
+
+Rules:
+
+- `runs/<run-id>/staging/` に生成してから commit する。
+- runtime root や `/System/Cryptexes` から staging へ出た artifact は、現行の relocation/rebase semantics を維持して final artifact path へ正規化する。
+- run history は latest 10 件だけ保持する。
+- old run cleanup は command startup で行う。
+- old run cleanup は `runs/<old-run-id>/` の logs/staging/run.json を削除する。
+- latest target state は `manifest.json` に残す。
+
+## Target Status
+
+Manifest target statuses:
+
+- `completed`
+- `partial`
+- `failed`
+- `interrupted`
+- `commitFailed`
+- `stale`
+
+Run-local statuses:
+
+- `pending`
+- `running`
+- `skipped`
+- `completed`
+- `partial`
+- `failed`
+- `interrupted`
+- `commitFailed`
+
+Phase statuses:
+
+- `pending`
+- `running`
+- `completed`
+- `failed`
+- `skipped`
+
+Partial definition:
+
+- target の一部 artifact は生成できたが、required phase の一部が失敗した状態。
+- `Swift interface` 失敗も partial として扱う。
+- nested bundle の失敗は親 target を無条件に completed にしない。親 target は `partial` または `failed` として扱い、resume で target 全体を再実行する。
+- partial は success ではないため exit code は non-zero。
+
+## Commit Transaction
+
+Per target:
+
+1. cleanup stale staging for target/run
+2. generate into `runs/<run-id>/staging/<target-id>/`
+3. collect attempted artifacts
+4. if generation failed before commit, keep old final artifacts untouched
+5. if generation succeeded, delete old manifest-managed final artifacts for target
+6. move/copy staging artifacts into final artifact directory
+7. write manifest target entry
+
+Commit failure:
+
+- target status becomes `commitFailed`
+- `run.json` records attempted final artifact paths
+- next resume cleans manifest-managed artifacts plus attempted paths before re-running target
+
+## Error Handling
+
+- Per-target failure is recorded and execution continues.
+- Summary shows first 20 failures.
+- Full failure details live in `run.json` and logs.
+- Any `failed`, `partial`, `interrupted`, or `commitFailed` result makes exit code non-zero.
+- No silent success with missing Swift interface when Swift extraction was expected.
+
+## Simulator Execution
+
+- helper は internal implementation detail として扱うが、runtime Objective-C fallback のため simulator process で実行できる状態を維持する。
+- resume state には、source identity だけでなく、実行に使った simulator runtime/device/clone policy/execution mode を記録する。
+- 再開時に同じ device が使えない場合は、source identity と plan compatibility を保ったまま代替 device を選び、run record に記録する。
+- `SIMCTL_CHILD_*` を含む helper 実行 environment は plan/run に残し、再現性を確保する。
+- simulator helper が実行できない場合の host fallback は、target result に fallback として記録する。fallback により情報量が落ちる場合は `partial` または warning として summary に出す。
+
+## Layout and Migration
+
+- 新 rewrite の primary layout は 1 つに寄せる。
+- 旧 `headers` / `bundle` layout のどちらを継続するかは implementation PR の初期 contract で固定する。
+- 旧 artifact tree の自動移行は必須にしない。
+- 既存 artifact が新 manifest で管理されていない場合は unknown file として扱い、destructive rebuild でも削除しない。
+- 旧 output path `~/PrivateHeaderKit/generated-headers/iOS/<version>` は新 source label path と別物として扱う。必要なら README に migration note を書く。
+
+## Implementation Split
+
+Initial worker PRs should avoid overlapping write ownership.
+
+0. Ownership boundary PR
+   - owner: `Package.swift`, new target skeletons, initial test file split
+   - goal: reduce conflicts before parallel implementation
+1. Requirements/docs baseline
+   - owner: `Docs/RewriteRequirements.md`, README follow-up notes only
+2. Core API and plan contracts
+   - owner: new `Sources/PrivateHeaderKitCore/*`, contract tests
+   - includes: `PrivateHeaderGeneration`, source identity, target identity, dump plan
+3. State model and persistence
+   - owner: new state module/files, manifest/run JSON tests
+4. Source/runtime discovery and label formatting
+   - owner: simctl parsing, source identity tests
+5. Target discovery and resolver
+   - owner: target model, `all`, comma input resolver, ambiguity tests
+6. Transactional executor
+   - owner: staging/commit/cleanup, status transitions
+7. Interactive wizard
+   - owner: prompt screens, Esc navigation, input retention
+8. CLI integration
+   - owner: public command, non-interactive flags, exit codes
+9. Header extraction/helper integration
+   - owner: internal host/simulator helper boundary
+10. Install/docs compatibility
+   - owner: install command/docs after behavior is stable
+
+Shared-file rules:
+
+- `Package.swift` is owned by the ownership boundary PR first; later worker PRs should avoid touching it unless explicitly assigned.
+- `Sources/PrivateHeaderKitDump/PrivateHeaderKitDumpMain.swift` is the largest conflict source. Extract pure types/functions into new modules early, then leave a thin facade until final integration.
+- `Tests/PrivateHeaderKitDumpTests/PrivateHeaderKitDumpTests.swift` should be split by responsibility early: selection, state, layout, simulator/process.
+- `Package.resolved` is currently dirty before this rewrite work. No worker should touch it unless dependency work is explicitly assigned.
+
+## Testing Contracts
+
+Priority tests:
+
+- source label formatting: display vs directory name
+- default/custom output layout
+- `.state` separation from artifact tree
+- pretty JSON manifest
+- completed resume skips target
+- failed/partial/interrupted resume reruns target
+- target set/layout/source mismatch rejects resume
+- old run cleanup keeps latest 10
+- managed artifact cleanup preserves unknown files
+- generation failure before commit keeps old artifacts
+- commit failure records attempted artifacts
+- interactive empty Enter re-prompts
+- interactive Esc goes back and preserves input
+- comma-separated target resolution
+- ambiguous partial match resolution
+- non-interactive unfinished run requires explicit `--resume`
+
+## Documentation Updates
+
+After implementation:
+
+- update `README.md` / `README.ja.md` for the new single command
+- document output/state layout
+- document resume/new/rebuild behavior
+- document non-interactive CI usage
+- remove old `headerdump` / `headerdump-sim` as user-facing commands from README

--- a/Package.swift
+++ b/Package.swift
@@ -8,6 +8,7 @@ let package = Package(
         .iOS(.v17),
     ],
     products: [
+        .library(name: "PrivateHeaderKitCore", targets: ["PrivateHeaderKitCore"]),
         .executable(name: "headerdump", targets: ["HeaderDumpCLI"]),
         .executable(name: "privateheaderkit-dump", targets: ["PrivateHeaderKitDump"]),
         .executable(name: "privateheaderkit-install", targets: ["PrivateHeaderKitInstall"]),
@@ -56,6 +57,10 @@ let package = Package(
             name: "PrivateHeaderKitTooling",
             dependencies: []
         ),
+        .target(
+            name: "PrivateHeaderKitCore",
+            dependencies: []
+        ),
         .executableTarget(
             name: "HeaderDumpCLI",
             dependencies: [
@@ -99,6 +104,12 @@ let package = Package(
                     condition: .when(platforms: [.macOS, .iOS])
                 ),
                 .product(name: "MachOKit", package: "MachOKit"),
+            ]
+        ),
+        .testTarget(
+            name: "PrivateHeaderKitCoreTests",
+            dependencies: [
+                "PrivateHeaderKitCore",
             ]
         ),
         .testTarget(

--- a/Sources/PrivateHeaderKitCore/PrivateHeaderGeneration.swift
+++ b/Sources/PrivateHeaderKitCore/PrivateHeaderGeneration.swift
@@ -1,0 +1,201 @@
+import Foundation
+
+public enum PrivateHeaderGeneration {
+    public static func makePlan(
+        source: Source,
+        output: Output,
+        options: Options = Options()
+    ) -> Plan {
+        Plan(
+            source: source,
+            output: output,
+            options: options
+        )
+    }
+
+    public static func generatePrivateHeaders(
+        source: Source,
+        output: Output,
+        options: Options = Options()
+    ) async throws -> Result {
+        throw GenerationError.notImplemented(
+            plan: makePlan(
+                source: source,
+                output: output,
+                options: options
+            )
+        )
+    }
+}
+
+public extension PrivateHeaderGeneration {
+    struct Source: Hashable, Sendable {
+        public let platform: Platform
+        public let version: String
+        public let build: String?
+
+        public init(platform: Platform, version: String, build: String? = nil) throws {
+            try Self.validatePathComponent(version, field: "version")
+            let build = build.flatMap { $0.isEmpty ? nil : $0 }
+            if let build {
+                try Self.validatePathComponent(build, field: "build")
+            }
+            self.platform = platform
+            self.version = version
+            self.build = build
+        }
+
+        public var label: Label {
+            Label(platform: platform, version: version, build: build)
+        }
+
+        private static func validatePathComponent(_ value: String, field: String) throws {
+            guard !value.isEmpty else {
+                throw ValidationError.emptyComponent(field: field)
+            }
+            guard value != ".", value != "..", !value.contains("/"), !value.contains("\0") else {
+                throw ValidationError.invalidPathComponent(field: field, value: value)
+            }
+        }
+    }
+}
+
+public extension PrivateHeaderGeneration.Source {
+    enum ValidationError: Error, Equatable, CustomStringConvertible, Sendable {
+        case emptyComponent(field: String)
+        case invalidPathComponent(field: String, value: String)
+
+        public var description: String {
+            switch self {
+            case .emptyComponent(let field):
+                "\(field) must not be empty"
+            case .invalidPathComponent(let field, let value):
+                "\(field) is not safe as a path component: \(value)"
+            }
+        }
+    }
+
+    enum Platform: String, CaseIterable, Hashable, Sendable {
+        case iOS = "iOS"
+        case macOS = "macOS"
+
+        public var displayName: String {
+            rawValue
+        }
+    }
+
+    struct Label: CustomStringConvertible, Hashable, Sendable {
+        public let displayName: String
+        public let directoryName: String
+
+        init(platform: Platform, version: String, build: String?) {
+            let baseName = "\(platform.displayName) \(version)"
+            let directoryBaseName = "\(platform.displayName)\(version)"
+            if let build {
+                self.displayName = "\(baseName) (\(build))"
+                self.directoryName = "\(directoryBaseName)(\(build))"
+            } else {
+                self.displayName = baseName
+                self.directoryName = directoryBaseName
+            }
+        }
+
+        public var description: String {
+            displayName
+        }
+    }
+}
+
+public extension PrivateHeaderGeneration {
+    struct Target: CustomStringConvertible, Hashable, Sendable {
+        public static let allAvailable = Target(identifier: "allAvailable")
+
+        private let identifier: String
+
+        private init(identifier: String) {
+            self.identifier = identifier
+        }
+
+        public var description: String {
+            identifier
+        }
+    }
+}
+
+public extension PrivateHeaderGeneration {
+    struct Options: Hashable, Sendable {
+        public init() {}
+    }
+
+    struct Output: Hashable, Sendable {
+        public let artifactBaseDirectory: URL
+        public let stateBaseDirectory: URL
+
+        public init(
+            artifactBaseDirectory: URL,
+            stateBaseDirectory: URL
+        ) {
+            self.artifactBaseDirectory = artifactBaseDirectory
+            self.stateBaseDirectory = stateBaseDirectory
+        }
+
+        public init(baseDirectory: URL) {
+            self.init(
+                artifactBaseDirectory: baseDirectory,
+                stateBaseDirectory: baseDirectory.appendingPathComponent(".state", isDirectory: true)
+            )
+        }
+    }
+
+    struct Plan: Hashable, Sendable {
+        public let source: Source
+        public let output: Output
+        public let artifactDirectory: URL
+        public let stateDirectory: URL
+        public let target: Target
+        public let options: Options
+
+        public init(
+            source: Source,
+            output: Output,
+            options: Options = Options()
+        ) {
+            let label = source.label
+            self.source = source
+            self.output = output
+            self.artifactDirectory = output.artifactBaseDirectory.appendingPathComponent(
+                label.directoryName,
+                isDirectory: true
+            )
+            self.stateDirectory = output.stateBaseDirectory.appendingPathComponent(
+                label.directoryName,
+                isDirectory: true
+            )
+            self.target = .allAvailable
+            self.options = options
+        }
+    }
+
+    struct Result: Hashable, Sendable {
+        public let plan: Plan
+        public let artifactDirectory: URL
+        public let generatedTargets: [Target]
+
+        init(plan: Plan, generatedTargets: [Target]) {
+            self.plan = plan
+            self.artifactDirectory = plan.artifactDirectory
+            self.generatedTargets = generatedTargets
+        }
+    }
+
+    enum GenerationError: Error, Equatable, CustomStringConvertible, Sendable {
+        case notImplemented(plan: Plan)
+
+        public var description: String {
+            switch self {
+            case .notImplemented(let plan):
+                "private header generation is not implemented for \(plan.source.label.displayName)"
+            }
+        }
+    }
+}

--- a/Sources/PrivateHeaderKitCore/PrivateHeaderGenerationArtifactStore.swift
+++ b/Sources/PrivateHeaderKitCore/PrivateHeaderGenerationArtifactStore.swift
@@ -1,0 +1,215 @@
+import Foundation
+
+public extension PrivateHeaderGeneration {
+    struct ArtifactCleanupResult: Equatable, Sendable {
+        public let deletedArtifacts: [ArtifactPath]
+        public let missingArtifacts: [ArtifactPath]
+        public let prunedDirectories: [ArtifactPath]
+
+        public init(
+            deletedArtifacts: [ArtifactPath],
+            missingArtifacts: [ArtifactPath],
+            prunedDirectories: [ArtifactPath]
+        ) {
+            self.deletedArtifacts = deletedArtifacts
+            self.missingArtifacts = missingArtifacts
+            self.prunedDirectories = prunedDirectories
+        }
+    }
+
+    enum ArtifactStoreError: Error, Equatable, CustomStringConvertible, Sendable {
+        case nonFileArtifactRoot(String)
+        case artifactPathEscapesRoot(artifactPath: ArtifactPath, artifactRoot: String, resolvedPath: String)
+
+        public var description: String {
+            switch self {
+            case .nonFileArtifactRoot(let artifactRoot):
+                "artifact root must be a file URL: \(artifactRoot)"
+            case .artifactPathEscapesRoot(let artifactPath, let artifactRoot, let resolvedPath):
+                "artifact path escapes artifact root: \(artifactPath.rawValue) resolved to \(resolvedPath) outside \(artifactRoot)"
+            }
+        }
+    }
+
+    struct ArtifactStore: Sendable {
+        public let artifactRoot: URL
+
+        public init(artifactRoot: URL) {
+            self.artifactRoot = artifactRoot
+        }
+
+        @discardableResult
+        public func cleanupManagedArtifacts(
+            _ artifacts: [ArtifactPath],
+            fileManager: FileManager = .default
+        ) throws -> ArtifactCleanupResult {
+            try Self.cleanupManagedArtifacts(
+                in: artifactRoot,
+                artifacts: artifacts,
+                fileManager: fileManager
+            )
+        }
+
+        @discardableResult
+        public static func cleanupManagedArtifacts(
+            in artifactRoot: URL,
+            artifacts: [ArtifactPath],
+            fileManager: FileManager = .default
+        ) throws -> ArtifactCleanupResult {
+            let root = try artifactRootURLs(for: artifactRoot)
+            let candidates = cleanupCandidates(manifestArtifacts: artifacts)
+            let candidateSet = Set(candidates)
+            var deletedArtifacts: [ArtifactPath] = []
+            var missingArtifacts: [ArtifactPath] = []
+            var prunedDirectories: [ArtifactPath] = []
+            var prunedDirectorySet = Set<ArtifactPath>()
+
+            for artifact in cleanupOperationOrder(candidates) {
+                let artifactURL = try artifactFileURL(
+                    for: artifact,
+                    root: root
+                )
+
+                guard fileManager.fileExists(atPath: artifactURL.path) else {
+                    missingArtifacts.append(artifact)
+                    continue
+                }
+
+                try fileManager.removeItem(at: artifactURL)
+                deletedArtifacts.append(artifact)
+
+                let pruned = try pruneEmptyParentDirectories(
+                    afterDeleting: artifact,
+                    root: root,
+                    cleanupCandidates: candidateSet,
+                    fileManager: fileManager
+                )
+                for directory in pruned where prunedDirectorySet.insert(directory).inserted {
+                    prunedDirectories.append(directory)
+                }
+            }
+
+            return ArtifactCleanupResult(
+                deletedArtifacts: cleanupCandidates(manifestArtifacts: deletedArtifacts),
+                missingArtifacts: cleanupCandidates(manifestArtifacts: missingArtifacts),
+                prunedDirectories: cleanupCandidates(manifestArtifacts: prunedDirectories)
+            )
+        }
+
+        public static func cleanupCandidates(
+            manifestArtifacts: [ArtifactPath],
+            attemptedArtifacts: [ArtifactPath] = []
+        ) -> [ArtifactPath] {
+            Array(Set(manifestArtifacts + attemptedArtifacts))
+                .sorted { $0.rawValue < $1.rawValue }
+        }
+
+        private struct ArtifactRootURLs {
+            let unresolved: URL
+            let resolved: URL
+        }
+
+        private static func artifactRootURLs(for artifactRoot: URL) throws -> ArtifactRootURLs {
+            guard artifactRoot.isFileURL else {
+                throw ArtifactStoreError.nonFileArtifactRoot(artifactRoot.absoluteString)
+            }
+
+            let unresolved = artifactRoot.standardizedFileURL
+            return ArtifactRootURLs(
+                unresolved: unresolved,
+                resolved: unresolved.resolvingSymlinksInPath()
+            )
+        }
+
+        private static func artifactFileURL(
+            for artifact: ArtifactPath,
+            root: ArtifactRootURLs
+        ) throws -> URL {
+            var url = root.unresolved
+            for component in artifact.rawValue.split(separator: "/", omittingEmptySubsequences: false) {
+                url.appendPathComponent(String(component))
+            }
+
+            let resolvedURL = url.standardizedFileURL.resolvingSymlinksInPath()
+            guard isSameOrDescendant(resolvedURL, of: root.resolved) else {
+                throw ArtifactStoreError.artifactPathEscapesRoot(
+                    artifactPath: artifact,
+                    artifactRoot: root.resolved.path,
+                    resolvedPath: resolvedURL.path
+                )
+            }
+
+            return url
+        }
+
+        private static func cleanupOperationOrder(_ artifacts: [ArtifactPath]) -> [ArtifactPath] {
+            artifacts.sorted {
+                let leftDepth = pathDepth($0)
+                let rightDepth = pathDepth($1)
+                if leftDepth == rightDepth {
+                    return $0.rawValue < $1.rawValue
+                }
+                return leftDepth > rightDepth
+            }
+        }
+
+        private static func pathDepth(_ artifact: ArtifactPath) -> Int {
+            artifact.rawValue.split(separator: "/").count
+        }
+
+        private static func pruneEmptyParentDirectories(
+            afterDeleting artifact: ArtifactPath,
+            root: ArtifactRootURLs,
+            cleanupCandidates: Set<ArtifactPath>,
+            fileManager: FileManager
+        ) throws -> [ArtifactPath] {
+            var prunedDirectories: [ArtifactPath] = []
+
+            for parent in try parentDirectories(for: artifact) {
+                if cleanupCandidates.contains(parent) {
+                    break
+                }
+
+                let parentURL = try artifactFileURL(for: parent, root: root)
+                var isDirectory = ObjCBool(false)
+                guard fileManager.fileExists(atPath: parentURL.path, isDirectory: &isDirectory),
+                      isDirectory.boolValue
+                else {
+                    continue
+                }
+
+                guard try fileManager.contentsOfDirectory(atPath: parentURL.path).isEmpty else {
+                    break
+                }
+
+                try fileManager.removeItem(at: parentURL)
+                prunedDirectories.append(parent)
+            }
+
+            return prunedDirectories
+        }
+
+        private static func parentDirectories(for artifact: ArtifactPath) throws -> [ArtifactPath] {
+            let components = artifact.rawValue.split(separator: "/").map(String.init)
+            guard components.count > 1 else {
+                return []
+            }
+
+            return try stride(from: components.count - 1, through: 1, by: -1).map { count in
+                try ArtifactPath(components.prefix(count).joined(separator: "/"))
+            }
+        }
+
+        private static func isSameOrDescendant(_ url: URL, of root: URL) -> Bool {
+            let path = url.path
+            let rootPath = root.path
+            if path == rootPath {
+                return true
+            }
+            if rootPath == "/" {
+                return path.hasPrefix("/")
+            }
+            return path.hasPrefix(rootPath + "/")
+        }
+    }
+}

--- a/Sources/PrivateHeaderKitCore/PrivateHeaderGenerationResume.swift
+++ b/Sources/PrivateHeaderKitCore/PrivateHeaderGenerationResume.swift
@@ -1,0 +1,458 @@
+import Foundation
+
+public extension PrivateHeaderGeneration {
+    typealias ArtifactExistence = @Sendable (ArtifactPath) -> Bool
+
+    enum ResumeCompatibilityRecord: String, Hashable, Sendable {
+        case manifest
+        case run
+    }
+
+    enum ResumeCompatibilityReason: Equatable, Sendable {
+        case unsupportedManifestSchema(actual: Int, supported: [Int])
+        case unsupportedRunSchema(actual: Int, supported: [Int])
+        case sourceBuildMismatch(
+            expected: SourceRecord,
+            actual: SourceRecord,
+            record: ResumeCompatibilityRecord
+        )
+        case outputMismatch(
+            expected: OutputRecord,
+            actual: OutputRecord,
+            record: ResumeCompatibilityRecord
+        )
+        case layoutMismatch(
+            expected: Layout,
+            actual: Layout,
+            record: ResumeCompatibilityRecord
+        )
+        case selectedTargetSetMismatch(
+            expected: [String],
+            actual: [String],
+            record: ResumeCompatibilityRecord
+        )
+        case missingLatestRun(runID: String)
+    }
+
+    enum ResumeCompatibility: Equatable, Sendable {
+        case compatible
+        case incompatible([ResumeCompatibilityReason])
+
+        public var isCompatible: Bool {
+            self == .compatible
+        }
+    }
+
+    enum ResumeTargetStatus: String, Hashable, Sendable {
+        case completed
+        case partial
+        case failed
+        case interrupted
+        case commitFailed
+        case stale
+        case pending
+    }
+
+    struct ResumeTargetDecision: Equatable, Sendable {
+        public let targetID: String
+        public let status: ResumeTargetStatus
+
+        public init(targetID: String, status: ResumeTargetStatus) {
+            self.targetID = targetID
+            self.status = status
+        }
+
+        public var shouldRun: Bool {
+            status != .completed
+        }
+    }
+
+    struct ResumeTargetCounts: Equatable, Sendable {
+        public let total: Int
+        public let completed: Int
+        public let partial: Int
+        public let failed: Int
+        public let interrupted: Int
+        public let commitFailed: Int
+        public let stale: Int
+        public let pending: Int
+
+        public init(
+            total: Int,
+            completed: Int,
+            partial: Int,
+            failed: Int,
+            interrupted: Int,
+            commitFailed: Int,
+            stale: Int,
+            pending: Int
+        ) {
+            self.total = total
+            self.completed = completed
+            self.partial = partial
+            self.failed = failed
+            self.interrupted = interrupted
+            self.commitFailed = commitFailed
+            self.stale = stale
+            self.pending = pending
+        }
+
+        public var unfinished: Int {
+            partial + failed + interrupted + commitFailed + stale + pending
+        }
+
+        fileprivate init(targets: [ResumeTargetDecision]) {
+            var completed = 0
+            var partial = 0
+            var failed = 0
+            var interrupted = 0
+            var commitFailed = 0
+            var stale = 0
+            var pending = 0
+
+            for target in targets {
+                switch target.status {
+                case .completed:
+                    completed += 1
+                case .partial:
+                    partial += 1
+                case .failed:
+                    failed += 1
+                case .interrupted:
+                    interrupted += 1
+                case .commitFailed:
+                    commitFailed += 1
+                case .stale:
+                    stale += 1
+                case .pending:
+                    pending += 1
+                }
+            }
+
+            self.init(
+                total: targets.count,
+                completed: completed,
+                partial: partial,
+                failed: failed,
+                interrupted: interrupted,
+                commitFailed: commitFailed,
+                stale: stale,
+                pending: pending
+            )
+        }
+    }
+
+    struct ResumeSummary: Equatable, Sendable {
+        public let source: SourceRecord
+        public let output: OutputRecord
+        public let layout: Layout
+        public let latestRunID: String?
+        public let startedAt: Date?
+        public let updatedAt: Date
+        public let counts: ResumeTargetCounts
+        public let targets: [ResumeTargetDecision]
+
+        public init(
+            source: SourceRecord,
+            output: OutputRecord,
+            layout: Layout,
+            latestRunID: String?,
+            startedAt: Date?,
+            updatedAt: Date,
+            counts: ResumeTargetCounts,
+            targets: [ResumeTargetDecision]
+        ) {
+            self.source = source
+            self.output = output
+            self.layout = layout
+            self.latestRunID = latestRunID
+            self.startedAt = startedAt
+            self.updatedAt = updatedAt
+            self.counts = counts
+            self.targets = targets
+        }
+
+        public var targetIDsToRun: [String] {
+            targets.filter(\.shouldRun).map(\.targetID)
+        }
+
+        public var isUnfinished: Bool {
+            counts.unfinished > 0
+        }
+    }
+
+    enum NonInteractiveResumeDecision: Equatable, Sendable {
+        case proceed
+        case resume(ResumeSummary)
+        case resumeRequired(ResumeSummary)
+        case incompatible([ResumeCompatibilityReason])
+    }
+}
+
+public extension PrivateHeaderGeneration {
+    static func evaluateResumeCompatibility(
+        plan: RunPlanRecord,
+        manifest: Manifest,
+        latestRun: RunRecord? = nil,
+        supportedSchemaVersions: Set<Int> = [1]
+    ) -> ResumeCompatibility {
+        let supported = supportedSchemaVersions.sorted()
+        var reasons: [ResumeCompatibilityReason] = []
+
+        if !supportedSchemaVersions.contains(manifest.schemaVersion) {
+            reasons.append(
+                .unsupportedManifestSchema(
+                    actual: manifest.schemaVersion,
+                    supported: supported
+                )
+            )
+        }
+
+        let manifestPlan = RunPlanRecord(
+            source: manifest.source,
+            output: manifest.output,
+            layout: manifest.layout,
+            targetIDs: manifest.targets.map(\.id)
+        )
+        appendCompatibilityMismatches(
+            to: &reasons,
+            expected: plan,
+            actual: manifestPlan,
+            record: .manifest,
+            compareTargetSet: false
+        )
+
+        if let latestRun {
+            if !supportedSchemaVersions.contains(latestRun.schemaVersion) {
+                reasons.append(
+                    .unsupportedRunSchema(
+                        actual: latestRun.schemaVersion,
+                        supported: supported
+                    )
+                )
+            }
+
+            appendCompatibilityMismatches(
+                to: &reasons,
+                expected: plan,
+                actual: latestRun.plan,
+                record: .run,
+                compareTargetSet: true
+            )
+        } else if reasons.isEmpty, let latestRunID = manifest.latestRunID {
+            reasons.append(.missingLatestRun(runID: latestRunID))
+        }
+
+        if reasons.isEmpty {
+            return .compatible
+        }
+        return .incompatible(reasons)
+    }
+
+    static func makeResumeSummary(
+        plan: RunPlanRecord,
+        manifest: Manifest,
+        latestRun: RunRecord? = nil,
+        artifactExists: ArtifactExistence
+    ) -> ResumeSummary {
+        let targets = resumeTargetDecisions(
+            plan: plan,
+            manifest: manifest,
+            artifactExists: artifactExists
+        )
+
+        return ResumeSummary(
+            source: manifest.source,
+            output: manifest.output,
+            layout: manifest.layout,
+            latestRunID: manifest.latestRunID,
+            startedAt: latestRun?.startedAt,
+            updatedAt: manifest.updatedAt,
+            counts: ResumeTargetCounts(targets: targets),
+            targets: targets
+        )
+    }
+
+    static func resumeTargetDecisions(
+        plan: RunPlanRecord,
+        manifest: Manifest,
+        artifactExists: ArtifactExistence
+    ) -> [ResumeTargetDecision] {
+        let targetsByID = manifestTargetsByID(manifest.targets)
+        return deduplicatedTargetIDs(plan.targetIDs).map { targetID in
+            let status: ResumeTargetStatus
+            if let target = targetsByID[targetID] {
+                status = resumeStatus(for: target, artifactExists: artifactExists)
+            } else {
+                status = .pending
+            }
+            return ResumeTargetDecision(targetID: targetID, status: status)
+        }
+    }
+
+    static func targetIDsToRunOnResume(
+        plan: RunPlanRecord,
+        manifest: Manifest,
+        artifactExists: ArtifactExistence
+    ) -> [String] {
+        resumeTargetDecisions(
+            plan: plan,
+            manifest: manifest,
+            artifactExists: artifactExists
+        )
+        .filter(\.shouldRun)
+        .map(\.targetID)
+    }
+
+    static func nonInteractiveResumeDecision(
+        plan: RunPlanRecord,
+        manifest: Manifest,
+        latestRun: RunRecord? = nil,
+        resumeRequested: Bool,
+        artifactExists: ArtifactExistence,
+        supportedSchemaVersions: Set<Int> = [1]
+    ) -> NonInteractiveResumeDecision {
+        let compatibility = evaluateResumeCompatibility(
+            plan: plan,
+            manifest: manifest,
+            latestRun: latestRun,
+            supportedSchemaVersions: supportedSchemaVersions
+        )
+        if case .incompatible(let reasons) = compatibility {
+            return .incompatible(reasons)
+        }
+
+        let summary = makeResumeSummary(
+            plan: plan,
+            manifest: manifest,
+            latestRun: latestRun,
+            artifactExists: artifactExists
+        )
+        if resumeRequested {
+            return .resume(summary)
+        }
+        if summary.isUnfinished {
+            return .resumeRequired(summary)
+        }
+        return .proceed
+    }
+}
+
+private extension PrivateHeaderGeneration {
+    static func appendCompatibilityMismatches(
+        to reasons: inout [ResumeCompatibilityReason],
+        expected: RunPlanRecord,
+        actual: RunPlanRecord,
+        record: ResumeCompatibilityRecord,
+        compareTargetSet: Bool
+    ) {
+        if expected.source != actual.source {
+            reasons.append(
+                .sourceBuildMismatch(
+                    expected: expected.source,
+                    actual: actual.source,
+                    record: record
+                )
+            )
+        }
+
+        if expected.output != actual.output {
+            reasons.append(
+                .outputMismatch(
+                    expected: expected.output,
+                    actual: actual.output,
+                    record: record
+                )
+            )
+        }
+
+        if expected.layout != actual.layout {
+            reasons.append(
+                .layoutMismatch(
+                    expected: expected.layout,
+                    actual: actual.layout,
+                    record: record
+                )
+            )
+        }
+
+        if compareTargetSet {
+            let expectedIDs = normalizedTargetIDs(expected.targetIDs)
+            let actualIDs = normalizedTargetIDs(actual.targetIDs)
+            if expectedIDs != actualIDs {
+                reasons.append(
+                    .selectedTargetSetMismatch(
+                        expected: expectedIDs,
+                        actual: actualIDs,
+                        record: record
+                    )
+                )
+            }
+        }
+    }
+
+    static func resumeStatus(
+        for target: TargetRecord,
+        artifactExists: ArtifactExistence
+    ) -> ResumeTargetStatus {
+        switch target.status {
+        case .completed:
+            return hasCompleteManagedArtifacts(target, artifactExists: artifactExists) ? .completed : .stale
+        case .partial:
+            return .partial
+        case .failed:
+            return .failed
+        case .interrupted:
+            return .interrupted
+        case .commitFailed:
+            return .commitFailed
+        case .stale:
+            return .stale
+        }
+    }
+
+    static func hasCompleteManagedArtifacts(
+        _ target: TargetRecord,
+        artifactExists: ArtifactExistence
+    ) -> Bool {
+        guard !target.artifacts.isEmpty else {
+            return false
+        }
+
+        var hasGeneratedHeaderOrInterface = false
+        for artifact in target.artifacts {
+            guard artifactExists(artifact) else {
+                return false
+            }
+            if isGeneratedHeaderOrInterface(artifact) {
+                hasGeneratedHeaderOrInterface = true
+            }
+        }
+        return hasGeneratedHeaderOrInterface
+    }
+
+    static func isGeneratedHeaderOrInterface(_ artifact: ArtifactPath) -> Bool {
+        artifact.rawValue.hasSuffix(".h") || artifact.rawValue.hasSuffix(".swiftinterface")
+    }
+
+    static func manifestTargetsByID(_ targets: [TargetRecord]) -> [String: TargetRecord] {
+        var targetsByID: [String: TargetRecord] = [:]
+        for target in targets {
+            targetsByID[target.id] = target
+        }
+        return targetsByID
+    }
+
+    static func normalizedTargetIDs(_ targetIDs: [String]) -> [String] {
+        Array(Set(targetIDs)).sorted()
+    }
+
+    static func deduplicatedTargetIDs(_ targetIDs: [String]) -> [String] {
+        var seen: Set<String> = []
+        var deduplicated: [String] = []
+        for targetID in targetIDs where seen.insert(targetID).inserted {
+            deduplicated.append(targetID)
+        }
+        return deduplicated
+    }
+}

--- a/Sources/PrivateHeaderKitCore/PrivateHeaderGenerationSourceDiscovery.swift
+++ b/Sources/PrivateHeaderKitCore/PrivateHeaderGenerationSourceDiscovery.swift
@@ -1,0 +1,238 @@
+import Foundation
+
+public extension PrivateHeaderGeneration {
+    struct SourceCandidate: Hashable, Sendable {
+        public let source: Source
+        public let runtimeName: String
+        public let runtimeIdentifier: String?
+        public let runtimeRoot: String?
+
+        public init(
+            source: Source,
+            runtimeName: String? = nil,
+            runtimeIdentifier: String? = nil,
+            runtimeRoot: String? = nil
+        ) {
+            self.source = source
+            self.runtimeName = runtimeName.trimmedNonEmpty ?? source.label.displayName
+            self.runtimeIdentifier = runtimeIdentifier.trimmedNonEmpty
+            self.runtimeRoot = runtimeRoot.trimmedNonEmpty
+        }
+    }
+
+    enum SourceDiscovery {
+        public static func iOSRuntimeSourceCandidates(
+            fromSimctlListRuntimesJSON json: String
+        ) throws -> [SourceCandidate] {
+            try iOSRuntimeSourceCandidates(fromSimctlListRuntimesJSON: Data(json.utf8))
+        }
+
+        public static func iOSRuntimeSourceCandidates(
+            fromSimctlListRuntimesJSON data: Data
+        ) throws -> [SourceCandidate] {
+            let decoded = try JSONDecoder().decode(SimctlRuntimeList.self, from: data)
+            let candidates = try (decoded.runtimes ?? []).compactMap { entry -> SourceCandidate? in
+                guard entry.isAvailableForUse, entry.isIOSRuntime else {
+                    return nil
+                }
+                guard let version = entry.version.trimmedNonEmpty,
+                      let build = entry.buildversion.trimmedNonEmpty else {
+                    return nil
+                }
+
+                return SourceCandidate(
+                    source: try Source(platform: .iOS, version: version, build: build),
+                    runtimeName: entry.name,
+                    runtimeIdentifier: entry.identifier,
+                    runtimeRoot: entry.runtimeRoot
+                )
+            }
+
+            return deduplicatedBySource(sortedIOSRuntimeSourceCandidates(candidates))
+        }
+
+        public static func sortedIOSRuntimeSourceCandidates(
+            _ candidates: [SourceCandidate]
+        ) -> [SourceCandidate] {
+            candidates.sorted(by: SourceCandidateOrdering.isOrderedBefore)
+        }
+
+        public static func latestIOSRuntimeSourceCandidate(
+            from candidates: [SourceCandidate]
+        ) -> SourceCandidate? {
+            sortedIOSRuntimeSourceCandidates(candidates).last
+        }
+
+        private static func deduplicatedBySource(
+            _ candidates: [SourceCandidate]
+        ) -> [SourceCandidate] {
+            var seenSources: Set<Source> = []
+            var uniqueCandidates: [SourceCandidate] = []
+            for candidate in candidates where seenSources.insert(candidate.source).inserted {
+                uniqueCandidates.append(candidate)
+            }
+            return uniqueCandidates
+        }
+    }
+}
+
+private struct SimctlRuntimeList: Decodable {
+    struct RuntimeEntry: Decodable {
+        let name: String?
+        let platform: String?
+        let version: String?
+        let buildversion: String?
+        let identifier: String?
+        let runtimeRoot: String?
+        let isAvailable: Bool?
+        let availability: String?
+
+        var isAvailableForUse: Bool {
+            if let isAvailable {
+                return isAvailable
+            }
+
+            guard let availability = availability.trimmedNonEmpty?.lowercased() else {
+                return false
+            }
+            return availability == "available" || availability == "(available)"
+        }
+
+        var isIOSRuntime: Bool {
+            if let platform = platform.trimmedNonEmpty {
+                return platform.caseInsensitiveCompare("iOS") == .orderedSame
+            }
+            if let name = name.trimmedNonEmpty {
+                let lowercasedName = name.lowercased()
+                return lowercasedName == "ios" || lowercasedName.hasPrefix("ios ")
+            }
+            if let identifier = identifier.trimmedNonEmpty {
+                return identifier.contains(".SimRuntime.iOS-")
+                    || identifier.hasSuffix(".SimRuntime.iOS")
+            }
+            return false
+        }
+    }
+
+    let runtimes: [RuntimeEntry]?
+}
+
+private enum SourceCandidateOrdering {
+    static func isOrderedBefore(
+        _ lhs: PrivateHeaderGeneration.SourceCandidate,
+        _ rhs: PrivateHeaderGeneration.SourceCandidate
+    ) -> Bool {
+        compare(lhs, rhs) == .orderedAscending
+    }
+
+    private static func compare(
+        _ lhs: PrivateHeaderGeneration.SourceCandidate,
+        _ rhs: PrivateHeaderGeneration.SourceCandidate
+    ) -> ComparisonResult {
+        compareSortTokens(lhs.source.version, rhs.source.version)
+            .orElse(compareSortTokens(lhs.source.build ?? "", rhs.source.build ?? ""))
+            .orElse(compareSortTokens(lhs.runtimeName, rhs.runtimeName))
+            .orElse(compareOptionalSortStrings(lhs.runtimeIdentifier, rhs.runtimeIdentifier))
+            .orElse(compareOptionalSortStrings(lhs.runtimeRoot, rhs.runtimeRoot))
+    }
+
+    private static func compareOptionalSortStrings(_ lhs: String?, _ rhs: String?) -> ComparisonResult {
+        switch (lhs, rhs) {
+        case (nil, nil):
+            return .orderedSame
+        case (.some, nil):
+            return .orderedAscending
+        case (nil, .some):
+            return .orderedDescending
+        case let (.some(lhs), .some(rhs)):
+            return compareSortTokens(lhs, rhs)
+        }
+    }
+
+    private static func compareSortTokens(_ lhs: String, _ rhs: String) -> ComparisonResult {
+        let lhsTokens = NaturalSortToken.tokenize(lhs)
+        let rhsTokens = NaturalSortToken.tokenize(rhs)
+        let count = min(lhsTokens.count, rhsTokens.count)
+
+        for index in 0..<count {
+            if lhsTokens[index] < rhsTokens[index] {
+                return .orderedAscending
+            }
+            if rhsTokens[index] < lhsTokens[index] {
+                return .orderedDescending
+            }
+        }
+
+        if lhsTokens.count == rhsTokens.count {
+            return .orderedSame
+        }
+        return lhsTokens.count < rhsTokens.count ? .orderedAscending : .orderedDescending
+    }
+}
+
+private enum NaturalSortToken: Comparable {
+    case number(Int)
+    case text(String)
+
+    static func tokenize(_ value: String) -> [NaturalSortToken] {
+        var tokens: [NaturalSortToken] = []
+        var current = ""
+        var currentIsNumber: Bool?
+
+        for scalar in value.unicodeScalars {
+            let isNumber = CharacterSet.decimalDigits.contains(scalar)
+            if currentIsNumber == nil || currentIsNumber == isNumber {
+                current.unicodeScalars.append(scalar)
+                currentIsNumber = isNumber
+            } else {
+                tokens.append(token(from: current, isNumber: currentIsNumber == true))
+                current = String(scalar)
+                currentIsNumber = isNumber
+            }
+        }
+
+        if let currentIsNumber {
+            tokens.append(token(from: current, isNumber: currentIsNumber))
+        }
+
+        return tokens
+    }
+
+    static func < (lhs: NaturalSortToken, rhs: NaturalSortToken) -> Bool {
+        switch (lhs, rhs) {
+        case let (.number(lhs), .number(rhs)):
+            return lhs < rhs
+        case let (.text(lhs), .text(rhs)):
+            return lhs.lowercased() < rhs.lowercased()
+        case (.number, .text):
+            return true
+        case (.text, .number):
+            return false
+        }
+    }
+
+    private static func token(from value: String, isNumber: Bool) -> NaturalSortToken {
+        if isNumber, let number = Int(value) {
+            return .number(number)
+        }
+        return .text(value)
+    }
+}
+
+private extension ComparisonResult {
+    func orElse(_ fallback: @autoclosure () -> ComparisonResult) -> ComparisonResult {
+        self == .orderedSame ? fallback() : self
+    }
+}
+
+private extension Optional where Wrapped == String {
+    var trimmedNonEmpty: String? {
+        switch self {
+        case .none:
+            return nil
+        case .some(let value):
+            let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+            return trimmed.isEmpty ? nil : trimmed
+        }
+    }
+}

--- a/Sources/PrivateHeaderKitCore/PrivateHeaderGenerationState.swift
+++ b/Sources/PrivateHeaderKitCore/PrivateHeaderGenerationState.swift
@@ -1,0 +1,538 @@
+import Foundation
+
+public extension PrivateHeaderGeneration {
+    enum Layout: String, Codable, CaseIterable, Hashable, Sendable {
+        case headers
+        case bundle
+    }
+
+    enum TargetStatus: String, Codable, CaseIterable, Hashable, Sendable {
+        case completed
+        case partial
+        case failed
+        case interrupted
+        case commitFailed
+        case stale
+    }
+
+    enum RunTargetStatus: String, Codable, CaseIterable, Hashable, Sendable {
+        case pending
+        case running
+        case skipped
+        case completed
+        case partial
+        case failed
+        case interrupted
+        case commitFailed
+    }
+
+    enum PhaseStatus: String, Codable, CaseIterable, Hashable, Sendable {
+        case pending
+        case running
+        case completed
+        case failed
+        case skipped
+    }
+
+    struct ArtifactPath: Codable, CustomStringConvertible, Hashable, Sendable {
+        public let rawValue: String
+
+        public init(_ rawValue: String) throws {
+            try Self.validate(rawValue)
+            self.rawValue = rawValue
+        }
+
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.singleValueContainer()
+            let rawValue = try container.decode(String.self)
+            try Self.validate(rawValue)
+            self.rawValue = rawValue
+        }
+
+        public func encode(to encoder: Encoder) throws {
+            var container = encoder.singleValueContainer()
+            try container.encode(rawValue)
+        }
+
+        public var description: String {
+            rawValue
+        }
+
+        private static func validate(_ rawValue: String) throws {
+            guard !rawValue.isEmpty else {
+                throw StateValidationError.emptyArtifactPath
+            }
+            guard !rawValue.hasPrefix("/") else {
+                throw StateValidationError.absoluteArtifactPath(rawValue)
+            }
+            guard !rawValue.contains("\0") else {
+                throw StateValidationError.invalidArtifactPath(rawValue)
+            }
+
+            let components = rawValue.split(separator: "/", omittingEmptySubsequences: false)
+            guard components.allSatisfy({ !$0.isEmpty && $0 != "." && $0 != ".." }) else {
+                throw StateValidationError.invalidArtifactPath(rawValue)
+            }
+        }
+    }
+
+    enum StateValidationError: Error, Equatable, CustomStringConvertible, Sendable {
+        case emptyArtifactPath
+        case absoluteArtifactPath(String)
+        case invalidArtifactPath(String)
+
+        public var description: String {
+            switch self {
+            case .emptyArtifactPath:
+                "artifact path must not be empty"
+            case .absoluteArtifactPath(let path):
+                "artifact path must be relative: \(path)"
+            case .invalidArtifactPath(let path):
+                "artifact path is not safe: \(path)"
+            }
+        }
+    }
+}
+
+public extension PrivateHeaderGeneration {
+    struct Manifest: Codable, Equatable, Sendable {
+        public let schemaVersion: Int
+        public let toolVersion: String
+        public let source: SourceRecord
+        public let output: OutputRecord
+        public let layout: Layout
+        public let latestRunID: String?
+        public let targets: [TargetRecord]
+        public let updatedAt: Date
+
+        public init(
+            schemaVersion: Int,
+            toolVersion: String,
+            source: SourceRecord,
+            output: OutputRecord,
+            layout: Layout,
+            latestRunID: String?,
+            targets: [TargetRecord],
+            updatedAt: Date
+        ) {
+            self.schemaVersion = schemaVersion
+            self.toolVersion = toolVersion
+            self.source = source
+            self.output = output
+            self.layout = layout
+            self.latestRunID = latestRunID
+            self.targets = targets
+            self.updatedAt = updatedAt
+        }
+
+        public func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode(schemaVersion, forKey: .schemaVersion)
+            try container.encode(toolVersion, forKey: .toolVersion)
+            try container.encode(source, forKey: .source)
+            try container.encode(output, forKey: .output)
+            try container.encode(layout, forKey: .layout)
+            try container.encodeRequired(latestRunID, forKey: .latestRunID)
+            try container.encode(targets, forKey: .targets)
+            try container.encode(updatedAt, forKey: .updatedAt)
+        }
+
+        private enum CodingKeys: String, CodingKey {
+            case schemaVersion
+            case toolVersion
+            case source
+            case output
+            case layout
+            case latestRunID
+            case targets
+            case updatedAt
+        }
+    }
+
+    struct SourceRecord: Codable, Equatable, Sendable {
+        public let platform: Source.Platform
+        public let version: String
+        public let build: String?
+        public let displayName: String
+        public let directoryName: String
+
+        public init(source: Source) {
+            self.platform = source.platform
+            self.version = source.version
+            self.build = source.build
+            self.displayName = source.label.displayName
+            self.directoryName = source.label.directoryName
+        }
+
+        public func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode(platform, forKey: .platform)
+            try container.encode(version, forKey: .version)
+            try container.encodeRequired(build, forKey: .build)
+            try container.encode(displayName, forKey: .displayName)
+            try container.encode(directoryName, forKey: .directoryName)
+        }
+
+        private enum CodingKeys: String, CodingKey {
+            case platform
+            case version
+            case build
+            case displayName
+            case directoryName
+        }
+    }
+
+    struct OutputRecord: Codable, Equatable, Sendable {
+        public let baseDirectory: String
+        public let artifactDirectory: String
+        public let stateDirectory: String
+
+        public init(
+            baseDirectory: String,
+            artifactDirectory: String,
+            stateDirectory: String
+        ) {
+            self.baseDirectory = baseDirectory
+            self.artifactDirectory = artifactDirectory
+            self.stateDirectory = stateDirectory
+        }
+
+        public init(plan: Plan, baseDirectory: URL) {
+            self.init(
+                baseDirectory: baseDirectory.path,
+                artifactDirectory: plan.artifactDirectory.path,
+                stateDirectory: plan.stateDirectory.path
+            )
+        }
+    }
+
+    struct TargetRecord: Codable, Equatable, Sendable {
+        public let id: String
+        public let displayName: String
+        public let kind: String
+        public let status: TargetStatus
+        public let phases: [PhaseRecord]
+        public let artifacts: [ArtifactPath]
+        public let lastRunID: String?
+        public let updatedAt: Date
+        public let failureSummary: String?
+
+        public init(
+            id: String,
+            displayName: String,
+            kind: String,
+            status: TargetStatus,
+            phases: [PhaseRecord],
+            artifacts: [ArtifactPath],
+            lastRunID: String?,
+            updatedAt: Date,
+            failureSummary: String?
+        ) {
+            self.id = id
+            self.displayName = displayName
+            self.kind = kind
+            self.status = status
+            self.phases = phases
+            self.artifacts = artifacts
+            self.lastRunID = lastRunID
+            self.updatedAt = updatedAt
+            self.failureSummary = failureSummary
+        }
+
+        public func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode(id, forKey: .id)
+            try container.encode(displayName, forKey: .displayName)
+            try container.encode(kind, forKey: .kind)
+            try container.encode(status, forKey: .status)
+            try container.encode(phases, forKey: .phases)
+            try container.encode(artifacts, forKey: .artifacts)
+            try container.encodeRequired(lastRunID, forKey: .lastRunID)
+            try container.encode(updatedAt, forKey: .updatedAt)
+            try container.encodeRequired(failureSummary, forKey: .failureSummary)
+        }
+
+        private enum CodingKeys: String, CodingKey {
+            case id
+            case displayName
+            case kind
+            case status
+            case phases
+            case artifacts
+            case lastRunID
+            case updatedAt
+            case failureSummary
+        }
+    }
+
+    struct PhaseRecord: Codable, Equatable, Sendable {
+        public let name: String
+        public let status: PhaseStatus
+        public let failureSummary: String?
+
+        public init(name: String, status: PhaseStatus, failureSummary: String? = nil) {
+            self.name = name
+            self.status = status
+            self.failureSummary = failureSummary
+        }
+
+        public func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode(name, forKey: .name)
+            try container.encode(status, forKey: .status)
+            try container.encodeRequired(failureSummary, forKey: .failureSummary)
+        }
+
+        private enum CodingKeys: String, CodingKey {
+            case name
+            case status
+            case failureSummary
+        }
+    }
+}
+
+public extension PrivateHeaderGeneration {
+    struct RunRecord: Codable, Equatable, Sendable {
+        public let runID: String
+        public let schemaVersion: Int
+        public let toolVersion: String
+        public let plan: RunPlanRecord
+        public let startedAt: Date
+        public let endedAt: Date?
+        public let status: RunTargetStatus
+        public let targetResults: [RunTargetRecord]
+        public let attemptedArtifacts: [ArtifactPath]
+        public let logs: [RunLogRecord]
+
+        public init(
+            runID: String,
+            schemaVersion: Int,
+            toolVersion: String,
+            plan: RunPlanRecord,
+            startedAt: Date,
+            endedAt: Date?,
+            status: RunTargetStatus,
+            targetResults: [RunTargetRecord],
+            attemptedArtifacts: [ArtifactPath],
+            logs: [RunLogRecord]
+        ) {
+            self.runID = runID
+            self.schemaVersion = schemaVersion
+            self.toolVersion = toolVersion
+            self.plan = plan
+            self.startedAt = startedAt
+            self.endedAt = endedAt
+            self.status = status
+            self.targetResults = targetResults
+            self.attemptedArtifacts = attemptedArtifacts
+            self.logs = logs
+        }
+
+        public func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode(runID, forKey: .runID)
+            try container.encode(schemaVersion, forKey: .schemaVersion)
+            try container.encode(toolVersion, forKey: .toolVersion)
+            try container.encode(plan, forKey: .plan)
+            try container.encode(startedAt, forKey: .startedAt)
+            try container.encodeRequired(endedAt, forKey: .endedAt)
+            try container.encode(status, forKey: .status)
+            try container.encode(targetResults, forKey: .targetResults)
+            try container.encode(attemptedArtifacts, forKey: .attemptedArtifacts)
+            try container.encode(logs, forKey: .logs)
+        }
+
+        private enum CodingKeys: String, CodingKey {
+            case runID
+            case schemaVersion
+            case toolVersion
+            case plan
+            case startedAt
+            case endedAt
+            case status
+            case targetResults
+            case attemptedArtifacts
+            case logs
+        }
+    }
+
+    struct RunPlanRecord: Codable, Equatable, Sendable {
+        public let source: SourceRecord
+        public let output: OutputRecord
+        public let layout: Layout
+        public let targetIDs: [String]
+
+        public init(
+            source: SourceRecord,
+            output: OutputRecord,
+            layout: Layout,
+            targetIDs: [String]
+        ) {
+            self.source = source
+            self.output = output
+            self.layout = layout
+            self.targetIDs = targetIDs
+        }
+    }
+
+    struct RunTargetRecord: Codable, Equatable, Sendable {
+        public let targetID: String
+        public let status: RunTargetStatus
+        public let phases: [PhaseRecord]
+        public let artifacts: [ArtifactPath]
+        public let attemptedArtifacts: [ArtifactPath]
+        public let failureSummary: String?
+
+        public init(
+            targetID: String,
+            status: RunTargetStatus,
+            phases: [PhaseRecord],
+            artifacts: [ArtifactPath],
+            attemptedArtifacts: [ArtifactPath],
+            failureSummary: String?
+        ) {
+            self.targetID = targetID
+            self.status = status
+            self.phases = phases
+            self.artifacts = artifacts
+            self.attemptedArtifacts = attemptedArtifacts
+            self.failureSummary = failureSummary
+        }
+
+        public func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode(targetID, forKey: .targetID)
+            try container.encode(status, forKey: .status)
+            try container.encode(phases, forKey: .phases)
+            try container.encode(artifacts, forKey: .artifacts)
+            try container.encode(attemptedArtifacts, forKey: .attemptedArtifacts)
+            try container.encodeRequired(failureSummary, forKey: .failureSummary)
+        }
+
+        private enum CodingKeys: String, CodingKey {
+            case targetID
+            case status
+            case phases
+            case artifacts
+            case attemptedArtifacts
+            case failureSummary
+        }
+    }
+
+    struct RunLogRecord: Codable, Equatable, Sendable {
+        public let kind: String
+        public let relativePath: ArtifactPath
+
+        public init(kind: String, relativePath: ArtifactPath) {
+            self.kind = kind
+            self.relativePath = relativePath
+        }
+    }
+}
+
+public extension PrivateHeaderGeneration {
+    enum StateJSON {
+        public static func encode<Value: Encodable>(_ value: Value) throws -> Data {
+            try encoder().encode(value)
+        }
+
+        public static func decode<Value: Decodable>(_ type: Value.Type, from data: Data) throws -> Value {
+            try decoder().decode(type, from: data)
+        }
+
+        public static func write<Value: Encodable>(_ value: Value, to url: URL) throws {
+            let data = try encode(value)
+            try data.write(to: url, options: [.atomic])
+        }
+
+        public static func read<Value: Decodable>(_ type: Value.Type, from url: URL) throws -> Value {
+            let data = try Data(contentsOf: url)
+            return try decode(type, from: data)
+        }
+
+        private static func encoder() -> JSONEncoder {
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+            encoder.dateEncodingStrategy = .custom { date, encoder in
+                var container = encoder.singleValueContainer()
+                try container.encode(date.timeIntervalSinceReferenceDate)
+            }
+            return encoder
+        }
+
+        private static func decoder() -> JSONDecoder {
+            let decoder = JSONDecoder()
+            decoder.dateDecodingStrategy = .custom { decoder in
+                let container = try decoder.singleValueContainer()
+                if let value = try? container.decode(Double.self) {
+                    return Date(timeIntervalSinceReferenceDate: value)
+                }
+                let value = try container.decode(String.self)
+                if let date = fractionalSecondsFormatter().date(from: value) ?? wholeSecondsFormatter().date(from: value) {
+                    return date
+                }
+                throw DecodingError.dataCorruptedError(
+                    in: container,
+                    debugDescription: "Invalid ISO 8601 date: \(value)"
+                )
+            }
+            return decoder
+        }
+
+        private static func fractionalSecondsFormatter() -> ISO8601DateFormatter {
+            let formatter = ISO8601DateFormatter()
+            formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+            return formatter
+        }
+
+        private static func wholeSecondsFormatter() -> ISO8601DateFormatter {
+            let formatter = ISO8601DateFormatter()
+            formatter.formatOptions = [.withInternetDateTime]
+            return formatter
+        }
+    }
+
+    struct RunSummary: Hashable, Sendable {
+        public let runID: String
+        public let startedAt: Date
+
+        public init(runID: String, startedAt: Date) {
+            self.runID = runID
+            self.startedAt = startedAt
+        }
+    }
+
+    enum RunHistoryRetention {
+        public static func retainedRunIDs(
+            from runs: [RunSummary],
+            limit: Int = 10
+        ) -> [String] {
+            guard limit > 0 else {
+                return []
+            }
+
+            return runs
+                .sorted {
+                    if $0.startedAt == $1.startedAt {
+                        $0.runID > $1.runID
+                    } else {
+                        $0.startedAt > $1.startedAt
+                    }
+                }
+                .prefix(limit)
+                .map(\.runID)
+        }
+    }
+}
+
+extension PrivateHeaderGeneration.Source.Platform: Codable {}
+
+private extension KeyedEncodingContainer {
+    mutating func encodeRequired<Value: Encodable>(_ value: Value?, forKey key: Key) throws {
+        if let value {
+            try encode(value, forKey: key)
+        } else {
+            try encodeNil(forKey: key)
+        }
+    }
+}

--- a/Sources/PrivateHeaderKitCore/PrivateHeaderGenerationTargetResolver.swift
+++ b/Sources/PrivateHeaderKitCore/PrivateHeaderGenerationTargetResolver.swift
@@ -1,0 +1,268 @@
+import Foundation
+
+extension PrivateHeaderGeneration {
+    enum TargetKind: String, CaseIterable, Hashable, Sendable {
+        case framework
+        case privateFramework
+        case systemBundle
+        case usrLibDylib
+        case nestedBundle
+        case other
+    }
+
+    struct TargetCandidate: Hashable, Sendable {
+        let identifier: String
+        let displayName: String
+        let kind: TargetKind
+        let aliases: [String]
+
+        init(
+            identifier: String,
+            displayName: String,
+            kind: TargetKind,
+            aliases: [String] = []
+        ) throws {
+            try Self.validateNonEmpty(identifier, field: "identifier")
+            try Self.validateNonEmpty(displayName, field: "displayName")
+            self.identifier = identifier
+            self.displayName = displayName
+            self.kind = kind
+            self.aliases = aliases.filter { !$0.isEmpty }
+        }
+
+        var searchableNames: [String] {
+            [displayName] + inferredAliases + aliases
+        }
+
+        private static func validateNonEmpty(_ value: String, field: String) throws {
+            guard !value.isEmpty else {
+                throw ValidationError.emptyComponent(field: field)
+            }
+        }
+
+        private var inferredAliases: [String] {
+            switch kind {
+            case .usrLibDylib where !displayName.hasPrefix("/"):
+                ["/usr/lib/\(displayName)"]
+            default:
+                []
+            }
+        }
+    }
+
+    enum TargetSelection: Hashable, Sendable {
+        case allAvailable
+        case targets([TargetCandidate])
+    }
+
+    struct TargetQuery: Hashable, Sendable {
+        let rawValue: String
+        let terms: [String]
+
+        init(commaSeparated rawValue: String) throws {
+            let terms = rawValue
+                .split(separator: ",", omittingEmptySubsequences: false)
+                .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            try Self.validate(terms: terms)
+            self.rawValue = rawValue
+            self.terms = terms
+        }
+
+        var requestsAllAvailableTargets: Bool {
+            terms.count == 1 && Self.allAvailableTerms.contains(Self.normalize(terms[0]))
+        }
+
+        private static let allAvailableTerms: Set<String> = [
+            "all",
+            "@all",
+            "すべて",
+        ]
+        private static let systemLibraryPrefix = "/System/Library/"
+        private static let usrLibPrefix = "/usr/lib/"
+
+        private static func validate(terms: [String]) throws {
+            guard !terms.isEmpty else {
+                throw ValidationError.emptyComponent(field: "query")
+            }
+
+            var requestedAll = false
+            for term in terms {
+                guard !term.isEmpty else {
+                    throw ValidationError.emptyComponent(field: "query")
+                }
+                let normalizedTerm = normalize(term)
+                if allAvailableTerms.contains(normalizedTerm) {
+                    requestedAll = true
+                    continue
+                }
+                guard isSafeTargetSelector(term) else {
+                    throw ValidationError.invalidPathComponent(field: "query", value: term)
+                }
+            }
+
+            if requestedAll && terms.count > 1 {
+                throw ValidationError.invalidAllTargetsCombination
+            }
+        }
+
+        private static func normalize(_ value: String) -> String {
+            value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        }
+
+        private static func isSafeTargetSelector(_ value: String) -> Bool {
+            guard !value.contains("\0") else { return false }
+            if value.hasPrefix(systemLibraryPrefix) {
+                return isValidSystemLibrarySelector(value)
+            }
+            if value.hasPrefix(usrLibPrefix) {
+                return isValidUsrLibDylibSelector(value)
+            }
+            if value.hasPrefix("/") {
+                return false
+            }
+            let components = value.split(separator: "/", omittingEmptySubsequences: false).map(String.init)
+            return components.allSatisfy(isSafeRelativePathComponent)
+        }
+
+        private static func isValidSystemLibrarySelector(_ value: String) -> Bool {
+            let relativePath = String(value.dropFirst(systemLibraryPrefix.count))
+            let components = relativePath.split(separator: "/", omittingEmptySubsequences: false).map(String.init)
+            return components.allSatisfy(isSafeRelativePathComponent)
+        }
+
+        private static func isValidUsrLibDylibSelector(_ value: String) -> Bool {
+            let name = String(value.dropFirst(usrLibPrefix.count))
+            return isSafeRelativePathComponent(name)
+                && !name.contains("/")
+                && name.lowercased().hasSuffix(".dylib")
+        }
+
+        private static func isSafeRelativePathComponent(_ component: String) -> Bool {
+            !component.isEmpty
+                && component != "."
+                && component != ".."
+                && !component.contains("..")
+        }
+    }
+
+    struct TargetResolver: Hashable, Sendable {
+        let candidates: [TargetCandidate]
+
+        init(candidates: [TargetCandidate]) {
+            self.candidates = candidates
+        }
+
+        func resolve(_ query: TargetQuery) -> TargetResolution {
+            if query.requestsAllAvailableTargets {
+                return .selected(.allAvailable)
+            }
+
+            var selected: [TargetCandidate] = []
+            var selectedIDs: Set<String> = []
+            var ambiguities: [TargetResolution.Ambiguity] = []
+            var failures: [TargetResolution.Failure] = []
+
+            for term in query.terms {
+                let matches = matches(for: term)
+                switch matches.count {
+                case 0:
+                    failures.append(
+                        TargetResolution.Failure(
+                            query: term,
+                            reason: .noMatch
+                        )
+                    )
+                case 1:
+                    let candidate = matches[0]
+                    if selectedIDs.insert(candidate.identifier).inserted {
+                        selected.append(candidate)
+                    }
+                default:
+                    ambiguities.append(
+                        TargetResolution.Ambiguity(
+                            query: term,
+                            candidates: matches
+                        )
+                    )
+                }
+            }
+
+            if !ambiguities.isEmpty, !failures.isEmpty {
+                return .unresolved(ambiguities: ambiguities, failures: failures)
+            }
+            if !failures.isEmpty {
+                return .failed(failures)
+            }
+            if !ambiguities.isEmpty {
+                return .needsDisambiguation(ambiguities)
+            }
+            return .selected(.targets(selected))
+        }
+
+        private func matches(for term: String) -> [TargetCandidate] {
+            let normalizedTerm = Self.normalize(term)
+            let exactMatches = candidates.filter { candidate in
+                candidate.searchableNames.contains { Self.normalize($0) == normalizedTerm }
+            }
+            if !exactMatches.isEmpty {
+                return exactMatches
+            }
+
+            return candidates.filter { candidate in
+                candidate.searchableNames.contains { Self.normalize($0).contains(normalizedTerm) }
+            }
+        }
+
+        private static func normalize(_ value: String) -> String {
+            value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        }
+    }
+
+    enum TargetResolution: Hashable, Sendable {
+        case selected(TargetSelection)
+        case needsDisambiguation([Ambiguity])
+        case failed([Failure])
+        case unresolved(ambiguities: [Ambiguity], failures: [Failure])
+
+        struct Ambiguity: Hashable, Sendable {
+            let query: String
+            let candidates: [TargetCandidate]
+
+            init(query: String, candidates: [TargetCandidate]) {
+                self.query = query
+                self.candidates = candidates
+            }
+        }
+
+        struct Failure: Hashable, Sendable {
+            let query: String
+            let reason: FailureReason
+
+            init(query: String, reason: FailureReason) {
+                self.query = query
+                self.reason = reason
+            }
+        }
+
+        enum FailureReason: String, Hashable, Sendable {
+            case noMatch
+        }
+    }
+
+    enum ValidationError: Error, Equatable, CustomStringConvertible, Sendable {
+        case emptyComponent(field: String)
+        case invalidPathComponent(field: String, value: String)
+        case invalidAllTargetsCombination
+
+        var description: String {
+            switch self {
+            case .emptyComponent(let field):
+                "\(field) must not be empty"
+            case .invalidPathComponent(let field, let value):
+                "\(field) is not safe as a path component: \(value)"
+            case .invalidAllTargetsCombination:
+                "all available targets cannot be combined with explicit target queries"
+            }
+        }
+    }
+}

--- a/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationArtifactStoreTests.swift
+++ b/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationArtifactStoreTests.swift
@@ -1,0 +1,179 @@
+import Foundation
+import Testing
+
+import PrivateHeaderKitCore
+
+@Suite
+struct PrivateHeaderGenerationArtifactStoreTests {
+    @Test func cleanupPreservesUnknownFilesInManagedParentDirectories() throws {
+        let root = try makeTemporaryDirectory()
+        defer {
+            try? FileManager.default.removeItem(at: root)
+        }
+        let managed = try PrivateHeaderGeneration.ArtifactPath("Frameworks/Foo/Foo.h")
+
+        try writeFile("Frameworks/Foo/Foo.h", in: root)
+        try writeFile("Frameworks/Foo/Notes.txt", in: root)
+
+        let result = try PrivateHeaderGeneration.ArtifactStore.cleanupManagedArtifacts(
+            in: root,
+            artifacts: [managed]
+        )
+
+        #expect(result.deletedArtifacts == [managed])
+        #expect(result.missingArtifacts.isEmpty)
+        #expect(!pathExists("Frameworks/Foo/Foo.h", in: root))
+        #expect(pathExists("Frameworks/Foo/Notes.txt", in: root))
+        #expect(directoryExists("Frameworks/Foo", in: root))
+    }
+
+    @Test func cleanupPrunesEmptyParentDirectoriesUpToArtifactRoot() throws {
+        let root = try makeTemporaryDirectory()
+        defer {
+            try? FileManager.default.removeItem(at: root)
+        }
+        let managed = try PrivateHeaderGeneration.ArtifactPath("Frameworks/Foo/Foo.h")
+
+        try writeFile("Frameworks/Foo/Foo.h", in: root)
+
+        let result = try PrivateHeaderGeneration.ArtifactStore.cleanupManagedArtifacts(
+            in: root,
+            artifacts: [managed]
+        )
+
+        #expect(result.prunedDirectories.map(\.rawValue) == ["Frameworks", "Frameworks/Foo"])
+        #expect(!pathExists("Frameworks/Foo/Foo.h", in: root))
+        #expect(!pathExists("Frameworks/Foo", in: root))
+        #expect(!pathExists("Frameworks", in: root))
+        #expect(directoryExists(root))
+    }
+
+    @Test func cleanupPreservesArtifactRootItself() throws {
+        let root = try makeTemporaryDirectory()
+        defer {
+            try? FileManager.default.removeItem(at: root)
+        }
+
+        try writeFile("Root.h", in: root)
+
+        try PrivateHeaderGeneration.ArtifactStore.cleanupManagedArtifacts(
+            in: root,
+            artifacts: [try PrivateHeaderGeneration.ArtifactPath("Root.h")]
+        )
+
+        #expect(directoryExists(root))
+        #expect(try FileManager.default.contentsOfDirectory(atPath: root.path).isEmpty)
+    }
+
+    @Test func cleanupTreatsMissingManagedPathsAsSuccess() throws {
+        let root = try makeTemporaryDirectory()
+        defer {
+            try? FileManager.default.removeItem(at: root)
+        }
+        let missing = try PrivateHeaderGeneration.ArtifactPath("Frameworks/Missing/Missing.h")
+
+        let result = try PrivateHeaderGeneration.ArtifactStore.cleanupManagedArtifacts(
+            in: root,
+            artifacts: [missing]
+        )
+
+        #expect(result.deletedArtifacts.isEmpty)
+        #expect(result.missingArtifacts == [missing])
+        #expect(result.prunedDirectories.isEmpty)
+        #expect(directoryExists(root))
+    }
+
+    @Test func cleanupCandidatesDedupeManifestAndAttemptedArtifactsDeterministically() throws {
+        let alpha = try PrivateHeaderGeneration.ArtifactPath("Frameworks/Alpha/Alpha.h")
+        let beta = try PrivateHeaderGeneration.ArtifactPath("Frameworks/Beta/Beta.h")
+        let gamma = try PrivateHeaderGeneration.ArtifactPath("Frameworks/Gamma/Gamma.h")
+
+        let candidates = PrivateHeaderGeneration.ArtifactStore.cleanupCandidates(
+            manifestArtifacts: [beta, alpha, beta],
+            attemptedArtifacts: [gamma, alpha]
+        )
+
+        #expect(candidates.map(\.rawValue) == [
+            "Frameworks/Alpha/Alpha.h",
+            "Frameworks/Beta/Beta.h",
+            "Frameworks/Gamma/Gamma.h",
+        ])
+    }
+
+    @Test func cleanupCanRemoveManagedDirectories() throws {
+        let root = try makeTemporaryDirectory()
+        defer {
+            try? FileManager.default.removeItem(at: root)
+        }
+        let managedDirectory = try PrivateHeaderGeneration.ArtifactPath("SystemLibrary/Foo.bundle")
+
+        try writeFile("SystemLibrary/Foo.bundle/Headers/Foo.h", in: root)
+        try writeFile("SystemLibrary/Foo.bundle/Modules/Foo.swiftinterface", in: root)
+
+        let result = try PrivateHeaderGeneration.ArtifactStore.cleanupManagedArtifacts(
+            in: root,
+            artifacts: [managedDirectory]
+        )
+
+        #expect(result.deletedArtifacts == [managedDirectory])
+        #expect(!pathExists("SystemLibrary/Foo.bundle", in: root))
+        #expect(!pathExists("SystemLibrary", in: root))
+        #expect(directoryExists(root))
+    }
+
+    @Test func cleanupRejectsResolvedPathsOutsideArtifactRoot() throws {
+        let base = try makeTemporaryDirectory()
+        defer {
+            try? FileManager.default.removeItem(at: base)
+        }
+        let root = base.appendingPathComponent("artifacts", isDirectory: true)
+        let outside = base.appendingPathComponent("outside", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: outside, withIntermediateDirectories: true)
+        try writeFile("Outside.h", in: outside)
+        try FileManager.default.createSymbolicLink(
+            at: root.appendingPathComponent("link"),
+            withDestinationURL: outside
+        )
+
+        #expect(throws: PrivateHeaderGeneration.ArtifactStoreError.self) {
+            try PrivateHeaderGeneration.ArtifactStore.cleanupManagedArtifacts(
+                in: root,
+                artifacts: [try PrivateHeaderGeneration.ArtifactPath("link/Outside.h")]
+            )
+        }
+        #expect(pathExists("Outside.h", in: outside))
+    }
+}
+
+private func makeTemporaryDirectory() throws -> URL {
+    let directory = FileManager.default.temporaryDirectory
+        .appendingPathComponent("PrivateHeaderGenerationArtifactStoreTests-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    return directory
+}
+
+private func writeFile(_ relativePath: String, in root: URL) throws {
+    let url = root.appendingPathComponent(relativePath)
+    try FileManager.default.createDirectory(
+        at: url.deletingLastPathComponent(),
+        withIntermediateDirectories: true
+    )
+    try Data("contents".utf8).write(to: url)
+}
+
+private func pathExists(_ relativePath: String, in root: URL) -> Bool {
+    FileManager.default.fileExists(
+        atPath: root.appendingPathComponent(relativePath).path
+    )
+}
+
+private func directoryExists(_ relativePath: String, in root: URL) -> Bool {
+    directoryExists(root.appendingPathComponent(relativePath, isDirectory: true))
+}
+
+private func directoryExists(_ url: URL) -> Bool {
+    var isDirectory = ObjCBool(false)
+    return FileManager.default.fileExists(atPath: url.path, isDirectory: &isDirectory)
+        && isDirectory.boolValue
+}

--- a/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationResumeTests.swift
+++ b/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationResumeTests.swift
@@ -1,0 +1,458 @@
+import Foundation
+import Testing
+
+import PrivateHeaderKitCore
+
+@Suite
+struct PrivateHeaderGenerationResumeTests {
+    @Test func completedTargetsWithExistingManagedArtifactsAreSkipped() throws {
+        let plan = try makeRunPlan(targetIDs: ["framework:Foo", "framework:Bar"])
+        let manifest = try makeManifest(
+            targets: [
+                makeTarget("framework:Foo", status: .completed),
+                makeTarget("framework:Bar", status: .completed),
+            ]
+        )
+
+        let summary = PrivateHeaderGeneration.makeResumeSummary(
+            plan: plan,
+            manifest: manifest,
+            artifactExists: existingArtifacts([
+                "Frameworks/Foo/Foo.h",
+                "Frameworks/Bar/Bar.h",
+            ])
+        )
+
+        #expect(summary.targetIDsToRun == [])
+        #expect(
+            summary.counts == PrivateHeaderGeneration.ResumeTargetCounts(
+                total: 2,
+                completed: 2,
+                partial: 0,
+                failed: 0,
+                interrupted: 0,
+                commitFailed: 0,
+                stale: 0,
+                pending: 0
+            )
+        )
+    }
+
+    @Test func failedPartialInterruptedCommitFailedAndStaleTargetsRerun() throws {
+        let targetIDs = [
+            "framework:Failed",
+            "framework:Partial",
+            "framework:Interrupted",
+            "framework:CommitFailed",
+            "framework:Stale",
+        ]
+        let plan = try makeRunPlan(targetIDs: targetIDs)
+        let manifest = try makeManifest(
+            targets: [
+                makeTarget("framework:Failed", status: .failed),
+                makeTarget("framework:Partial", status: .partial),
+                makeTarget("framework:Interrupted", status: .interrupted),
+                makeTarget("framework:CommitFailed", status: .commitFailed),
+                makeTarget("framework:Stale", status: .stale),
+            ]
+        )
+
+        let summary = PrivateHeaderGeneration.makeResumeSummary(
+            plan: plan,
+            manifest: manifest,
+            artifactExists: existingArtifacts([])
+        )
+
+        #expect(summary.targetIDsToRun == targetIDs)
+        #expect(summary.counts.failed == 1)
+        #expect(summary.counts.partial == 1)
+        #expect(summary.counts.interrupted == 1)
+        #expect(summary.counts.commitFailed == 1)
+        #expect(summary.counts.stale == 1)
+        #expect(summary.counts.unfinished == 5)
+    }
+
+    @Test func missingManagedArtifactMakesCompletedTargetStale() throws {
+        let plan = try makeRunPlan(targetIDs: ["framework:Foo"])
+        let manifest = try makeManifest(
+            targets: [
+                makeTarget(
+                    "framework:Foo",
+                    status: .completed,
+                    artifacts: [
+                        "Frameworks/Foo/Foo.h",
+                        "Frameworks/Foo/Foo.swiftinterface",
+                    ]
+                ),
+            ]
+        )
+
+        let summary = PrivateHeaderGeneration.makeResumeSummary(
+            plan: plan,
+            manifest: manifest,
+            artifactExists: existingArtifacts([
+                "Frameworks/Foo/Foo.h",
+            ])
+        )
+
+        #expect(summary.targets == [
+            PrivateHeaderGeneration.ResumeTargetDecision(
+                targetID: "framework:Foo",
+                status: .stale
+            ),
+        ])
+        #expect(summary.targetIDsToRun == ["framework:Foo"])
+        #expect(summary.counts.completed == 0)
+        #expect(summary.counts.stale == 1)
+    }
+
+    @Test func missingManifestEntryIsPendingAndReruns() throws {
+        let plan = try makeRunPlan(targetIDs: ["framework:Foo", "framework:New"])
+        let manifest = try makeManifest(
+            targets: [
+                makeTarget("framework:Foo", status: .completed),
+            ]
+        )
+
+        let summary = PrivateHeaderGeneration.makeResumeSummary(
+            plan: plan,
+            manifest: manifest,
+            artifactExists: existingArtifacts([
+                "Frameworks/Foo/Foo.h",
+            ])
+        )
+
+        #expect(summary.targetIDsToRun == ["framework:New"])
+        #expect(summary.counts.completed == 1)
+        #expect(summary.counts.pending == 1)
+    }
+
+    @Test func selectedTargetSetMismatchReturnsStructuredReason() throws {
+        let plan = try makeRunPlan(targetIDs: ["framework:Foo", "framework:Bar"])
+        let manifest = try makeManifest(
+            targets: [
+                makeTarget("framework:Foo", status: .partial),
+            ]
+        )
+        let latestRun = try makeRunRecord(
+            plan: makeRunPlan(targetIDs: ["framework:Foo"])
+        )
+
+        #expect(
+            PrivateHeaderGeneration.evaluateResumeCompatibility(
+                plan: plan,
+                manifest: manifest,
+                latestRun: latestRun
+            ) == .incompatible(
+                [
+                    .selectedTargetSetMismatch(
+                        expected: ["framework:Bar", "framework:Foo"],
+                        actual: ["framework:Foo"],
+                        record: .run
+                    ),
+                ]
+            )
+        )
+    }
+
+    @Test func selectedTargetSetIsNotInferredFromManifestWithoutLatestRun() throws {
+        let plan = try makeRunPlan(targetIDs: ["framework:Foo", "framework:Bar"])
+        let manifest = try makeManifest(
+            targets: [
+                makeTarget("framework:Foo", status: .partial),
+            ]
+        )
+
+        #expect(
+            PrivateHeaderGeneration.evaluateResumeCompatibility(
+                plan: plan,
+                manifest: manifest
+            ) == .incompatible(
+                [
+                    .missingLatestRun(runID: "run-001"),
+                ]
+            )
+        )
+    }
+
+    @Test func sourceBuildMismatchReturnsStructuredReason() throws {
+        let plan = try makeRunPlan(targetIDs: ["framework:Foo"])
+        let expectedSource = try makeSource()
+        let actualSource = try makeSource(build: "24B1")
+        let manifest = try makeManifest(
+            source: actualSource,
+            targets: [
+                makeTarget("framework:Foo", status: .completed),
+            ]
+        )
+
+        #expect(
+            PrivateHeaderGeneration.evaluateResumeCompatibility(
+                plan: plan,
+                manifest: manifest
+            ) == .incompatible(
+                [
+                    .sourceBuildMismatch(
+                        expected: expectedSource,
+                        actual: actualSource,
+                        record: .manifest
+                    ),
+                ]
+            )
+        )
+    }
+
+    @Test func layoutMismatchReturnsStructuredReason() throws {
+        let plan = try makeRunPlan(targetIDs: ["framework:Foo"])
+        let manifest = try makeManifest(
+            layout: .bundle,
+            targets: [
+                makeTarget("framework:Foo", status: .completed),
+            ]
+        )
+
+        #expect(
+            PrivateHeaderGeneration.evaluateResumeCompatibility(
+                plan: plan,
+                manifest: manifest
+            ) == .incompatible(
+                [
+                    .layoutMismatch(
+                        expected: .headers,
+                        actual: .bundle,
+                        record: .manifest
+                    ),
+                ]
+            )
+        )
+    }
+
+    @Test func outputMismatchReturnsStructuredReason() throws {
+        let plan = try makeRunPlan(targetIDs: ["framework:Foo"])
+        let mismatchedOutput = makeOutput(baseDirectory: "/Volumes/Data/Headers")
+        let manifest = try makeManifest(
+            output: mismatchedOutput,
+            targets: [
+                makeTarget("framework:Foo", status: .completed),
+            ]
+        )
+
+        #expect(
+            PrivateHeaderGeneration.evaluateResumeCompatibility(
+                plan: plan,
+                manifest: manifest
+            ) == .incompatible(
+                [
+                    .outputMismatch(
+                        expected: makeOutput(),
+                        actual: mismatchedOutput,
+                        record: .manifest
+                    ),
+                ]
+            )
+        )
+    }
+
+    @Test func unsupportedManifestSchemaReturnsStructuredReason() throws {
+        let plan = try makeRunPlan(targetIDs: ["framework:Foo"])
+        let manifest = try makeManifest(
+            schemaVersion: 99,
+            targets: [
+                makeTarget("framework:Foo", status: .completed),
+            ]
+        )
+
+        #expect(
+            PrivateHeaderGeneration.evaluateResumeCompatibility(
+                plan: plan,
+                manifest: manifest,
+                supportedSchemaVersions: [1]
+            ) == .incompatible(
+                [
+                    .unsupportedManifestSchema(actual: 99, supported: [1]),
+                ]
+            )
+        )
+    }
+
+    @Test func unsupportedRunSchemaReturnsStructuredReason() throws {
+        let plan = try makeRunPlan(targetIDs: ["framework:Foo"])
+        let manifest = try makeManifest(
+            targets: [
+                makeTarget("framework:Foo", status: .completed),
+            ]
+        )
+        let latestRun = try makeRunRecord(plan: plan, schemaVersion: 99)
+
+        #expect(
+            PrivateHeaderGeneration.evaluateResumeCompatibility(
+                plan: plan,
+                manifest: manifest,
+                latestRun: latestRun,
+                supportedSchemaVersions: [1]
+            ) == .incompatible(
+                [
+                    .unsupportedRunSchema(actual: 99, supported: [1]),
+                ]
+            )
+        )
+    }
+
+    @Test func nonInteractiveUnfinishedCompatibleRunRequiresExplicitResume() throws {
+        let plan = try makeRunPlan(targetIDs: ["framework:Foo"])
+        let manifest = try makeManifest(
+            targets: [
+                makeTarget("framework:Foo", status: .partial),
+            ]
+        )
+        let latestRun = try makeRunRecord(plan: plan)
+        let summary = PrivateHeaderGeneration.makeResumeSummary(
+            plan: plan,
+            manifest: manifest,
+            latestRun: latestRun,
+            artifactExists: existingArtifacts([])
+        )
+
+        #expect(
+            PrivateHeaderGeneration.nonInteractiveResumeDecision(
+                plan: plan,
+                manifest: manifest,
+                latestRun: latestRun,
+                resumeRequested: false,
+                artifactExists: existingArtifacts([])
+            ) == .resumeRequired(summary)
+        )
+    }
+
+    @Test func nonInteractiveExplicitResumeAllowsCompatibleUnfinishedRun() throws {
+        let plan = try makeRunPlan(targetIDs: ["framework:Foo"])
+        let manifest = try makeManifest(
+            targets: [
+                makeTarget("framework:Foo", status: .partial),
+            ]
+        )
+        let latestRun = try makeRunRecord(plan: plan)
+        let summary = PrivateHeaderGeneration.makeResumeSummary(
+            plan: plan,
+            manifest: manifest,
+            latestRun: latestRun,
+            artifactExists: existingArtifacts([])
+        )
+
+        #expect(
+            PrivateHeaderGeneration.nonInteractiveResumeDecision(
+                plan: plan,
+                manifest: manifest,
+                latestRun: latestRun,
+                resumeRequested: true,
+                artifactExists: existingArtifacts([])
+            ) == .resume(summary)
+        )
+    }
+}
+
+private func makeSource(
+    build: String = "24A5355q"
+) throws -> PrivateHeaderGeneration.SourceRecord {
+    let source = try PrivateHeaderGeneration.Source(
+        platform: .iOS,
+        version: "27.0",
+        build: build
+    )
+    return PrivateHeaderGeneration.SourceRecord(source: source)
+}
+
+private func makeOutput(
+    baseDirectory: String = "/tmp/PrivateHeaderKit"
+) -> PrivateHeaderGeneration.OutputRecord {
+    PrivateHeaderGeneration.OutputRecord(
+        baseDirectory: baseDirectory,
+        artifactDirectory: "\(baseDirectory)/iOS27.0(24A5355q)",
+        stateDirectory: "\(baseDirectory)/.state/iOS27.0(24A5355q)"
+    )
+}
+
+private func makeRunPlan(
+    targetIDs: [String],
+    source: PrivateHeaderGeneration.SourceRecord? = nil,
+    output: PrivateHeaderGeneration.OutputRecord? = nil,
+    layout: PrivateHeaderGeneration.Layout = .headers
+) throws -> PrivateHeaderGeneration.RunPlanRecord {
+    try PrivateHeaderGeneration.RunPlanRecord(
+        source: source ?? makeSource(),
+        output: output ?? makeOutput(),
+        layout: layout,
+        targetIDs: targetIDs
+    )
+}
+
+private func makeManifest(
+    schemaVersion: Int = 1,
+    source: PrivateHeaderGeneration.SourceRecord? = nil,
+    output: PrivateHeaderGeneration.OutputRecord? = nil,
+    layout: PrivateHeaderGeneration.Layout = .headers,
+    targets: [PrivateHeaderGeneration.TargetRecord]
+) throws -> PrivateHeaderGeneration.Manifest {
+    PrivateHeaderGeneration.Manifest(
+        schemaVersion: schemaVersion,
+        toolVersion: "0.1.0",
+        source: try source ?? makeSource(),
+        output: output ?? makeOutput(),
+        layout: layout,
+        latestRunID: "run-001",
+        targets: targets,
+        updatedAt: Date(timeIntervalSince1970: 1_100)
+    )
+}
+
+private func makeRunRecord(
+    plan: PrivateHeaderGeneration.RunPlanRecord,
+    schemaVersion: Int = 1
+) throws -> PrivateHeaderGeneration.RunRecord {
+    PrivateHeaderGeneration.RunRecord(
+        runID: "run-001",
+        schemaVersion: schemaVersion,
+        toolVersion: "0.1.0",
+        plan: plan,
+        startedAt: Date(timeIntervalSince1970: 1_000),
+        endedAt: nil,
+        status: .running,
+        targetResults: [],
+        attemptedArtifacts: [],
+        logs: []
+    )
+}
+
+private func makeTarget(
+    _ id: String,
+    status: PrivateHeaderGeneration.TargetStatus,
+    artifacts: [String]? = nil
+) throws -> PrivateHeaderGeneration.TargetRecord {
+    let displayName = String(id.split(separator: ":").last ?? Substring(id))
+    let artifactPaths = try (artifacts ?? ["Frameworks/\(displayName)/\(displayName).h"]).map {
+        try PrivateHeaderGeneration.ArtifactPath($0)
+    }
+    return PrivateHeaderGeneration.TargetRecord(
+        id: id,
+        displayName: "\(displayName).framework",
+        kind: "framework",
+        status: status,
+        phases: [],
+        artifacts: artifactPaths,
+        lastRunID: "run-001",
+        updatedAt: Date(timeIntervalSince1970: 1_100),
+        failureSummary: status == .completed ? nil : "\(status.rawValue) target"
+    )
+}
+
+private func existingArtifacts(
+    _ paths: Set<String>
+) -> PrivateHeaderGeneration.ArtifactExistence {
+    { paths.contains($0.rawValue) }
+}
+
+private func existingArtifacts(
+    _ paths: [String]
+) -> PrivateHeaderGeneration.ArtifactExistence {
+    existingArtifacts(Set(paths))
+}

--- a/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationSourceDiscoveryTests.swift
+++ b/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationSourceDiscoveryTests.swift
@@ -1,0 +1,132 @@
+import Testing
+
+import PrivateHeaderKitCore
+
+@Suite
+struct PrivateHeaderGenerationSourceDiscoveryTests {
+    @Test func parsesAvailableIOSRuntimeSourcesAndUsesSourceLabels() throws {
+        let candidates = try PrivateHeaderGeneration.SourceDiscovery.iOSRuntimeSourceCandidates(
+            fromSimctlListRuntimesJSON: """
+            {
+              "runtimes": [
+                {"name": "watchOS 27.0", "platform": "watchOS", "version": "27.0", "buildversion": "24A1", "isAvailable": true},
+                {"name": "iOS 26.0", "platform": "iOS", "version": "26.0", "buildversion": "23A1", "isAvailable": false},
+                {"name": "iOS Missing Build", "platform": "iOS", "version": "26.1", "isAvailable": true},
+                {"name": "iOS Missing Version", "platform": "iOS", "buildversion": "23B1", "isAvailable": true},
+                {
+                  "name": "iOS 27.0",
+                  "platform": "iOS",
+                  "version": "27.0",
+                  "buildversion": "24A5355q",
+                  "identifier": "com.apple.CoreSimulator.SimRuntime.iOS-27-0",
+                  "runtimeRoot": "/runtimes/iOS-27.0",
+                  "isAvailable": true
+                }
+              ]
+            }
+            """
+        )
+
+        let candidate = try #require(candidates.only)
+        #expect(candidate.source.platform == .iOS)
+        #expect(candidate.source.version == "27.0")
+        #expect(candidate.source.build == "24A5355q")
+        #expect(candidate.source.label.displayName == "iOS 27.0 (24A5355q)")
+        #expect(candidate.source.label.directoryName == "iOS27.0(24A5355q)")
+        #expect(candidate.runtimeName == "iOS 27.0")
+        #expect(candidate.runtimeIdentifier == "com.apple.CoreSimulator.SimRuntime.iOS-27-0")
+        #expect(candidate.runtimeRoot == "/runtimes/iOS-27.0")
+    }
+
+    @Test func candidatesUseExplicitVersionBuildAndNameOrderForLatestSelection() throws {
+        let candidates = try PrivateHeaderGeneration.SourceDiscovery.iOSRuntimeSourceCandidates(
+            fromSimctlListRuntimesJSON: """
+            {
+              "runtimes": [
+                {"name": "iOS 26.10 B", "platform": "iOS", "version": "26.10", "buildversion": "23Z10", "identifier": "ios-26-10-b", "isAvailable": true},
+                {"name": "iOS 27.0", "platform": "iOS", "version": "27.0", "buildversion": "24A5355q", "identifier": "ios-27-0", "isAvailable": true},
+                {"name": "iOS 26.2", "platform": "iOS", "version": "26.2", "buildversion": "23C54", "identifier": "ios-26-2", "isAvailable": true},
+                {"name": "iOS 26.10", "platform": "iOS", "version": "26.10", "buildversion": "23Z9", "identifier": "ios-26-10-z9", "isAvailable": true},
+                {"name": "iOS 26.10 A", "platform": "iOS", "version": "26.10", "buildversion": "23Z10", "identifier": "ios-26-10-a", "isAvailable": true}
+              ]
+            }
+            """
+        )
+
+        #expect(candidates.map(\.source.label.displayName) == [
+            "iOS 26.2 (23C54)",
+            "iOS 26.10 (23Z9)",
+            "iOS 26.10 (23Z10)",
+            "iOS 27.0 (24A5355q)",
+        ])
+        #expect(candidates.map(\.runtimeName) == [
+            "iOS 26.2",
+            "iOS 26.10",
+            "iOS 26.10 A",
+            "iOS 27.0",
+        ])
+
+        let latest = try #require(
+            PrivateHeaderGeneration.SourceDiscovery.latestIOSRuntimeSourceCandidate(from: candidates)
+        )
+        #expect(latest.source.label.displayName == "iOS 27.0 (24A5355q)")
+    }
+
+    @Test func duplicateRuntimeSourcesAreCanonicalizedWithoutDependingOnJSONOrder() throws {
+        let firstOrder = """
+        {
+          "runtimes": [
+            {"name": "iOS 26.2 B", "platform": "iOS", "version": "26.2", "buildversion": "23C54", "identifier": "ios-26-2-b", "isAvailable": true},
+            {"name": "iOS 26.2 A", "platform": "iOS", "version": "26.2", "buildversion": "23C54", "identifier": "ios-26-2-a", "isAvailable": true}
+          ]
+        }
+        """
+        let secondOrder = """
+        {
+          "runtimes": [
+            {"name": "iOS 26.2 A", "platform": "iOS", "version": "26.2", "buildversion": "23C54", "identifier": "ios-26-2-a", "isAvailable": true},
+            {"name": "iOS 26.2 B", "platform": "iOS", "version": "26.2", "buildversion": "23C54", "identifier": "ios-26-2-b", "isAvailable": true}
+          ]
+        }
+        """
+
+        let first = try PrivateHeaderGeneration.SourceDiscovery.iOSRuntimeSourceCandidates(
+            fromSimctlListRuntimesJSON: firstOrder
+        )
+        let second = try PrivateHeaderGeneration.SourceDiscovery.iOSRuntimeSourceCandidates(
+            fromSimctlListRuntimesJSON: secondOrder
+        )
+
+        #expect(first == second)
+        #expect(first.map(\.source.label.displayName) == ["iOS 26.2 (23C54)"])
+        #expect(first.map(\.runtimeIdentifier) == ["ios-26-2-a"])
+    }
+
+    @Test func recognizesIOSRuntimeFromNameOrIdentifierWhenPlatformIsMissing() throws {
+        let candidates = try PrivateHeaderGeneration.SourceDiscovery.iOSRuntimeSourceCandidates(
+            fromSimctlListRuntimesJSON: """
+            {
+              "runtimes": [
+                {"name": "iOS 26.2", "version": "26.2", "buildversion": "23C54", "isAvailable": true},
+                {"identifier": "com.apple.CoreSimulator.SimRuntime.iOS-27-0", "version": "27.0", "buildversion": "24A5355q", "isAvailable": true}
+              ]
+            }
+            """
+        )
+
+        #expect(candidates.map(\.source.label.displayName) == [
+            "iOS 26.2 (23C54)",
+            "iOS 27.0 (24A5355q)",
+        ])
+        #expect(candidates.map(\.runtimeName) == [
+            "iOS 26.2",
+            "iOS 27.0 (24A5355q)",
+        ])
+    }
+}
+
+private extension Collection {
+    var only: Element? {
+        count == 1 ? first : nil
+    }
+}

--- a/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationStateTests.swift
+++ b/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationStateTests.swift
@@ -1,0 +1,318 @@
+import Foundation
+import Testing
+
+import PrivateHeaderKitCore
+
+@Suite
+struct PrivateHeaderGenerationManifestTests {
+    @Test func manifestRoundTripsAsPrettyJSON() throws {
+        let manifest = try makeManifest()
+
+        let data = try PrivateHeaderGeneration.StateJSON.encode(manifest)
+        let json = try #require(String(data: data, encoding: .utf8))
+        let decoded = try PrivateHeaderGeneration.StateJSON.decode(
+            PrivateHeaderGeneration.Manifest.self,
+            from: data
+        )
+
+        #expect(decoded == manifest)
+        #expect(json.contains("\n  \"layout\" : \"headers\""))
+        #expect(json.contains("\"schemaVersion\" : 1"))
+        #expect(json.contains("\"artifacts\" : [\n"))
+    }
+
+    @Test func manifestStoreWritesAndReadsJSON() throws {
+        let manifest = try makeManifest()
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("PrivateHeaderKitStateTests-\(UUID().uuidString)", isDirectory: true)
+        let url = directory.appendingPathComponent("manifest.json")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer {
+            try? FileManager.default.removeItem(at: directory)
+        }
+
+        try PrivateHeaderGeneration.StateJSON.write(manifest, to: url)
+        let decoded = try PrivateHeaderGeneration.StateJSON.read(
+            PrivateHeaderGeneration.Manifest.self,
+            from: url
+        )
+
+        #expect(decoded == manifest)
+    }
+
+    @Test func stateJSONPreservesFractionalSecondDates() throws {
+        let updatedAt = Date(timeIntervalSinceReferenceDate: .pi)
+        let manifest = try makeManifest(updatedAt: updatedAt)
+
+        let data = try PrivateHeaderGeneration.StateJSON.encode(manifest)
+        let json = try #require(String(data: data, encoding: .utf8))
+        let decoded = try PrivateHeaderGeneration.StateJSON.decode(
+            PrivateHeaderGeneration.Manifest.self,
+            from: data
+        )
+
+        #expect(decoded.updatedAt == manifest.updatedAt)
+        #expect(json.contains("\"updatedAt\" : 3.141592653589793"))
+    }
+
+    @Test func manifestEncodingKeepsRequiredNullFields() throws {
+        let source = try PrivateHeaderGeneration.Source(
+            platform: .iOS,
+            version: "27.0",
+            build: nil
+        )
+        let updatedAt = Date(timeIntervalSinceReferenceDate: 42)
+        let manifest = PrivateHeaderGeneration.Manifest(
+            schemaVersion: 1,
+            toolVersion: "0.1.0",
+            source: PrivateHeaderGeneration.SourceRecord(source: source),
+            output: PrivateHeaderGeneration.OutputRecord(
+                baseDirectory: "/tmp/PrivateHeaderKit",
+                artifactDirectory: "/tmp/PrivateHeaderKit/generated-headers",
+                stateDirectory: "/tmp/PrivateHeaderKit/.state"
+            ),
+            layout: .headers,
+            latestRunID: nil,
+            targets: [
+                PrivateHeaderGeneration.TargetRecord(
+                    id: "framework:Foo",
+                    displayName: "Foo.framework",
+                    kind: "framework",
+                    status: .completed,
+                    phases: [
+                        PrivateHeaderGeneration.PhaseRecord(name: "static ObjC", status: .completed),
+                    ],
+                    artifacts: [
+                        try PrivateHeaderGeneration.ArtifactPath("Frameworks/Foo/Foo.h"),
+                    ],
+                    lastRunID: nil,
+                    updatedAt: updatedAt,
+                    failureSummary: nil
+                ),
+            ],
+            updatedAt: updatedAt
+        )
+
+        let data = try PrivateHeaderGeneration.StateJSON.encode(manifest)
+        let json = try #require(String(data: data, encoding: .utf8))
+        let decoded = try PrivateHeaderGeneration.StateJSON.decode(
+            PrivateHeaderGeneration.Manifest.self,
+            from: data
+        )
+
+        #expect(decoded == manifest)
+        #expect(json.contains("\"build\" : null"))
+        #expect(json.contains("\"latestRunID\" : null"))
+        #expect(json.contains("\"lastRunID\" : null"))
+        #expect(json.contains("\"failureSummary\" : null"))
+    }
+
+    @Test func artifactPathRejectsAbsoluteTraversalAndEmptyPaths() {
+        #expect(throws: PrivateHeaderGeneration.StateValidationError.self) {
+            _ = try PrivateHeaderGeneration.ArtifactPath("/System/Library/Foo.h")
+        }
+        #expect(throws: PrivateHeaderGeneration.StateValidationError.self) {
+            _ = try PrivateHeaderGeneration.ArtifactPath("Frameworks/../Foo.h")
+        }
+        #expect(throws: PrivateHeaderGeneration.StateValidationError.self) {
+            _ = try PrivateHeaderGeneration.ArtifactPath("")
+        }
+    }
+
+    @Test func artifactPathValidationRunsDuringJSONDecode() throws {
+        let data = Data(#""../escape.h""#.utf8)
+
+        #expect(throws: PrivateHeaderGeneration.StateValidationError.self) {
+            _ = try PrivateHeaderGeneration.StateJSON.decode(
+                PrivateHeaderGeneration.ArtifactPath.self,
+                from: data
+            )
+        }
+    }
+}
+
+@Suite
+struct PrivateHeaderGenerationRunRecordTests {
+    @Test func runRecordRoundTripsTargetResultsAndAttemptedArtifacts() throws {
+        let run = try makeRunRecord()
+        let data = try PrivateHeaderGeneration.StateJSON.encode(run)
+        let decoded = try PrivateHeaderGeneration.StateJSON.decode(
+            PrivateHeaderGeneration.RunRecord.self,
+            from: data
+        )
+
+        #expect(decoded == run)
+        #expect(decoded.status == .partial)
+        #expect(decoded.targetResults.first?.status == .commitFailed)
+        #expect(decoded.attemptedArtifacts.map(\.rawValue) == ["Frameworks/Foo/Foo.h"])
+    }
+
+    @Test func runRecordEncodingKeepsRequiredNullFields() throws {
+        let manifest = try makeManifest()
+        let run = PrivateHeaderGeneration.RunRecord(
+            runID: "run-002",
+            schemaVersion: 1,
+            toolVersion: "0.1.0",
+            plan: PrivateHeaderGeneration.RunPlanRecord(
+                source: manifest.source,
+                output: manifest.output,
+                layout: manifest.layout,
+                targetIDs: ["framework:Foo"]
+            ),
+            startedAt: Date(timeIntervalSinceReferenceDate: 42),
+            endedAt: nil,
+            status: .running,
+            targetResults: [
+                PrivateHeaderGeneration.RunTargetRecord(
+                    targetID: "framework:Foo",
+                    status: .running,
+                    phases: [
+                        PrivateHeaderGeneration.PhaseRecord(name: "static ObjC", status: .running),
+                    ],
+                    artifacts: [],
+                    attemptedArtifacts: [],
+                    failureSummary: nil
+                ),
+            ],
+            attemptedArtifacts: [],
+            logs: []
+        )
+
+        let data = try PrivateHeaderGeneration.StateJSON.encode(run)
+        let json = try #require(String(data: data, encoding: .utf8))
+        let decoded = try PrivateHeaderGeneration.StateJSON.decode(
+            PrivateHeaderGeneration.RunRecord.self,
+            from: data
+        )
+
+        #expect(decoded == run)
+        #expect(json.contains("\"endedAt\" : null"))
+        #expect(json.contains("\"failureSummary\" : null"))
+    }
+
+    @Test func runHistoryRetentionKeepsLatestTenRuns() {
+        let base = Date(timeIntervalSince1970: 1_000)
+        let runs = (0..<12).map { index in
+            PrivateHeaderGeneration.RunSummary(
+                runID: "run-\(index)",
+                startedAt: base.addingTimeInterval(TimeInterval(index))
+            )
+        }
+
+        let retained = PrivateHeaderGeneration.RunHistoryRetention.retainedRunIDs(from: runs)
+
+        #expect(retained == [
+            "run-11",
+            "run-10",
+            "run-9",
+            "run-8",
+            "run-7",
+            "run-6",
+            "run-5",
+            "run-4",
+            "run-3",
+            "run-2",
+        ])
+    }
+
+    @Test func runHistoryRetentionUsesRunIDAsStableTieBreaker() {
+        let startedAt = Date(timeIntervalSince1970: 1_000)
+        let runs = [
+            PrivateHeaderGeneration.RunSummary(runID: "run-a", startedAt: startedAt),
+            PrivateHeaderGeneration.RunSummary(runID: "run-c", startedAt: startedAt),
+            PrivateHeaderGeneration.RunSummary(runID: "run-b", startedAt: startedAt),
+        ]
+
+        let retained = PrivateHeaderGeneration.RunHistoryRetention.retainedRunIDs(from: runs, limit: 2)
+
+        #expect(retained == ["run-c", "run-b"])
+    }
+}
+
+private func makeManifest(
+    updatedAt: Date = Date(timeIntervalSince1970: 1_000)
+) throws -> PrivateHeaderGeneration.Manifest {
+    let source = try PrivateHeaderGeneration.Source(
+        platform: .iOS,
+        version: "27.0",
+        build: "24A5355q"
+    )
+    let root = URL(fileURLWithPath: "/tmp/PrivateHeaderKit", isDirectory: true)
+    let output = PrivateHeaderGeneration.Output(
+        artifactBaseDirectory: root.appendingPathComponent("generated-headers", isDirectory: true),
+        stateBaseDirectory: root.appendingPathComponent(".state", isDirectory: true)
+    )
+    let plan = PrivateHeaderGeneration.makePlan(source: source, output: output)
+    return PrivateHeaderGeneration.Manifest(
+        schemaVersion: 1,
+        toolVersion: "0.1.0",
+        source: PrivateHeaderGeneration.SourceRecord(source: source),
+        output: PrivateHeaderGeneration.OutputRecord(plan: plan, baseDirectory: root),
+        layout: .headers,
+        latestRunID: "run-001",
+        targets: [
+            PrivateHeaderGeneration.TargetRecord(
+                id: "framework:Foo",
+                displayName: "Foo.framework",
+                kind: "framework",
+                status: .partial,
+                phases: [
+                    PrivateHeaderGeneration.PhaseRecord(name: "static ObjC", status: .completed),
+                    PrivateHeaderGeneration.PhaseRecord(
+                        name: "Swift interface",
+                        status: .failed,
+                        failureSummary: "swift interface failed"
+                    ),
+                ],
+                artifacts: [
+                    try PrivateHeaderGeneration.ArtifactPath("Frameworks/Foo/Foo.h"),
+                    try PrivateHeaderGeneration.ArtifactPath("Frameworks/Foo/Foo.swiftinterface"),
+                ],
+                lastRunID: "run-001",
+                updatedAt: updatedAt,
+                failureSummary: "swift interface failed"
+            ),
+        ],
+        updatedAt: updatedAt
+    )
+}
+
+private func makeRunRecord() throws -> PrivateHeaderGeneration.RunRecord {
+    let manifest = try makeManifest()
+    let artifact = try PrivateHeaderGeneration.ArtifactPath("Frameworks/Foo/Foo.h")
+    let plan = PrivateHeaderGeneration.RunPlanRecord(
+        source: manifest.source,
+        output: manifest.output,
+        layout: manifest.layout,
+        targetIDs: ["framework:Foo"]
+    )
+
+    return PrivateHeaderGeneration.RunRecord(
+        runID: "run-001",
+        schemaVersion: 1,
+        toolVersion: "0.1.0",
+        plan: plan,
+        startedAt: Date(timeIntervalSince1970: 1_000),
+        endedAt: Date(timeIntervalSince1970: 1_100),
+        status: .partial,
+        targetResults: [
+            PrivateHeaderGeneration.RunTargetRecord(
+                targetID: "framework:Foo",
+                status: .commitFailed,
+                phases: [
+                    PrivateHeaderGeneration.PhaseRecord(name: "commit", status: .failed),
+                ],
+                artifacts: [],
+                attemptedArtifacts: [artifact],
+                failureSummary: "commit failed"
+            ),
+        ],
+        attemptedArtifacts: [artifact],
+        logs: [
+            PrivateHeaderGeneration.RunLogRecord(
+                kind: "stderr",
+                relativePath: try PrivateHeaderGeneration.ArtifactPath("runs/run-001/logs/stderr.log")
+            ),
+        ]
+    )
+}

--- a/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationTargetResolverTests.swift
+++ b/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationTargetResolverTests.swift
@@ -1,0 +1,245 @@
+import Testing
+
+@testable import PrivateHeaderKitCore
+
+@Suite
+struct PrivateHeaderGenerationTargetResolverTests {
+    @Test func commaSeparatedQueryResolvesTargetsInStableDeduplicatedOrder() throws {
+        let resolver = PrivateHeaderGeneration.TargetResolver(
+            candidates: try [
+                candidate("UIKitCore", kind: .framework),
+                candidate("SwiftUI", kind: .framework),
+                candidate("SafariShared", kind: .privateFramework),
+            ]
+        )
+        let query = try PrivateHeaderGeneration.TargetQuery(
+            commaSeparated: "SwiftUI, UIKitCore, SwiftUI"
+        )
+
+        #expect(
+            resolver.resolve(query) == .selected(
+                .targets(
+                    try [
+                        candidate("SwiftUI", kind: .framework),
+                        candidate("UIKitCore", kind: .framework),
+                    ]
+                )
+            )
+        )
+    }
+
+    @Test func exactMatchWinsOverPartialMatches() throws {
+        let exact = try candidate("UIKit", kind: .framework)
+        let resolver = PrivateHeaderGeneration.TargetResolver(
+            candidates: try [
+                candidate("UIKitCore", kind: .framework),
+                exact,
+                candidate("UIKitServices", kind: .privateFramework),
+            ]
+        )
+        let query = try PrivateHeaderGeneration.TargetQuery(commaSeparated: "UIKit")
+
+        #expect(resolver.resolve(query) == .selected(.targets([exact])))
+    }
+
+    @Test func partialMatchCanResolveSingleCandidate() throws {
+        let candidate = try candidate("SafariShared", kind: .privateFramework)
+        let resolver = PrivateHeaderGeneration.TargetResolver(
+            candidates: [
+                candidate,
+            ]
+        )
+        let query = try PrivateHeaderGeneration.TargetQuery(commaSeparated: "safari")
+
+        #expect(resolver.resolve(query) == .selected(.targets([candidate])))
+    }
+
+    @Test func ambiguousPartialMatchReturnsCandidatesForUISelection() throws {
+        let candidates = try [
+            candidate("UIKitCore", kind: .framework),
+            candidate("UIKitServices", kind: .privateFramework),
+        ]
+        let resolver = PrivateHeaderGeneration.TargetResolver(candidates: candidates)
+        let query = try PrivateHeaderGeneration.TargetQuery(commaSeparated: "UIKit")
+
+        #expect(
+            resolver.resolve(query) == .needsDisambiguation(
+                [
+                    PrivateHeaderGeneration.TargetResolution.Ambiguity(
+                        query: "UIKit",
+                        candidates: candidates
+                    ),
+                ]
+            )
+        )
+    }
+
+    @Test func noMatchReturnsStructuredFailure() throws {
+        let resolver = PrivateHeaderGeneration.TargetResolver(
+            candidates: try [
+                candidate("SwiftUI", kind: .framework),
+            ]
+        )
+        let query = try PrivateHeaderGeneration.TargetQuery(commaSeparated: "NoSuchTarget")
+
+        #expect(
+            resolver.resolve(query) == .failed(
+                [
+                    PrivateHeaderGeneration.TargetResolution.Failure(
+                        query: "NoSuchTarget",
+                        reason: .noMatch
+                    ),
+                ]
+            )
+        )
+    }
+
+    @Test func mixedAmbiguousAndMissingTermsKeepBothStructuredResults() throws {
+        let ambiguousCandidates = try [
+            candidate("UIKitCore", kind: .framework),
+            candidate("UIKitServices", kind: .privateFramework),
+        ]
+        let resolver = PrivateHeaderGeneration.TargetResolver(candidates: ambiguousCandidates)
+        let query = try PrivateHeaderGeneration.TargetQuery(commaSeparated: "UIKit, NoSuchTarget")
+
+        #expect(
+            resolver.resolve(query) == .unresolved(
+                ambiguities: [
+                    PrivateHeaderGeneration.TargetResolution.Ambiguity(
+                        query: "UIKit",
+                        candidates: ambiguousCandidates
+                    ),
+                ],
+                failures: [
+                    PrivateHeaderGeneration.TargetResolution.Failure(
+                        query: "NoSuchTarget",
+                        reason: .noMatch
+                    ),
+                ]
+            )
+        )
+    }
+
+    @Test func allAvailableQuerySupportsEnglishAndJapaneseAliases() throws {
+        let resolver = PrivateHeaderGeneration.TargetResolver(candidates: [])
+
+        #expect(
+            resolver.resolve(try PrivateHeaderGeneration.TargetQuery(commaSeparated: "all"))
+                == .selected(.allAvailable)
+        )
+        #expect(
+            resolver.resolve(try PrivateHeaderGeneration.TargetQuery(commaSeparated: "すべて"))
+                == .selected(.allAvailable)
+        )
+        #expect(
+            resolver.resolve(try PrivateHeaderGeneration.TargetQuery(commaSeparated: "@all"))
+                == .selected(.allAvailable)
+        )
+    }
+
+    @Test func allAvailableCannotBeMixedWithExplicitQueries() throws {
+        #expect(throws: PrivateHeaderGeneration.ValidationError.self) {
+            _ = try PrivateHeaderGeneration.TargetQuery(commaSeparated: "all, UIKitCore")
+        }
+    }
+
+    @Test func queryRejectsPathUnsafeTerms() throws {
+        #expect(throws: PrivateHeaderGeneration.ValidationError.self) {
+            _ = try PrivateHeaderGeneration.TargetQuery(commaSeparated: "../UIKitCore")
+        }
+
+        #expect(throws: PrivateHeaderGeneration.ValidationError.self) {
+            _ = try PrivateHeaderGeneration.TargetQuery(commaSeparated: "/tmp/libobjc.A.dylib")
+        }
+
+        #expect(throws: PrivateHeaderGeneration.ValidationError.self) {
+            _ = try PrivateHeaderGeneration.TargetQuery(
+                commaSeparated: "/System/Library/PreferenceBundles/../Foo.bundle"
+            )
+        }
+
+        #expect(throws: PrivateHeaderGeneration.ValidationError.self) {
+            _ = try PrivateHeaderGeneration.TargetQuery(commaSeparated: "PreferenceBundles/./Foo.bundle")
+        }
+
+        #expect(throws: PrivateHeaderGeneration.ValidationError.self) {
+            _ = try PrivateHeaderGeneration.TargetQuery(commaSeparated: "/usr/lib/subdir/libobjc.A.dylib")
+        }
+    }
+
+    @Test func relativeSystemLibraryPathSelectorCanResolveCandidate() throws {
+        let candidate = try candidate(
+            "PreferenceBundles/Foo.bundle",
+            kind: .systemBundle
+        )
+        let resolver = PrivateHeaderGeneration.TargetResolver(candidates: [candidate])
+        let query = try PrivateHeaderGeneration.TargetQuery(commaSeparated: "PreferenceBundles/Foo.bundle")
+
+        #expect(resolver.resolve(query) == .selected(.targets([candidate])))
+    }
+
+    @Test func absoluteSystemLibraryPathAliasCanResolveCandidate() throws {
+        let candidate = try candidate(
+            "PreferenceBundles/Foo.bundle",
+            kind: .systemBundle,
+            aliases: ["/System/Library/PreferenceBundles/Foo.bundle"]
+        )
+        let resolver = PrivateHeaderGeneration.TargetResolver(candidates: [candidate])
+        let query = try PrivateHeaderGeneration.TargetQuery(
+            commaSeparated: "/System/Library/PreferenceBundles/Foo.bundle"
+        )
+
+        #expect(resolver.resolve(query) == .selected(.targets([candidate])))
+    }
+
+    @Test func usrLibDylibPathSelectorCanResolveByInferredAlias() throws {
+        let candidate = try candidate(
+            "libobjc.A.dylib",
+            kind: .usrLibDylib
+        )
+        let resolver = PrivateHeaderGeneration.TargetResolver(candidates: [candidate])
+        let query = try PrivateHeaderGeneration.TargetQuery(commaSeparated: "/usr/lib/libobjc.A.dylib")
+
+        #expect(resolver.resolve(query) == .selected(.targets([candidate])))
+    }
+
+    @Test func candidatesKeepKindMetadataOutOfUserFacingSelectionRequirements() throws {
+        let resolver = PrivateHeaderGeneration.TargetResolver(
+            candidates: try [
+                candidate(
+                    "libobjc.A.dylib",
+                    kind: .usrLibDylib,
+                    aliases: ["objc runtime"]
+                ),
+            ]
+        )
+        let query = try PrivateHeaderGeneration.TargetQuery(commaSeparated: "objc runtime")
+
+        #expect(
+            resolver.resolve(query) == .selected(
+                .targets(
+                    try [
+                        candidate(
+                            "libobjc.A.dylib",
+                            kind: .usrLibDylib,
+                            aliases: ["objc runtime"]
+                        ),
+                    ]
+                )
+            )
+        )
+    }
+}
+
+private func candidate(
+    _ displayName: String,
+    kind: PrivateHeaderGeneration.TargetKind,
+    aliases: [String] = []
+) throws -> PrivateHeaderGeneration.TargetCandidate {
+    try PrivateHeaderGeneration.TargetCandidate(
+        identifier: "target.\(displayName)",
+        displayName: displayName,
+        kind: kind,
+        aliases: aliases
+    )
+}

--- a/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationTests.swift
+++ b/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationTests.swift
@@ -1,0 +1,132 @@
+import Foundation
+import Testing
+
+import PrivateHeaderKitCore
+
+@Suite
+struct PrivateHeaderGenerationLabelTests {
+    @Test func iOSSourceLabelUsesUserFacingDisplayAndCompactDirectoryNames() throws {
+        let source = try PrivateHeaderGeneration.Source(
+            platform: .iOS,
+            version: "27.0",
+            build: "24A5355q"
+        )
+
+        #expect(source.label.displayName == "iOS 27.0 (24A5355q)")
+        #expect(source.label.directoryName == "iOS27.0(24A5355q)")
+        #expect(source.label.description == "iOS 27.0 (24A5355q)")
+    }
+
+    @Test func macOSSourceLabelUsesUserFacingDisplayAndCompactDirectoryNames() throws {
+        let source = try PrivateHeaderGeneration.Source(
+            platform: .macOS,
+            version: "16.0",
+            build: "25A5279m"
+        )
+
+        #expect(source.label.displayName == "macOS 16.0 (25A5279m)")
+        #expect(source.label.directoryName == "macOS16.0(25A5279m)")
+    }
+
+    @Test func sourceLabelOmitsEmptyBuild() throws {
+        let source = try PrivateHeaderGeneration.Source(
+            platform: .iOS,
+            version: "27.0",
+            build: ""
+        )
+
+        #expect(source.label.displayName == "iOS 27.0")
+        #expect(source.label.directoryName == "iOS27.0")
+    }
+
+    @Test func sourceRejectsPathUnsafeVersionAndBuildComponents() throws {
+        #expect(throws: PrivateHeaderGeneration.Source.ValidationError.self) {
+            _ = try PrivateHeaderGeneration.Source(
+                platform: .iOS,
+                version: "../27.0",
+                build: "24A5355q"
+            )
+        }
+
+        #expect(throws: PrivateHeaderGeneration.Source.ValidationError.self) {
+            _ = try PrivateHeaderGeneration.Source(
+                platform: .iOS,
+                version: "27.0",
+                build: "24A/5355q"
+            )
+        }
+    }
+}
+
+@Suite
+struct PrivateHeaderGenerationPlanTests {
+    @Test func customOutputBaseKeepsStateOutsideArtifactDirectoryAndUsesSourceLabelAsResumeKey() throws {
+        let source = try PrivateHeaderGeneration.Source(
+            platform: .iOS,
+            version: "27.0",
+            build: "24A5355q"
+        )
+        let root = URL(fileURLWithPath: "/tmp/PrivateHeaderKit", isDirectory: true)
+        let output = PrivateHeaderGeneration.Output(baseDirectory: root)
+
+        let plan = PrivateHeaderGeneration.makePlan(
+            source: source,
+            output: output
+        )
+
+        #expect(plan.source == source)
+        #expect(plan.output == output)
+        #expect(plan.artifactDirectory.path == "/tmp/PrivateHeaderKit/iOS27.0(24A5355q)")
+        #expect(plan.stateDirectory.path == "/tmp/PrivateHeaderKit/.state/iOS27.0(24A5355q)")
+        #expect(plan.target == .allAvailable)
+    }
+
+    @Test func defaultOutputCanSeparateArtifactAndStateBases() throws {
+        let source = try PrivateHeaderGeneration.Source(
+            platform: .iOS,
+            version: "27.0",
+            build: "24A5355q"
+        )
+        let root = URL(fileURLWithPath: "/tmp/PrivateHeaderKit", isDirectory: true)
+        let output = PrivateHeaderGeneration.Output(
+            artifactBaseDirectory: root.appendingPathComponent("generated-headers", isDirectory: true),
+            stateBaseDirectory: root.appendingPathComponent(".state", isDirectory: true)
+        )
+
+        let plan = PrivateHeaderGeneration.makePlan(
+            source: source,
+            output: output
+        )
+
+        #expect(plan.artifactDirectory.path == "/tmp/PrivateHeaderKit/generated-headers/iOS27.0(24A5355q)")
+        #expect(plan.stateDirectory.path == "/tmp/PrivateHeaderKit/.state/iOS27.0(24A5355q)")
+    }
+
+    @Test func generatePrivateHeadersThrowsExplicitUnimplementedError() async throws {
+        let source = try PrivateHeaderGeneration.Source(
+            platform: .macOS,
+            version: "16.0",
+            build: "25A5279m"
+        )
+        let output = PrivateHeaderGeneration.Output(
+            baseDirectory: URL(fileURLWithPath: "/tmp/PrivateHeaderKit", isDirectory: true)
+        )
+
+        do {
+            _ = try await PrivateHeaderGeneration.generatePrivateHeaders(
+                source: source,
+                output: output
+            )
+            Issue.record("generatePrivateHeaders unexpectedly returned a result")
+        } catch let error as PrivateHeaderGeneration.GenerationError {
+            #expect(
+                error == .notImplemented(
+                    plan: PrivateHeaderGeneration.makePlan(
+                        source: source,
+                        output: output
+                    )
+                )
+            )
+        }
+    }
+}


### PR DESCRIPTION
Purpose
- Move the rewrite foundation off main so it can be reviewed as a PR after restoring main to dc744389e9e2c03c4d647491ec06aafc9a9a3d57.

Changes
- Add rewrite requirements for the new PrivateHeaderKit dump flow.
- Add the PrivateHeaderKitCore product, target, and generation skeleton.
- Add state and manifest models for resumable generation records.
- Add target query resolution for exact, partial, preset, and safe path inputs.

Testing
- git diff --check origin/main...HEAD
- swift test
- codex-review against main reported no findings for the state/manifest and target resolver branches before this stack was preserved.