### PR TITLE
feat(core): add state manifest models

### DIFF
--- a/Docs/RewriteRequirements.md
+++ b/Docs/RewriteRequirements.md
@@ -1,0 +1,436 @@
+# PrivateHeaderKit Rewrite Requirements
+
+この文書は PrivateHeaderKit を破壊的変更前提で作り直すための要件を固定する。既存 CLI/API 互換より、実行の再現性、resume 可能性、最大情報取得、CI/自動化との相性を優先する。
+
+## Goals
+
+- ユーザーが直接使うコマンド成果物は 1 つにする。
+- iOS simulator runtime から取得できる情報量を最大化するため、内部 helper は維持する。
+- interactive wizard は first-class にする。ただし CI/自動化では interactive を要求しない。
+- dump artifact と管理情報を分離し、通常の `rg` で state/log/manifest が混ざらないようにする。
+- 中断、失敗、partial 成果物を明示的に管理し、build/source 単位で安全に resume できるようにする。
+- SwiftUI/ObservationBridge 風に、公開 API は薄い top-level entry と namespace 型に整理する。
+
+## Non-Goals
+
+- 旧 CLI option の完全互換は目標にしない。
+- `quality` のような情報量を落とす mode は持たない。常に最大取得を試みる。
+- ユーザーに安定 ID や内部 target identity を指定させない。
+- `SystemLibrary` や `/usr/lib dylib` などの内部分類を通常 UI の選択肢として見せない。
+
+## Public Surface
+
+### Command
+
+- 公開する user-facing executable product は 1 つにする。
+- 推奨名は `privateheaderkit`。
+- 旧 `privateheaderkit-dump` / `headerdump` / `headerdump-sim` は公開 surface から外す。
+- simulator 内で動く helper は内部実装として維持する。最大情報取得のため、runtime Objective-C fallback などを担当する。
+
+Breaking changes from current CLI:
+
+- 現行の複数 executable product は 1 つへ統合する。
+- 現行の `privateheaderkit-dump <version>` style は廃止し、source selection は explicit option または wizard で扱う。
+- `--list-runtimes`, `--list-devices`, `--json`, `--platform`, `--out`, `--target` は新 CLI surface として再設計する。
+- legacy `--framework`, `--filter`, `--scope` は互換維持を目的に残さない。必要なら migration note だけ書く。
+- 旧 default scope の Frameworks/PrivateFrameworks only から、新しい `すべて` は SystemLibrary bundles、`/usr/lib` dylibs、nested bundles まで含む。
+
+### Swift API Shape
+
+ObservationBridge のように、公開 API は小さく保つ。
+
+- top-level function: `generatePrivateHeaders(...)`
+- namespace 型: `PrivateHeaderGeneration`
+- nested types: `PrivateHeaderGeneration.Options`, `PrivateHeaderGeneration.Result`, `PrivateHeaderGeneration.Target`, `PrivateHeaderGeneration.Source`
+- long-running operation を公開する必要がある場合は `PrivateHeaderGeneration.Token` を使い、`cancel()` を持たせる。
+- 内部 target は `_PrivateHeaderKit...` prefix で隠す。
+
+## Source Identity
+
+Source は resume と出力ディレクトリの単位になる。
+
+- 表示名: `iOS 27.0 (24A5355q)`
+- ディレクトリ名: `iOS27.0(24A5355q)`
+- macOS も同じ規則にする: `macOS26.5(25F...)`
+- iOS runtime の version/build は `xcrun simctl list runtimes -j` の `version` と `buildversion` を使う。
+- 同じ iOS version でも build が違えば別 source として扱う。
+
+## Output Layout
+
+default:
+
+```text
+~/PrivateHeaderKit/
+  generated-headers/
+    iOS27.0(24A5355q)/
+      ...
+  .state/
+    iOS27.0(24A5355q)/
+      manifest.json
+      runs/
+        <run-id>/
+          run.json
+          logs/
+          staging/
+```
+
+custom output base:
+
+```text
+/Volumes/Data/Headers/
+  iOS27.0(24A5355q)/
+    ...
+  .state/
+    iOS27.0(24A5355q)/
+      manifest.json
+      runs/
+```
+
+Rules:
+
+- `--out` and `PH_OUT_DIR` は artifact root ではなく output base directory として扱う。
+- artifact は常に `<artifact-base>/<source-label>/` に置く。
+- default の artifact base は `~/PrivateHeaderKit/generated-headers`、state base は `~/PrivateHeaderKit/.state` とする。
+- custom output の場合は、artifact base と state base を同じ指定 directory の下に置く。artifact は `<output-base>/<source-label>/`、state は `<output-base>/.state/<source-label>/`。
+- state/log/staging は artifact tree の中に置かない。
+
+## Interactive Flow
+
+Command with no non-interactive target enters wizard.
+
+1. Source selection
+   - available runtimes を表示する。
+   - `iOS 27.0 (24A5355q)` のように space ありで表示する。
+   - Enter default は持たない。空入力は `入力してください` として再入力。
+2. Target selection
+   - `[1] すべて`
+   - `[2] 個別に選ぶ`
+   - `[3] キャンセル`
+3. Individual target input
+   - comma-separated text input。
+   - partial match を許可する。
+   - no match は候補なしとして再入力。
+   - ambiguous match は候補一覧を出し、番号入力で解決する。
+   - 複数候補を選べる。`all` 相当も許可する。
+4. Output plan
+   - source, output path, selected target count を表示する。
+5. Existing state/output check
+   - unfinished compatible run があれば resume screen を出す。
+   - unfinished run がなく、既存 completed artifact があれば existing output screen を出す。
+6. Final confirmation
+   - `すべて` の場合は target count と output path を出して開始確認する。
+   - destructive rebuild の場合は削除対象 target 数を出して明示確認する。
+7. Run progress
+   - current target と phase を表示する。
+   - phase examples: `static ObjC`, `runtime ObjC`, `Swift interface`, `nested bundles`, `commit`
+8. Summary
+   - output path
+   - `Completed`, `Partial`, `Failed`, `Skipped`
+   - first 20 failures
+   - manifest path
+
+Keyboard behavior:
+
+- `Esc` は 1 screen 戻る。
+- first screen での `Esc` は cancel。
+- 戻った場合も入力済み state は保持する。
+- `Ctrl-C` before run は exit。
+- `Ctrl-C` during run は current target を `interrupted` として記録し、次回 resume で target 全体を再実行する。
+
+## Target Semantics
+
+- `すべて` は内部的に current `@all` 相当を意味する。
+- 対象には Frameworks、PrivateFrameworks、SystemLibrary bundles、`/usr/lib` dylibs、nested bundles を含める。
+- ユーザー向け UI では分類を選ばせず、必要なら summary として件数だけ表示する。
+- target identity は内部で安定化するが、ユーザーには名前/partial match で入力させる。
+
+## Non-Interactive Behavior
+
+- CI/script では interactive prompt を出さない。
+- unfinished compatible run がある場合は error にし、明示的な `--resume` を要求する。
+- `--resume` は compatible run の incomplete targets を再実行する。
+- `--fresh` またはそれに相当する explicit option は、選択 target の既存 managed artifacts を消して再作成する。
+- destructive option は non-interactive でも明示されている場合だけ実行する。
+- failures/partials があれば exit code は non-zero。
+
+## Resume Rules
+
+Resume は source label/build 単位で管理する。
+
+Compatible run の条件:
+
+- same source label
+- same output base
+- same selected target set
+- same layout
+- manifest schema が読み取れる
+
+Not compatible:
+
+- runtime build が違う
+- selected target set が違う
+- layout が違う
+- manifest schema がサポート外
+
+Unfinished compatible run screen:
+
+```text
+前回の実行が途中で終了しています。
+
+Source: iOS 27.0 (24A5355q)
+Output: ~/PrivateHeaderKit/generated-headers/iOS27.0(24A5355q)
+Targets: all (1842)
+Started: 2026-06-18 12:25:10
+Updated: 2026-06-18 13:14:02
+Completed: 1310, Partial: 4, Failed: 12, Pending: 516
+
+[1] 続きから実行
+[2] 最初から実行
+[3] キャンセル
+```
+
+Rules:
+
+- completed target は resume で skip する。
+- failed target は resume で retry する。
+- partial target は target 全体を再実行する。
+- interrupted target は target 全体を再実行する。
+- commitFailed target は cleanup して target 全体を再実行する。
+- 「最初から実行」は selected target の managed artifacts と previous staging/log を片付けてから開始する。
+
+Existing completed output screen:
+
+```text
+既存の出力があります。
+
+Source: iOS 27.0 (24A5355q)
+Output: ~/PrivateHeaderKit/generated-headers/iOS27.0(24A5355q)
+Completed: 1842, Partial: 0, Failed: 0
+
+[1] 不足分だけ実行
+[2] 最初から作り直す
+[3] キャンセル
+```
+
+Rules:
+
+- all complete なら `[1]` は no-op summary を出して終了する。
+- `[2]` は selected targets の managed artifacts だけを削除する。
+- unknown user files は削除しない。
+
+## State Files
+
+### `manifest.json`
+
+Pretty JSON で書く。source label 単位の latest state を表す。
+
+Required fields:
+
+- `schemaVersion`
+- `toolVersion`
+- `source`
+  - `platform`
+  - `version`
+  - `build`
+  - `displayName`
+  - `directoryName`
+- `output`
+  - `baseDirectory`
+  - `artifactDirectory`
+  - `stateDirectory`
+- `layout`
+- `latestRunID`
+- `targets`
+- `updatedAt`
+
+Each target entry:
+
+- `id`
+- `displayName`
+- `kind`
+- `status`
+- `phases`
+- `artifacts`
+- `lastRunID`
+- `updatedAt`
+- `failureSummary`
+
+Artifacts:
+
+- all generated `.h` and `.swiftinterface` relative paths are stored.
+- `completed` 判定は manifest entry だけで行わない。manifest-managed artifact の実体が存在し、少なくとも期待される `.h` または `.swiftinterface` があることを確認する。
+- cleanup/recreate only deletes manifest-managed paths.
+- unknown files are preserved.
+- after deleting files, empty parent directories are removed up to artifact root.
+
+### `run.json`
+
+Run 単位の immutable-ish record として扱う。
+
+Required fields:
+
+- `runID`
+- `schemaVersion`
+- `toolVersion`
+- `plan`
+- `startedAt`
+- `endedAt`
+- `status`
+- `targetResults`
+- `attemptedArtifacts`
+- `logs`
+
+Rules:
+
+- `runs/<run-id>/staging/` に生成してから commit する。
+- runtime root や `/System/Cryptexes` から staging へ出た artifact は、現行の relocation/rebase semantics を維持して final artifact path へ正規化する。
+- run history は latest 10 件だけ保持する。
+- old run cleanup は command startup で行う。
+- old run cleanup は `runs/<old-run-id>/` の logs/staging/run.json を削除する。
+- latest target state は `manifest.json` に残す。
+
+## Target Status
+
+Manifest target statuses:
+
+- `completed`
+- `partial`
+- `failed`
+- `interrupted`
+- `commitFailed`
+- `stale`
+
+Run-local statuses:
+
+- `pending`
+- `running`
+- `skipped`
+- `completed`
+- `partial`
+- `failed`
+- `interrupted`
+- `commitFailed`
+
+Phase statuses:
+
+- `pending`
+- `running`
+- `completed`
+- `failed`
+- `skipped`
+
+Partial definition:
+
+- target の一部 artifact は生成できたが、required phase の一部が失敗した状態。
+- `Swift interface` 失敗も partial として扱う。
+- nested bundle の失敗は親 target を無条件に completed にしない。親 target は `partial` または `failed` として扱い、resume で target 全体を再実行する。
+- partial は success ではないため exit code は non-zero。
+
+## Commit Transaction
+
+Per target:
+
+1. cleanup stale staging for target/run
+2. generate into `runs/<run-id>/staging/<target-id>/`
+3. collect attempted artifacts
+4. if generation failed before commit, keep old final artifacts untouched
+5. if generation succeeded, delete old manifest-managed final artifacts for target
+6. move/copy staging artifacts into final artifact directory
+7. write manifest target entry
+
+Commit failure:
+
+- target status becomes `commitFailed`
+- `run.json` records attempted final artifact paths
+- next resume cleans manifest-managed artifacts plus attempted paths before re-running target
+
+## Error Handling
+
+- Per-target failure is recorded and execution continues.
+- Summary shows first 20 failures.
+- Full failure details live in `run.json` and logs.
+- Any `failed`, `partial`, `interrupted`, or `commitFailed` result makes exit code non-zero.
+- No silent success with missing Swift interface when Swift extraction was expected.
+
+## Simulator Execution
+
+- helper は internal implementation detail として扱うが、runtime Objective-C fallback のため simulator process で実行できる状態を維持する。
+- resume state には、source identity だけでなく、実行に使った simulator runtime/device/clone policy/execution mode を記録する。
+- 再開時に同じ device が使えない場合は、source identity と plan compatibility を保ったまま代替 device を選び、run record に記録する。
+- `SIMCTL_CHILD_*` を含む helper 実行 environment は plan/run に残し、再現性を確保する。
+- simulator helper が実行できない場合の host fallback は、target result に fallback として記録する。fallback により情報量が落ちる場合は `partial` または warning として summary に出す。
+
+## Layout and Migration
+
+- 新 rewrite の primary layout は 1 つに寄せる。
+- 旧 `headers` / `bundle` layout のどちらを継続するかは implementation PR の初期 contract で固定する。
+- 旧 artifact tree の自動移行は必須にしない。
+- 既存 artifact が新 manifest で管理されていない場合は unknown file として扱い、destructive rebuild でも削除しない。
+- 旧 output path `~/PrivateHeaderKit/generated-headers/iOS/<version>` は新 source label path と別物として扱う。必要なら README に migration note を書く。
+
+## Implementation Split
+
+Initial worker PRs should avoid overlapping write ownership.
+
+0. Ownership boundary PR
+   - owner: `Package.swift`, new target skeletons, initial test file split
+   - goal: reduce conflicts before parallel implementation
+1. Requirements/docs baseline
+   - owner: `Docs/RewriteRequirements.md`, README follow-up notes only
+2. Core API and plan contracts
+   - owner: new `Sources/PrivateHeaderKitCore/*`, contract tests
+   - includes: `PrivateHeaderGeneration`, source identity, target identity, dump plan
+3. State model and persistence
+   - owner: new state module/files, manifest/run JSON tests
+4. Source/runtime discovery and label formatting
+   - owner: simctl parsing, source identity tests
+5. Target discovery and resolver
+   - owner: target model, `all`, comma input resolver, ambiguity tests
+6. Transactional executor
+   - owner: staging/commit/cleanup, status transitions
+7. Interactive wizard
+   - owner: prompt screens, Esc navigation, input retention
+8. CLI integration
+   - owner: public command, non-interactive flags, exit codes
+9. Header extraction/helper integration
+   - owner: internal host/simulator helper boundary
+10. Install/docs compatibility
+   - owner: install command/docs after behavior is stable
+
+Shared-file rules:
+
+- `Package.swift` is owned by the ownership boundary PR first; later worker PRs should avoid touching it unless explicitly assigned.
+- `Sources/PrivateHeaderKitDump/PrivateHeaderKitDumpMain.swift` is the largest conflict source. Extract pure types/functions into new modules early, then leave a thin facade until final integration.
+- `Tests/PrivateHeaderKitDumpTests/PrivateHeaderKitDumpTests.swift` should be split by responsibility early: selection, state, layout, simulator/process.
+- `Package.resolved` is currently dirty before this rewrite work. No worker should touch it unless dependency work is explicitly assigned.
+
+## Testing Contracts
+
+Priority tests:
+
+- source label formatting: display vs directory name
+- default/custom output layout
+- `.state` separation from artifact tree
+- pretty JSON manifest
+- completed resume skips target
+- failed/partial/interrupted resume reruns target
+- target set/layout/source mismatch rejects resume
+- old run cleanup keeps latest 10
+- managed artifact cleanup preserves unknown files
+- generation failure before commit keeps old artifacts
+- commit failure records attempted artifacts
+- interactive empty Enter re-prompts
+- interactive Esc goes back and preserves input
+- comma-separated target resolution
+- ambiguous partial match resolution
+- non-interactive unfinished run requires explicit `--resume`
+
+## Documentation Updates
+
+After implementation:
+
+- update `README.md` / `README.ja.md` for the new single command
+- document output/state layout
+- document resume/new/rebuild behavior
+- document non-interactive CI usage
+- remove old `headerdump` / `headerdump-sim` as user-facing commands from README

--- a/Package.swift
+++ b/Package.swift
@@ -8,6 +8,7 @@ let package = Package(
         .iOS(.v17),
     ],
     products: [
+        .library(name: "PrivateHeaderKitCore", targets: ["PrivateHeaderKitCore"]),
         .executable(name: "headerdump", targets: ["HeaderDumpCLI"]),
         .executable(name: "privateheaderkit-dump", targets: ["PrivateHeaderKitDump"]),
         .executable(name: "privateheaderkit-install", targets: ["PrivateHeaderKitInstall"]),
@@ -56,6 +57,10 @@ let package = Package(
             name: "PrivateHeaderKitTooling",
             dependencies: []
         ),
+        .target(
+            name: "PrivateHeaderKitCore",
+            dependencies: []
+        ),
         .executableTarget(
             name: "HeaderDumpCLI",
             dependencies: [
@@ -99,6 +104,12 @@ let package = Package(
                     condition: .when(platforms: [.macOS, .iOS])
                 ),
                 .product(name: "MachOKit", package: "MachOKit"),
+            ]
+        ),
+        .testTarget(
+            name: "PrivateHeaderKitCoreTests",
+            dependencies: [
+                "PrivateHeaderKitCore",
             ]
         ),
         .testTarget(

--- a/Sources/PrivateHeaderKitCore/PrivateHeaderGeneration.swift
+++ b/Sources/PrivateHeaderKitCore/PrivateHeaderGeneration.swift
@@ -28,6 +28,18 @@ public enum PrivateHeaderGeneration {
     }
 }
 
+public func generatePrivateHeaders(
+    source: PrivateHeaderGeneration.Source,
+    output: PrivateHeaderGeneration.Output,
+    options: PrivateHeaderGeneration.Options = PrivateHeaderGeneration.Options()
+) async throws -> PrivateHeaderGeneration.Result {
+    try await PrivateHeaderGeneration.generatePrivateHeaders(
+        source: source,
+        output: output,
+        options: options
+    )
+}
+
 public extension PrivateHeaderGeneration {
     struct Source: Hashable, Sendable {
         public let platform: Platform

--- a/Sources/PrivateHeaderKitCore/PrivateHeaderGeneration.swift
+++ b/Sources/PrivateHeaderKitCore/PrivateHeaderGeneration.swift
@@ -1,0 +1,201 @@
+import Foundation
+
+public enum PrivateHeaderGeneration {
+    public static func makePlan(
+        source: Source,
+        output: Output,
+        options: Options = Options()
+    ) -> Plan {
+        Plan(
+            source: source,
+            output: output,
+            options: options
+        )
+    }
+
+    public static func generatePrivateHeaders(
+        source: Source,
+        output: Output,
+        options: Options = Options()
+    ) async throws -> Result {
+        throw GenerationError.notImplemented(
+            plan: makePlan(
+                source: source,
+                output: output,
+                options: options
+            )
+        )
+    }
+}
+
+public extension PrivateHeaderGeneration {
+    struct Source: Hashable, Sendable {
+        public let platform: Platform
+        public let version: String
+        public let build: String?
+
+        public init(platform: Platform, version: String, build: String? = nil) throws {
+            try Self.validatePathComponent(version, field: "version")
+            let build = build.flatMap { $0.isEmpty ? nil : $0 }
+            if let build {
+                try Self.validatePathComponent(build, field: "build")
+            }
+            self.platform = platform
+            self.version = version
+            self.build = build
+        }
+
+        public var label: Label {
+            Label(platform: platform, version: version, build: build)
+        }
+
+        private static func validatePathComponent(_ value: String, field: String) throws {
+            guard !value.isEmpty else {
+                throw ValidationError.emptyComponent(field: field)
+            }
+            guard value != ".", value != "..", !value.contains("/"), !value.contains("\0") else {
+                throw ValidationError.invalidPathComponent(field: field, value: value)
+            }
+        }
+    }
+}
+
+public extension PrivateHeaderGeneration.Source {
+    enum ValidationError: Error, Equatable, CustomStringConvertible, Sendable {
+        case emptyComponent(field: String)
+        case invalidPathComponent(field: String, value: String)
+
+        public var description: String {
+            switch self {
+            case .emptyComponent(let field):
+                "\(field) must not be empty"
+            case .invalidPathComponent(let field, let value):
+                "\(field) is not safe as a path component: \(value)"
+            }
+        }
+    }
+
+    enum Platform: String, CaseIterable, Hashable, Sendable {
+        case iOS = "iOS"
+        case macOS = "macOS"
+
+        public var displayName: String {
+            rawValue
+        }
+    }
+
+    struct Label: CustomStringConvertible, Hashable, Sendable {
+        public let displayName: String
+        public let directoryName: String
+
+        init(platform: Platform, version: String, build: String?) {
+            let baseName = "\(platform.displayName) \(version)"
+            let directoryBaseName = "\(platform.displayName)\(version)"
+            if let build {
+                self.displayName = "\(baseName) (\(build))"
+                self.directoryName = "\(directoryBaseName)(\(build))"
+            } else {
+                self.displayName = baseName
+                self.directoryName = directoryBaseName
+            }
+        }
+
+        public var description: String {
+            displayName
+        }
+    }
+}
+
+public extension PrivateHeaderGeneration {
+    struct Target: CustomStringConvertible, Hashable, Sendable {
+        public static let allAvailable = Target(identifier: "allAvailable")
+
+        private let identifier: String
+
+        private init(identifier: String) {
+            self.identifier = identifier
+        }
+
+        public var description: String {
+            identifier
+        }
+    }
+}
+
+public extension PrivateHeaderGeneration {
+    struct Options: Hashable, Sendable {
+        public init() {}
+    }
+
+    struct Output: Hashable, Sendable {
+        public let artifactBaseDirectory: URL
+        public let stateBaseDirectory: URL
+
+        public init(
+            artifactBaseDirectory: URL,
+            stateBaseDirectory: URL
+        ) {
+            self.artifactBaseDirectory = artifactBaseDirectory
+            self.stateBaseDirectory = stateBaseDirectory
+        }
+
+        public init(baseDirectory: URL) {
+            self.init(
+                artifactBaseDirectory: baseDirectory,
+                stateBaseDirectory: baseDirectory.appendingPathComponent(".state", isDirectory: true)
+            )
+        }
+    }
+
+    struct Plan: Hashable, Sendable {
+        public let source: Source
+        public let output: Output
+        public let artifactDirectory: URL
+        public let stateDirectory: URL
+        public let target: Target
+        public let options: Options
+
+        public init(
+            source: Source,
+            output: Output,
+            options: Options = Options()
+        ) {
+            let label = source.label
+            self.source = source
+            self.output = output
+            self.artifactDirectory = output.artifactBaseDirectory.appendingPathComponent(
+                label.directoryName,
+                isDirectory: true
+            )
+            self.stateDirectory = output.stateBaseDirectory.appendingPathComponent(
+                label.directoryName,
+                isDirectory: true
+            )
+            self.target = .allAvailable
+            self.options = options
+        }
+    }
+
+    struct Result: Hashable, Sendable {
+        public let plan: Plan
+        public let artifactDirectory: URL
+        public let generatedTargets: [Target]
+
+        init(plan: Plan, generatedTargets: [Target]) {
+            self.plan = plan
+            self.artifactDirectory = plan.artifactDirectory
+            self.generatedTargets = generatedTargets
+        }
+    }
+
+    enum GenerationError: Error, Equatable, CustomStringConvertible, Sendable {
+        case notImplemented(plan: Plan)
+
+        public var description: String {
+            switch self {
+            case .notImplemented(let plan):
+                "private header generation is not implemented for \(plan.source.label.displayName)"
+            }
+        }
+    }
+}

--- a/Sources/PrivateHeaderKitCore/PrivateHeaderGenerationState.swift
+++ b/Sources/PrivateHeaderKitCore/PrivateHeaderGenerationState.swift
@@ -1,0 +1,376 @@
+import Foundation
+
+public extension PrivateHeaderGeneration {
+    enum Layout: String, Codable, CaseIterable, Hashable, Sendable {
+        case headers
+        case bundle
+    }
+
+    enum TargetStatus: String, Codable, CaseIterable, Hashable, Sendable {
+        case completed
+        case partial
+        case failed
+        case interrupted
+        case commitFailed
+        case stale
+    }
+
+    enum RunTargetStatus: String, Codable, CaseIterable, Hashable, Sendable {
+        case pending
+        case running
+        case skipped
+        case completed
+        case partial
+        case failed
+        case interrupted
+        case commitFailed
+    }
+
+    enum PhaseStatus: String, Codable, CaseIterable, Hashable, Sendable {
+        case pending
+        case running
+        case completed
+        case failed
+        case skipped
+    }
+
+    struct ArtifactPath: Codable, CustomStringConvertible, Hashable, Sendable {
+        public let rawValue: String
+
+        public init(_ rawValue: String) throws {
+            try Self.validate(rawValue)
+            self.rawValue = rawValue
+        }
+
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.singleValueContainer()
+            let rawValue = try container.decode(String.self)
+            try Self.validate(rawValue)
+            self.rawValue = rawValue
+        }
+
+        public func encode(to encoder: Encoder) throws {
+            var container = encoder.singleValueContainer()
+            try container.encode(rawValue)
+        }
+
+        public var description: String {
+            rawValue
+        }
+
+        private static func validate(_ rawValue: String) throws {
+            guard !rawValue.isEmpty else {
+                throw StateValidationError.emptyArtifactPath
+            }
+            guard !rawValue.hasPrefix("/") else {
+                throw StateValidationError.absoluteArtifactPath(rawValue)
+            }
+            guard !rawValue.contains("\0") else {
+                throw StateValidationError.invalidArtifactPath(rawValue)
+            }
+
+            let components = rawValue.split(separator: "/", omittingEmptySubsequences: false)
+            guard components.allSatisfy({ !$0.isEmpty && $0 != "." && $0 != ".." }) else {
+                throw StateValidationError.invalidArtifactPath(rawValue)
+            }
+        }
+    }
+
+    enum StateValidationError: Error, Equatable, CustomStringConvertible, Sendable {
+        case emptyArtifactPath
+        case absoluteArtifactPath(String)
+        case invalidArtifactPath(String)
+
+        public var description: String {
+            switch self {
+            case .emptyArtifactPath:
+                "artifact path must not be empty"
+            case .absoluteArtifactPath(let path):
+                "artifact path must be relative: \(path)"
+            case .invalidArtifactPath(let path):
+                "artifact path is not safe: \(path)"
+            }
+        }
+    }
+}
+
+public extension PrivateHeaderGeneration {
+    struct Manifest: Codable, Equatable, Sendable {
+        public let schemaVersion: Int
+        public let toolVersion: String
+        public let source: SourceRecord
+        public let output: OutputRecord
+        public let layout: Layout
+        public let latestRunID: String?
+        public let targets: [TargetRecord]
+        public let updatedAt: Date
+
+        public init(
+            schemaVersion: Int,
+            toolVersion: String,
+            source: SourceRecord,
+            output: OutputRecord,
+            layout: Layout,
+            latestRunID: String?,
+            targets: [TargetRecord],
+            updatedAt: Date
+        ) {
+            self.schemaVersion = schemaVersion
+            self.toolVersion = toolVersion
+            self.source = source
+            self.output = output
+            self.layout = layout
+            self.latestRunID = latestRunID
+            self.targets = targets
+            self.updatedAt = updatedAt
+        }
+    }
+
+    struct SourceRecord: Codable, Equatable, Sendable {
+        public let platform: Source.Platform
+        public let version: String
+        public let build: String?
+        public let displayName: String
+        public let directoryName: String
+
+        public init(source: Source) {
+            self.platform = source.platform
+            self.version = source.version
+            self.build = source.build
+            self.displayName = source.label.displayName
+            self.directoryName = source.label.directoryName
+        }
+    }
+
+    struct OutputRecord: Codable, Equatable, Sendable {
+        public let baseDirectory: String
+        public let artifactDirectory: String
+        public let stateDirectory: String
+
+        public init(
+            baseDirectory: String,
+            artifactDirectory: String,
+            stateDirectory: String
+        ) {
+            self.baseDirectory = baseDirectory
+            self.artifactDirectory = artifactDirectory
+            self.stateDirectory = stateDirectory
+        }
+
+        public init(plan: Plan, baseDirectory: URL) {
+            self.init(
+                baseDirectory: baseDirectory.path,
+                artifactDirectory: plan.artifactDirectory.path,
+                stateDirectory: plan.stateDirectory.path
+            )
+        }
+    }
+
+    struct TargetRecord: Codable, Equatable, Sendable {
+        public let id: String
+        public let displayName: String
+        public let kind: String
+        public let status: TargetStatus
+        public let phases: [PhaseRecord]
+        public let artifacts: [ArtifactPath]
+        public let lastRunID: String?
+        public let updatedAt: Date
+        public let failureSummary: String?
+
+        public init(
+            id: String,
+            displayName: String,
+            kind: String,
+            status: TargetStatus,
+            phases: [PhaseRecord],
+            artifacts: [ArtifactPath],
+            lastRunID: String?,
+            updatedAt: Date,
+            failureSummary: String?
+        ) {
+            self.id = id
+            self.displayName = displayName
+            self.kind = kind
+            self.status = status
+            self.phases = phases
+            self.artifacts = artifacts
+            self.lastRunID = lastRunID
+            self.updatedAt = updatedAt
+            self.failureSummary = failureSummary
+        }
+    }
+
+    struct PhaseRecord: Codable, Equatable, Sendable {
+        public let name: String
+        public let status: PhaseStatus
+        public let failureSummary: String?
+
+        public init(name: String, status: PhaseStatus, failureSummary: String? = nil) {
+            self.name = name
+            self.status = status
+            self.failureSummary = failureSummary
+        }
+    }
+}
+
+public extension PrivateHeaderGeneration {
+    struct RunRecord: Codable, Equatable, Sendable {
+        public let runID: String
+        public let schemaVersion: Int
+        public let toolVersion: String
+        public let plan: RunPlanRecord
+        public let startedAt: Date
+        public let endedAt: Date?
+        public let status: RunTargetStatus
+        public let targetResults: [RunTargetRecord]
+        public let attemptedArtifacts: [ArtifactPath]
+        public let logs: [RunLogRecord]
+
+        public init(
+            runID: String,
+            schemaVersion: Int,
+            toolVersion: String,
+            plan: RunPlanRecord,
+            startedAt: Date,
+            endedAt: Date?,
+            status: RunTargetStatus,
+            targetResults: [RunTargetRecord],
+            attemptedArtifacts: [ArtifactPath],
+            logs: [RunLogRecord]
+        ) {
+            self.runID = runID
+            self.schemaVersion = schemaVersion
+            self.toolVersion = toolVersion
+            self.plan = plan
+            self.startedAt = startedAt
+            self.endedAt = endedAt
+            self.status = status
+            self.targetResults = targetResults
+            self.attemptedArtifacts = attemptedArtifacts
+            self.logs = logs
+        }
+    }
+
+    struct RunPlanRecord: Codable, Equatable, Sendable {
+        public let source: SourceRecord
+        public let output: OutputRecord
+        public let layout: Layout
+        public let targetIDs: [String]
+
+        public init(
+            source: SourceRecord,
+            output: OutputRecord,
+            layout: Layout,
+            targetIDs: [String]
+        ) {
+            self.source = source
+            self.output = output
+            self.layout = layout
+            self.targetIDs = targetIDs
+        }
+    }
+
+    struct RunTargetRecord: Codable, Equatable, Sendable {
+        public let targetID: String
+        public let status: RunTargetStatus
+        public let phases: [PhaseRecord]
+        public let artifacts: [ArtifactPath]
+        public let attemptedArtifacts: [ArtifactPath]
+        public let failureSummary: String?
+
+        public init(
+            targetID: String,
+            status: RunTargetStatus,
+            phases: [PhaseRecord],
+            artifacts: [ArtifactPath],
+            attemptedArtifacts: [ArtifactPath],
+            failureSummary: String?
+        ) {
+            self.targetID = targetID
+            self.status = status
+            self.phases = phases
+            self.artifacts = artifacts
+            self.attemptedArtifacts = attemptedArtifacts
+            self.failureSummary = failureSummary
+        }
+    }
+
+    struct RunLogRecord: Codable, Equatable, Sendable {
+        public let kind: String
+        public let relativePath: ArtifactPath
+
+        public init(kind: String, relativePath: ArtifactPath) {
+            self.kind = kind
+            self.relativePath = relativePath
+        }
+    }
+}
+
+public extension PrivateHeaderGeneration {
+    enum StateJSON {
+        public static func encode<Value: Encodable>(_ value: Value) throws -> Data {
+            try encoder().encode(value)
+        }
+
+        public static func decode<Value: Decodable>(_ type: Value.Type, from data: Data) throws -> Value {
+            try decoder().decode(type, from: data)
+        }
+
+        public static func write<Value: Encodable>(_ value: Value, to url: URL) throws {
+            let data = try encode(value)
+            try data.write(to: url, options: [.atomic])
+        }
+
+        public static func read<Value: Decodable>(_ type: Value.Type, from url: URL) throws -> Value {
+            let data = try Data(contentsOf: url)
+            return try decode(type, from: data)
+        }
+
+        private static func encoder() -> JSONEncoder {
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+            encoder.dateEncodingStrategy = .iso8601
+            return encoder
+        }
+
+        private static func decoder() -> JSONDecoder {
+            let decoder = JSONDecoder()
+            decoder.dateDecodingStrategy = .iso8601
+            return decoder
+        }
+    }
+
+    struct RunSummary: Hashable, Sendable {
+        public let runID: String
+        public let startedAt: Date
+
+        public init(runID: String, startedAt: Date) {
+            self.runID = runID
+            self.startedAt = startedAt
+        }
+    }
+
+    enum RunHistoryRetention {
+        public static func retainedRunIDs(
+            from runs: [RunSummary],
+            limit: Int = 10
+        ) -> [String] {
+            guard limit > 0 else {
+                return []
+            }
+
+            return runs
+                .sorted {
+                    if $0.startedAt == $1.startedAt {
+                        $0.runID > $1.runID
+                    } else {
+                        $0.startedAt > $1.startedAt
+                    }
+                }
+                .prefix(limit)
+                .map(\.runID)
+        }
+    }
+}
+
+extension PrivateHeaderGeneration.Source.Platform: Codable {}

--- a/Sources/PrivateHeaderKitCore/PrivateHeaderGenerationState.swift
+++ b/Sources/PrivateHeaderKitCore/PrivateHeaderGenerationState.swift
@@ -329,14 +329,39 @@ public extension PrivateHeaderGeneration {
         private static func encoder() -> JSONEncoder {
             let encoder = JSONEncoder()
             encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
-            encoder.dateEncodingStrategy = .iso8601
+            encoder.dateEncodingStrategy = .custom { date, encoder in
+                var container = encoder.singleValueContainer()
+                try container.encode(fractionalSecondsFormatter().string(from: date))
+            }
             return encoder
         }
 
         private static func decoder() -> JSONDecoder {
             let decoder = JSONDecoder()
-            decoder.dateDecodingStrategy = .iso8601
+            decoder.dateDecodingStrategy = .custom { decoder in
+                let container = try decoder.singleValueContainer()
+                let value = try container.decode(String.self)
+                if let date = fractionalSecondsFormatter().date(from: value) ?? wholeSecondsFormatter().date(from: value) {
+                    return date
+                }
+                throw DecodingError.dataCorruptedError(
+                    in: container,
+                    debugDescription: "Invalid ISO 8601 date: \(value)"
+                )
+            }
             return decoder
+        }
+
+        private static func fractionalSecondsFormatter() -> ISO8601DateFormatter {
+            let formatter = ISO8601DateFormatter()
+            formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+            return formatter
+        }
+
+        private static func wholeSecondsFormatter() -> ISO8601DateFormatter {
+            let formatter = ISO8601DateFormatter()
+            formatter.formatOptions = [.withInternetDateTime]
+            return formatter
         }
     }
 

--- a/Sources/PrivateHeaderKitCore/PrivateHeaderGenerationState.swift
+++ b/Sources/PrivateHeaderKitCore/PrivateHeaderGenerationState.swift
@@ -416,17 +416,77 @@ public extension PrivateHeaderGeneration {
         public let output: OutputRecord
         public let layout: Layout
         public let targetIDs: [String]
+        public let execution: ExecutionRecord
 
         public init(
             source: SourceRecord,
             output: OutputRecord,
             layout: Layout,
-            targetIDs: [String]
+            targetIDs: [String],
+            execution: ExecutionRecord
         ) {
             self.source = source
             self.output = output
             self.layout = layout
             self.targetIDs = targetIDs
+            self.execution = execution
+        }
+    }
+
+    struct ExecutionRecord: Codable, Equatable, Sendable {
+        public let mode: String
+        public let runtimeIdentifier: String?
+        public let deviceName: String?
+        public let deviceUDID: String?
+        public let clonePolicy: String?
+        public let helperEnvironment: [String: String]
+
+        public init(
+            mode: String,
+            runtimeIdentifier: String?,
+            deviceName: String?,
+            deviceUDID: String?,
+            clonePolicy: String?,
+            helperEnvironment: [String: String]
+        ) {
+            self.mode = mode
+            self.runtimeIdentifier = runtimeIdentifier
+            self.deviceName = deviceName
+            self.deviceUDID = deviceUDID
+            self.clonePolicy = clonePolicy
+            self.helperEnvironment = helperEnvironment
+        }
+
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            self.mode = try container.decode(String.self, forKey: .mode)
+            self.runtimeIdentifier = try container.decodeRequiredNullable(
+                String.self,
+                forKey: .runtimeIdentifier
+            )
+            self.deviceName = try container.decodeRequiredNullable(String.self, forKey: .deviceName)
+            self.deviceUDID = try container.decodeRequiredNullable(String.self, forKey: .deviceUDID)
+            self.clonePolicy = try container.decodeRequiredNullable(String.self, forKey: .clonePolicy)
+            self.helperEnvironment = try container.decode([String: String].self, forKey: .helperEnvironment)
+        }
+
+        public func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode(mode, forKey: .mode)
+            try container.encodeRequired(runtimeIdentifier, forKey: .runtimeIdentifier)
+            try container.encodeRequired(deviceName, forKey: .deviceName)
+            try container.encodeRequired(deviceUDID, forKey: .deviceUDID)
+            try container.encodeRequired(clonePolicy, forKey: .clonePolicy)
+            try container.encode(helperEnvironment, forKey: .helperEnvironment)
+        }
+
+        private enum CodingKeys: String, CodingKey {
+            case mode
+            case runtimeIdentifier
+            case deviceName
+            case deviceUDID
+            case clonePolicy
+            case helperEnvironment
         }
     }
 

--- a/Sources/PrivateHeaderKitCore/PrivateHeaderGenerationState.swift
+++ b/Sources/PrivateHeaderKitCore/PrivateHeaderGenerationState.swift
@@ -331,7 +331,7 @@ public extension PrivateHeaderGeneration {
             encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
             encoder.dateEncodingStrategy = .custom { date, encoder in
                 var container = encoder.singleValueContainer()
-                try container.encode(fractionalSecondsFormatter().string(from: date))
+                try container.encode(date.timeIntervalSinceReferenceDate)
             }
             return encoder
         }
@@ -340,6 +340,9 @@ public extension PrivateHeaderGeneration {
             let decoder = JSONDecoder()
             decoder.dateDecodingStrategy = .custom { decoder in
                 let container = try decoder.singleValueContainer()
+                if let value = try? container.decode(Double.self) {
+                    return Date(timeIntervalSinceReferenceDate: value)
+                }
                 let value = try container.decode(String.self)
                 if let date = fractionalSecondsFormatter().date(from: value) ?? wholeSecondsFormatter().date(from: value) {
                     return date

--- a/Sources/PrivateHeaderKitCore/PrivateHeaderGenerationState.swift
+++ b/Sources/PrivateHeaderKitCore/PrivateHeaderGenerationState.swift
@@ -125,6 +125,18 @@ public extension PrivateHeaderGeneration {
             self.updatedAt = updatedAt
         }
 
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            self.schemaVersion = try container.decode(Int.self, forKey: .schemaVersion)
+            self.toolVersion = try container.decode(String.self, forKey: .toolVersion)
+            self.source = try container.decode(SourceRecord.self, forKey: .source)
+            self.output = try container.decode(OutputRecord.self, forKey: .output)
+            self.layout = try container.decode(Layout.self, forKey: .layout)
+            self.latestRunID = try container.decodeRequiredNullable(String.self, forKey: .latestRunID)
+            self.targets = try container.decode([TargetRecord].self, forKey: .targets)
+            self.updatedAt = try container.decode(Date.self, forKey: .updatedAt)
+        }
+
         public func encode(to encoder: Encoder) throws {
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(schemaVersion, forKey: .schemaVersion)
@@ -162,6 +174,15 @@ public extension PrivateHeaderGeneration {
             self.build = source.build
             self.displayName = source.label.displayName
             self.directoryName = source.label.directoryName
+        }
+
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            self.platform = try container.decode(Source.Platform.self, forKey: .platform)
+            self.version = try container.decode(String.self, forKey: .version)
+            self.build = try container.decodeRequiredNullable(String.self, forKey: .build)
+            self.displayName = try container.decode(String.self, forKey: .displayName)
+            self.directoryName = try container.decode(String.self, forKey: .directoryName)
         }
 
         public func encode(to encoder: Encoder) throws {
@@ -239,6 +260,19 @@ public extension PrivateHeaderGeneration {
             self.failureSummary = failureSummary
         }
 
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            self.id = try container.decode(String.self, forKey: .id)
+            self.displayName = try container.decode(String.self, forKey: .displayName)
+            self.kind = try container.decode(String.self, forKey: .kind)
+            self.status = try container.decode(TargetStatus.self, forKey: .status)
+            self.phases = try container.decode([PhaseRecord].self, forKey: .phases)
+            self.artifacts = try container.decode([ArtifactPath].self, forKey: .artifacts)
+            self.lastRunID = try container.decodeRequiredNullable(String.self, forKey: .lastRunID)
+            self.updatedAt = try container.decode(Date.self, forKey: .updatedAt)
+            self.failureSummary = try container.decodeRequiredNullable(String.self, forKey: .failureSummary)
+        }
+
         public func encode(to encoder: Encoder) throws {
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(id, forKey: .id)
@@ -274,6 +308,13 @@ public extension PrivateHeaderGeneration {
             self.name = name
             self.status = status
             self.failureSummary = failureSummary
+        }
+
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            self.name = try container.decode(String.self, forKey: .name)
+            self.status = try container.decode(PhaseStatus.self, forKey: .status)
+            self.failureSummary = try container.decodeRequiredNullable(String.self, forKey: .failureSummary)
         }
 
         public func encode(to encoder: Encoder) throws {
@@ -326,6 +367,20 @@ public extension PrivateHeaderGeneration {
             self.targetResults = targetResults
             self.attemptedArtifacts = attemptedArtifacts
             self.logs = logs
+        }
+
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            self.runID = try container.decode(String.self, forKey: .runID)
+            self.schemaVersion = try container.decode(Int.self, forKey: .schemaVersion)
+            self.toolVersion = try container.decode(String.self, forKey: .toolVersion)
+            self.plan = try container.decode(RunPlanRecord.self, forKey: .plan)
+            self.startedAt = try container.decode(Date.self, forKey: .startedAt)
+            self.endedAt = try container.decodeRequiredNullable(Date.self, forKey: .endedAt)
+            self.status = try container.decode(RunTargetStatus.self, forKey: .status)
+            self.targetResults = try container.decode([RunTargetRecord].self, forKey: .targetResults)
+            self.attemptedArtifacts = try container.decode([ArtifactPath].self, forKey: .attemptedArtifacts)
+            self.logs = try container.decode([RunLogRecord].self, forKey: .logs)
         }
 
         public func encode(to encoder: Encoder) throws {
@@ -397,6 +452,16 @@ public extension PrivateHeaderGeneration {
             self.artifacts = artifacts
             self.attemptedArtifacts = attemptedArtifacts
             self.failureSummary = failureSummary
+        }
+
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            self.targetID = try container.decode(String.self, forKey: .targetID)
+            self.status = try container.decode(RunTargetStatus.self, forKey: .status)
+            self.phases = try container.decode([PhaseRecord].self, forKey: .phases)
+            self.artifacts = try container.decode([ArtifactPath].self, forKey: .artifacts)
+            self.attemptedArtifacts = try container.decode([ArtifactPath].self, forKey: .attemptedArtifacts)
+            self.failureSummary = try container.decodeRequiredNullable(String.self, forKey: .failureSummary)
         }
 
         public func encode(to encoder: Encoder) throws {
@@ -534,5 +599,18 @@ private extension KeyedEncodingContainer {
         } else {
             try encodeNil(forKey: key)
         }
+    }
+}
+
+private extension KeyedDecodingContainer {
+    func decodeRequiredNullable<Value: Decodable>(_ type: Value.Type, forKey key: Key) throws -> Value? {
+        guard contains(key) else {
+            let context = DecodingError.Context(
+                codingPath: codingPath + [key],
+                debugDescription: "Missing required nullable key: \(key.stringValue)"
+            )
+            throw DecodingError.keyNotFound(key, context)
+        }
+        return try decodeIfPresent(type, forKey: key)
     }
 }

--- a/Sources/PrivateHeaderKitCore/PrivateHeaderGenerationState.swift
+++ b/Sources/PrivateHeaderKitCore/PrivateHeaderGenerationState.swift
@@ -124,6 +124,29 @@ public extension PrivateHeaderGeneration {
             self.targets = targets
             self.updatedAt = updatedAt
         }
+
+        public func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode(schemaVersion, forKey: .schemaVersion)
+            try container.encode(toolVersion, forKey: .toolVersion)
+            try container.encode(source, forKey: .source)
+            try container.encode(output, forKey: .output)
+            try container.encode(layout, forKey: .layout)
+            try container.encodeRequired(latestRunID, forKey: .latestRunID)
+            try container.encode(targets, forKey: .targets)
+            try container.encode(updatedAt, forKey: .updatedAt)
+        }
+
+        private enum CodingKeys: String, CodingKey {
+            case schemaVersion
+            case toolVersion
+            case source
+            case output
+            case layout
+            case latestRunID
+            case targets
+            case updatedAt
+        }
     }
 
     struct SourceRecord: Codable, Equatable, Sendable {
@@ -139,6 +162,23 @@ public extension PrivateHeaderGeneration {
             self.build = source.build
             self.displayName = source.label.displayName
             self.directoryName = source.label.directoryName
+        }
+
+        public func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode(platform, forKey: .platform)
+            try container.encode(version, forKey: .version)
+            try container.encodeRequired(build, forKey: .build)
+            try container.encode(displayName, forKey: .displayName)
+            try container.encode(directoryName, forKey: .directoryName)
+        }
+
+        private enum CodingKeys: String, CodingKey {
+            case platform
+            case version
+            case build
+            case displayName
+            case directoryName
         }
     }
 
@@ -198,6 +238,31 @@ public extension PrivateHeaderGeneration {
             self.updatedAt = updatedAt
             self.failureSummary = failureSummary
         }
+
+        public func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode(id, forKey: .id)
+            try container.encode(displayName, forKey: .displayName)
+            try container.encode(kind, forKey: .kind)
+            try container.encode(status, forKey: .status)
+            try container.encode(phases, forKey: .phases)
+            try container.encode(artifacts, forKey: .artifacts)
+            try container.encodeRequired(lastRunID, forKey: .lastRunID)
+            try container.encode(updatedAt, forKey: .updatedAt)
+            try container.encodeRequired(failureSummary, forKey: .failureSummary)
+        }
+
+        private enum CodingKeys: String, CodingKey {
+            case id
+            case displayName
+            case kind
+            case status
+            case phases
+            case artifacts
+            case lastRunID
+            case updatedAt
+            case failureSummary
+        }
     }
 
     struct PhaseRecord: Codable, Equatable, Sendable {
@@ -209,6 +274,19 @@ public extension PrivateHeaderGeneration {
             self.name = name
             self.status = status
             self.failureSummary = failureSummary
+        }
+
+        public func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode(name, forKey: .name)
+            try container.encode(status, forKey: .status)
+            try container.encodeRequired(failureSummary, forKey: .failureSummary)
+        }
+
+        private enum CodingKeys: String, CodingKey {
+            case name
+            case status
+            case failureSummary
         }
     }
 }
@@ -248,6 +326,33 @@ public extension PrivateHeaderGeneration {
             self.targetResults = targetResults
             self.attemptedArtifacts = attemptedArtifacts
             self.logs = logs
+        }
+
+        public func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode(runID, forKey: .runID)
+            try container.encode(schemaVersion, forKey: .schemaVersion)
+            try container.encode(toolVersion, forKey: .toolVersion)
+            try container.encode(plan, forKey: .plan)
+            try container.encode(startedAt, forKey: .startedAt)
+            try container.encodeRequired(endedAt, forKey: .endedAt)
+            try container.encode(status, forKey: .status)
+            try container.encode(targetResults, forKey: .targetResults)
+            try container.encode(attemptedArtifacts, forKey: .attemptedArtifacts)
+            try container.encode(logs, forKey: .logs)
+        }
+
+        private enum CodingKeys: String, CodingKey {
+            case runID
+            case schemaVersion
+            case toolVersion
+            case plan
+            case startedAt
+            case endedAt
+            case status
+            case targetResults
+            case attemptedArtifacts
+            case logs
         }
     }
 
@@ -292,6 +397,25 @@ public extension PrivateHeaderGeneration {
             self.artifacts = artifacts
             self.attemptedArtifacts = attemptedArtifacts
             self.failureSummary = failureSummary
+        }
+
+        public func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode(targetID, forKey: .targetID)
+            try container.encode(status, forKey: .status)
+            try container.encode(phases, forKey: .phases)
+            try container.encode(artifacts, forKey: .artifacts)
+            try container.encode(attemptedArtifacts, forKey: .attemptedArtifacts)
+            try container.encodeRequired(failureSummary, forKey: .failureSummary)
+        }
+
+        private enum CodingKeys: String, CodingKey {
+            case targetID
+            case status
+            case phases
+            case artifacts
+            case attemptedArtifacts
+            case failureSummary
         }
     }
 
@@ -402,3 +526,13 @@ public extension PrivateHeaderGeneration {
 }
 
 extension PrivateHeaderGeneration.Source.Platform: Codable {}
+
+private extension KeyedEncodingContainer {
+    mutating func encodeRequired<Value: Encodable>(_ value: Value?, forKey key: Key) throws {
+        if let value {
+            try encode(value, forKey: key)
+        } else {
+            try encodeNil(forKey: key)
+        }
+    }
+}

--- a/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationStateTests.swift
+++ b/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationStateTests.swift
@@ -160,6 +160,39 @@ struct PrivateHeaderGenerationRunRecordTests {
         #expect(decoded.status == .partial)
         #expect(decoded.targetResults.first?.status == .commitFailed)
         #expect(decoded.attemptedArtifacts.map(\.rawValue) == ["Frameworks/Foo/Foo.h"])
+        #expect(decoded.plan.execution.runtimeIdentifier == "com.apple.CoreSimulator.SimRuntime.iOS-27-0")
+    }
+
+    @Test func runPlanRecordsExecutionMetadata() throws {
+        let manifest = try makeManifest()
+        let first = PrivateHeaderGeneration.RunPlanRecord(
+            source: manifest.source,
+            output: manifest.output,
+            layout: manifest.layout,
+            targetIDs: ["framework:Foo"],
+            execution: makeExecutionRecord(deviceUDID: "SIM-001")
+        )
+        let second = PrivateHeaderGeneration.RunPlanRecord(
+            source: manifest.source,
+            output: manifest.output,
+            layout: manifest.layout,
+            targetIDs: ["framework:Foo"],
+            execution: makeExecutionRecord(deviceUDID: "SIM-002")
+        )
+
+        let data = try PrivateHeaderGeneration.StateJSON.encode(first)
+        let json = try #require(String(data: data, encoding: .utf8))
+        let decoded = try PrivateHeaderGeneration.StateJSON.decode(
+            PrivateHeaderGeneration.RunPlanRecord.self,
+            from: data
+        )
+
+        #expect(first != second)
+        #expect(decoded == first)
+        #expect(json.contains("\"runtimeIdentifier\" : \"com.apple.CoreSimulator.SimRuntime.iOS-27-0\""))
+        #expect(json.contains("\"deviceUDID\" : \"SIM-001\""))
+        #expect(json.contains("\"clonePolicy\" : \"reuseOrCreate\""))
+        #expect(json.contains("\"execution\" : {"))
     }
 
     @Test func runRecordEncodingKeepsRequiredNullFields() throws {
@@ -172,7 +205,8 @@ struct PrivateHeaderGenerationRunRecordTests {
                 source: manifest.source,
                 output: manifest.output,
                 layout: manifest.layout,
-                targetIDs: ["framework:Foo"]
+                targetIDs: ["framework:Foo"],
+                execution: makeExecutionRecord()
             ),
             startedAt: Date(timeIntervalSinceReferenceDate: 42),
             endedAt: nil,
@@ -314,7 +348,8 @@ private func makeRunRecord() throws -> PrivateHeaderGeneration.RunRecord {
         source: manifest.source,
         output: manifest.output,
         layout: manifest.layout,
-        targetIDs: ["framework:Foo"]
+        targetIDs: ["framework:Foo"],
+        execution: makeExecutionRecord()
     )
 
     return PrivateHeaderGeneration.RunRecord(
@@ -343,6 +378,21 @@ private func makeRunRecord() throws -> PrivateHeaderGeneration.RunRecord {
                 kind: "stderr",
                 relativePath: try PrivateHeaderGeneration.ArtifactPath("runs/run-001/logs/stderr.log")
             ),
+        ]
+    )
+}
+
+private func makeExecutionRecord(
+    deviceUDID: String = "SIM-001"
+) -> PrivateHeaderGeneration.ExecutionRecord {
+    PrivateHeaderGeneration.ExecutionRecord(
+        mode: "simulator",
+        runtimeIdentifier: "com.apple.CoreSimulator.SimRuntime.iOS-27-0",
+        deviceName: "iPhone 17",
+        deviceUDID: deviceUDID,
+        clonePolicy: "reuseOrCreate",
+        helperEnvironment: [
+            "PRIVATEHEADERKIT_DUMP_QUALITY": "max",
         ]
     )
 }

--- a/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationStateTests.swift
+++ b/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationStateTests.swift
@@ -41,7 +41,8 @@ struct PrivateHeaderGenerationManifestTests {
     }
 
     @Test func stateJSONPreservesFractionalSecondDates() throws {
-        let manifest = try makeManifest(updatedAt: Date(timeIntervalSince1970: 1_000.123))
+        let updatedAt = Date(timeIntervalSinceReferenceDate: .pi)
+        let manifest = try makeManifest(updatedAt: updatedAt)
 
         let data = try PrivateHeaderGeneration.StateJSON.encode(manifest)
         let json = try #require(String(data: data, encoding: .utf8))
@@ -51,7 +52,7 @@ struct PrivateHeaderGenerationManifestTests {
         )
 
         #expect(decoded.updatedAt == manifest.updatedAt)
-        #expect(json.contains("\"updatedAt\" : \"1970-01-01T00:16:40.123Z\""))
+        #expect(json.contains("\"updatedAt\" : 3.141592653589793"))
     }
 
     @Test func artifactPathRejectsAbsoluteTraversalAndEmptyPaths() {

--- a/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationStateTests.swift
+++ b/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationStateTests.swift
@@ -55,6 +55,58 @@ struct PrivateHeaderGenerationManifestTests {
         #expect(json.contains("\"updatedAt\" : 3.141592653589793"))
     }
 
+    @Test func manifestEncodingKeepsRequiredNullFields() throws {
+        let source = try PrivateHeaderGeneration.Source(
+            platform: .iOS,
+            version: "27.0",
+            build: nil
+        )
+        let updatedAt = Date(timeIntervalSinceReferenceDate: 42)
+        let manifest = PrivateHeaderGeneration.Manifest(
+            schemaVersion: 1,
+            toolVersion: "0.1.0",
+            source: PrivateHeaderGeneration.SourceRecord(source: source),
+            output: PrivateHeaderGeneration.OutputRecord(
+                baseDirectory: "/tmp/PrivateHeaderKit",
+                artifactDirectory: "/tmp/PrivateHeaderKit/generated-headers",
+                stateDirectory: "/tmp/PrivateHeaderKit/.state"
+            ),
+            layout: .headers,
+            latestRunID: nil,
+            targets: [
+                PrivateHeaderGeneration.TargetRecord(
+                    id: "framework:Foo",
+                    displayName: "Foo.framework",
+                    kind: "framework",
+                    status: .completed,
+                    phases: [
+                        PrivateHeaderGeneration.PhaseRecord(name: "static ObjC", status: .completed),
+                    ],
+                    artifacts: [
+                        try PrivateHeaderGeneration.ArtifactPath("Frameworks/Foo/Foo.h"),
+                    ],
+                    lastRunID: nil,
+                    updatedAt: updatedAt,
+                    failureSummary: nil
+                ),
+            ],
+            updatedAt: updatedAt
+        )
+
+        let data = try PrivateHeaderGeneration.StateJSON.encode(manifest)
+        let json = try #require(String(data: data, encoding: .utf8))
+        let decoded = try PrivateHeaderGeneration.StateJSON.decode(
+            PrivateHeaderGeneration.Manifest.self,
+            from: data
+        )
+
+        #expect(decoded == manifest)
+        #expect(json.contains("\"build\" : null"))
+        #expect(json.contains("\"latestRunID\" : null"))
+        #expect(json.contains("\"lastRunID\" : null"))
+        #expect(json.contains("\"failureSummary\" : null"))
+    }
+
     @Test func artifactPathRejectsAbsoluteTraversalAndEmptyPaths() {
         #expect(throws: PrivateHeaderGeneration.StateValidationError.self) {
             _ = try PrivateHeaderGeneration.ArtifactPath("/System/Library/Foo.h")
@@ -93,6 +145,49 @@ struct PrivateHeaderGenerationRunRecordTests {
         #expect(decoded.status == .partial)
         #expect(decoded.targetResults.first?.status == .commitFailed)
         #expect(decoded.attemptedArtifacts.map(\.rawValue) == ["Frameworks/Foo/Foo.h"])
+    }
+
+    @Test func runRecordEncodingKeepsRequiredNullFields() throws {
+        let manifest = try makeManifest()
+        let run = PrivateHeaderGeneration.RunRecord(
+            runID: "run-002",
+            schemaVersion: 1,
+            toolVersion: "0.1.0",
+            plan: PrivateHeaderGeneration.RunPlanRecord(
+                source: manifest.source,
+                output: manifest.output,
+                layout: manifest.layout,
+                targetIDs: ["framework:Foo"]
+            ),
+            startedAt: Date(timeIntervalSinceReferenceDate: 42),
+            endedAt: nil,
+            status: .running,
+            targetResults: [
+                PrivateHeaderGeneration.RunTargetRecord(
+                    targetID: "framework:Foo",
+                    status: .running,
+                    phases: [
+                        PrivateHeaderGeneration.PhaseRecord(name: "static ObjC", status: .running),
+                    ],
+                    artifacts: [],
+                    attemptedArtifacts: [],
+                    failureSummary: nil
+                ),
+            ],
+            attemptedArtifacts: [],
+            logs: []
+        )
+
+        let data = try PrivateHeaderGeneration.StateJSON.encode(run)
+        let json = try #require(String(data: data, encoding: .utf8))
+        let decoded = try PrivateHeaderGeneration.StateJSON.decode(
+            PrivateHeaderGeneration.RunRecord.self,
+            from: data
+        )
+
+        #expect(decoded == run)
+        #expect(json.contains("\"endedAt\" : null"))
+        #expect(json.contains("\"failureSummary\" : null"))
     }
 
     @Test func runHistoryRetentionKeepsLatestTenRuns() {

--- a/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationStateTests.swift
+++ b/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationStateTests.swift
@@ -1,0 +1,208 @@
+import Foundation
+import Testing
+
+import PrivateHeaderKitCore
+
+@Suite
+struct PrivateHeaderGenerationManifestTests {
+    @Test func manifestRoundTripsAsPrettyJSON() throws {
+        let manifest = try makeManifest()
+
+        let data = try PrivateHeaderGeneration.StateJSON.encode(manifest)
+        let json = try #require(String(data: data, encoding: .utf8))
+        let decoded = try PrivateHeaderGeneration.StateJSON.decode(
+            PrivateHeaderGeneration.Manifest.self,
+            from: data
+        )
+
+        #expect(decoded == manifest)
+        #expect(json.contains("\n  \"layout\" : \"headers\""))
+        #expect(json.contains("\"schemaVersion\" : 1"))
+        #expect(json.contains("\"artifacts\" : [\n"))
+    }
+
+    @Test func manifestStoreWritesAndReadsJSON() throws {
+        let manifest = try makeManifest()
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("PrivateHeaderKitStateTests-\(UUID().uuidString)", isDirectory: true)
+        let url = directory.appendingPathComponent("manifest.json")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer {
+            try? FileManager.default.removeItem(at: directory)
+        }
+
+        try PrivateHeaderGeneration.StateJSON.write(manifest, to: url)
+        let decoded = try PrivateHeaderGeneration.StateJSON.read(
+            PrivateHeaderGeneration.Manifest.self,
+            from: url
+        )
+
+        #expect(decoded == manifest)
+    }
+
+    @Test func artifactPathRejectsAbsoluteTraversalAndEmptyPaths() {
+        #expect(throws: PrivateHeaderGeneration.StateValidationError.self) {
+            _ = try PrivateHeaderGeneration.ArtifactPath("/System/Library/Foo.h")
+        }
+        #expect(throws: PrivateHeaderGeneration.StateValidationError.self) {
+            _ = try PrivateHeaderGeneration.ArtifactPath("Frameworks/../Foo.h")
+        }
+        #expect(throws: PrivateHeaderGeneration.StateValidationError.self) {
+            _ = try PrivateHeaderGeneration.ArtifactPath("")
+        }
+    }
+
+    @Test func artifactPathValidationRunsDuringJSONDecode() throws {
+        let data = Data(#""../escape.h""#.utf8)
+
+        #expect(throws: PrivateHeaderGeneration.StateValidationError.self) {
+            _ = try PrivateHeaderGeneration.StateJSON.decode(
+                PrivateHeaderGeneration.ArtifactPath.self,
+                from: data
+            )
+        }
+    }
+}
+
+@Suite
+struct PrivateHeaderGenerationRunRecordTests {
+    @Test func runRecordRoundTripsTargetResultsAndAttemptedArtifacts() throws {
+        let run = try makeRunRecord()
+        let data = try PrivateHeaderGeneration.StateJSON.encode(run)
+        let decoded = try PrivateHeaderGeneration.StateJSON.decode(
+            PrivateHeaderGeneration.RunRecord.self,
+            from: data
+        )
+
+        #expect(decoded == run)
+        #expect(decoded.status == .partial)
+        #expect(decoded.targetResults.first?.status == .commitFailed)
+        #expect(decoded.attemptedArtifacts.map(\.rawValue) == ["Frameworks/Foo/Foo.h"])
+    }
+
+    @Test func runHistoryRetentionKeepsLatestTenRuns() {
+        let base = Date(timeIntervalSince1970: 1_000)
+        let runs = (0..<12).map { index in
+            PrivateHeaderGeneration.RunSummary(
+                runID: "run-\(index)",
+                startedAt: base.addingTimeInterval(TimeInterval(index))
+            )
+        }
+
+        let retained = PrivateHeaderGeneration.RunHistoryRetention.retainedRunIDs(from: runs)
+
+        #expect(retained == [
+            "run-11",
+            "run-10",
+            "run-9",
+            "run-8",
+            "run-7",
+            "run-6",
+            "run-5",
+            "run-4",
+            "run-3",
+            "run-2",
+        ])
+    }
+
+    @Test func runHistoryRetentionUsesRunIDAsStableTieBreaker() {
+        let startedAt = Date(timeIntervalSince1970: 1_000)
+        let runs = [
+            PrivateHeaderGeneration.RunSummary(runID: "run-a", startedAt: startedAt),
+            PrivateHeaderGeneration.RunSummary(runID: "run-c", startedAt: startedAt),
+            PrivateHeaderGeneration.RunSummary(runID: "run-b", startedAt: startedAt),
+        ]
+
+        let retained = PrivateHeaderGeneration.RunHistoryRetention.retainedRunIDs(from: runs, limit: 2)
+
+        #expect(retained == ["run-c", "run-b"])
+    }
+}
+
+private func makeManifest() throws -> PrivateHeaderGeneration.Manifest {
+    let source = try PrivateHeaderGeneration.Source(
+        platform: .iOS,
+        version: "27.0",
+        build: "24A5355q"
+    )
+    let root = URL(fileURLWithPath: "/tmp/PrivateHeaderKit", isDirectory: true)
+    let output = PrivateHeaderGeneration.Output(
+        artifactBaseDirectory: root.appendingPathComponent("generated-headers", isDirectory: true),
+        stateBaseDirectory: root.appendingPathComponent(".state", isDirectory: true)
+    )
+    let plan = PrivateHeaderGeneration.makePlan(source: source, output: output)
+    let updatedAt = Date(timeIntervalSince1970: 1_000)
+
+    return PrivateHeaderGeneration.Manifest(
+        schemaVersion: 1,
+        toolVersion: "0.1.0",
+        source: PrivateHeaderGeneration.SourceRecord(source: source),
+        output: PrivateHeaderGeneration.OutputRecord(plan: plan, baseDirectory: root),
+        layout: .headers,
+        latestRunID: "run-001",
+        targets: [
+            PrivateHeaderGeneration.TargetRecord(
+                id: "framework:Foo",
+                displayName: "Foo.framework",
+                kind: "framework",
+                status: .partial,
+                phases: [
+                    PrivateHeaderGeneration.PhaseRecord(name: "static ObjC", status: .completed),
+                    PrivateHeaderGeneration.PhaseRecord(
+                        name: "Swift interface",
+                        status: .failed,
+                        failureSummary: "swift interface failed"
+                    ),
+                ],
+                artifacts: [
+                    try PrivateHeaderGeneration.ArtifactPath("Frameworks/Foo/Foo.h"),
+                    try PrivateHeaderGeneration.ArtifactPath("Frameworks/Foo/Foo.swiftinterface"),
+                ],
+                lastRunID: "run-001",
+                updatedAt: updatedAt,
+                failureSummary: "swift interface failed"
+            ),
+        ],
+        updatedAt: updatedAt
+    )
+}
+
+private func makeRunRecord() throws -> PrivateHeaderGeneration.RunRecord {
+    let manifest = try makeManifest()
+    let artifact = try PrivateHeaderGeneration.ArtifactPath("Frameworks/Foo/Foo.h")
+    let plan = PrivateHeaderGeneration.RunPlanRecord(
+        source: manifest.source,
+        output: manifest.output,
+        layout: manifest.layout,
+        targetIDs: ["framework:Foo"]
+    )
+
+    return PrivateHeaderGeneration.RunRecord(
+        runID: "run-001",
+        schemaVersion: 1,
+        toolVersion: "0.1.0",
+        plan: plan,
+        startedAt: Date(timeIntervalSince1970: 1_000),
+        endedAt: Date(timeIntervalSince1970: 1_100),
+        status: .partial,
+        targetResults: [
+            PrivateHeaderGeneration.RunTargetRecord(
+                targetID: "framework:Foo",
+                status: .commitFailed,
+                phases: [
+                    PrivateHeaderGeneration.PhaseRecord(name: "commit", status: .failed),
+                ],
+                artifacts: [],
+                attemptedArtifacts: [artifact],
+                failureSummary: "commit failed"
+            ),
+        ],
+        attemptedArtifacts: [artifact],
+        logs: [
+            PrivateHeaderGeneration.RunLogRecord(
+                kind: "stderr",
+                relativePath: try PrivateHeaderGeneration.ArtifactPath("runs/run-001/logs/stderr.log")
+            ),
+        ]
+    )
+}

--- a/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationStateTests.swift
+++ b/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationStateTests.swift
@@ -107,6 +107,21 @@ struct PrivateHeaderGenerationManifestTests {
         #expect(json.contains("\"failureSummary\" : null"))
     }
 
+    @Test func manifestDecodingRejectsMissingRequiredNullableFields() throws {
+        let manifest = try makeManifest()
+        let data = try PrivateHeaderGeneration.StateJSON.encode(manifest)
+        var object = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        object.removeValue(forKey: "latestRunID")
+        let missingKeyData = try JSONSerialization.data(withJSONObject: object, options: [.sortedKeys])
+
+        #expect(throws: DecodingError.self) {
+            _ = try PrivateHeaderGeneration.StateJSON.decode(
+                PrivateHeaderGeneration.Manifest.self,
+                from: missingKeyData
+            )
+        }
+    }
+
     @Test func artifactPathRejectsAbsoluteTraversalAndEmptyPaths() {
         #expect(throws: PrivateHeaderGeneration.StateValidationError.self) {
             _ = try PrivateHeaderGeneration.ArtifactPath("/System/Library/Foo.h")
@@ -188,6 +203,21 @@ struct PrivateHeaderGenerationRunRecordTests {
         #expect(decoded == run)
         #expect(json.contains("\"endedAt\" : null"))
         #expect(json.contains("\"failureSummary\" : null"))
+    }
+
+    @Test func runRecordDecodingRejectsMissingRequiredNullableFields() throws {
+        let run = try makeRunRecord()
+        let data = try PrivateHeaderGeneration.StateJSON.encode(run)
+        var object = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        object.removeValue(forKey: "endedAt")
+        let missingKeyData = try JSONSerialization.data(withJSONObject: object, options: [.sortedKeys])
+
+        #expect(throws: DecodingError.self) {
+            _ = try PrivateHeaderGeneration.StateJSON.decode(
+                PrivateHeaderGeneration.RunRecord.self,
+                from: missingKeyData
+            )
+        }
     }
 
     @Test func runHistoryRetentionKeepsLatestTenRuns() {

--- a/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationStateTests.swift
+++ b/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationStateTests.swift
@@ -40,6 +40,20 @@ struct PrivateHeaderGenerationManifestTests {
         #expect(decoded == manifest)
     }
 
+    @Test func stateJSONPreservesFractionalSecondDates() throws {
+        let manifest = try makeManifest(updatedAt: Date(timeIntervalSince1970: 1_000.123))
+
+        let data = try PrivateHeaderGeneration.StateJSON.encode(manifest)
+        let json = try #require(String(data: data, encoding: .utf8))
+        let decoded = try PrivateHeaderGeneration.StateJSON.decode(
+            PrivateHeaderGeneration.Manifest.self,
+            from: data
+        )
+
+        #expect(decoded.updatedAt == manifest.updatedAt)
+        #expect(json.contains("\"updatedAt\" : \"1970-01-01T00:16:40.123Z\""))
+    }
+
     @Test func artifactPathRejectsAbsoluteTraversalAndEmptyPaths() {
         #expect(throws: PrivateHeaderGeneration.StateValidationError.self) {
             _ = try PrivateHeaderGeneration.ArtifactPath("/System/Library/Foo.h")
@@ -119,7 +133,9 @@ struct PrivateHeaderGenerationRunRecordTests {
     }
 }
 
-private func makeManifest() throws -> PrivateHeaderGeneration.Manifest {
+private func makeManifest(
+    updatedAt: Date = Date(timeIntervalSince1970: 1_000)
+) throws -> PrivateHeaderGeneration.Manifest {
     let source = try PrivateHeaderGeneration.Source(
         platform: .iOS,
         version: "27.0",
@@ -131,8 +147,6 @@ private func makeManifest() throws -> PrivateHeaderGeneration.Manifest {
         stateBaseDirectory: root.appendingPathComponent(".state", isDirectory: true)
     )
     let plan = PrivateHeaderGeneration.makePlan(source: source, output: output)
-    let updatedAt = Date(timeIntervalSince1970: 1_000)
-
     return PrivateHeaderGeneration.Manifest(
         schemaVersion: 1,
         toolVersion: "0.1.0",

--- a/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationTests.swift
+++ b/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationTests.swift
@@ -129,4 +129,29 @@ struct PrivateHeaderGenerationPlanTests {
             )
         }
     }
+
+    @Test func topLevelGeneratePrivateHeadersForwardsToNamespaceEntryPoint() async throws {
+        let source = try PrivateHeaderGeneration.Source(
+            platform: .macOS,
+            version: "16.0",
+            build: "25A5279m"
+        )
+        let output = PrivateHeaderGeneration.Output(
+            baseDirectory: URL(fileURLWithPath: "/tmp/PrivateHeaderKit", isDirectory: true)
+        )
+
+        do {
+            _ = try await generatePrivateHeaders(source: source, output: output)
+            Issue.record("generatePrivateHeaders unexpectedly returned a result")
+        } catch let error as PrivateHeaderGeneration.GenerationError {
+            #expect(
+                error == .notImplemented(
+                    plan: PrivateHeaderGeneration.makePlan(
+                        source: source,
+                        output: output
+                    )
+                )
+            )
+        }
+    }
 }

--- a/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationTests.swift
+++ b/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationTests.swift
@@ -1,0 +1,132 @@
+import Foundation
+import Testing
+
+import PrivateHeaderKitCore
+
+@Suite
+struct PrivateHeaderGenerationLabelTests {
+    @Test func iOSSourceLabelUsesUserFacingDisplayAndCompactDirectoryNames() throws {
+        let source = try PrivateHeaderGeneration.Source(
+            platform: .iOS,
+            version: "27.0",
+            build: "24A5355q"
+        )
+
+        #expect(source.label.displayName == "iOS 27.0 (24A5355q)")
+        #expect(source.label.directoryName == "iOS27.0(24A5355q)")
+        #expect(source.label.description == "iOS 27.0 (24A5355q)")
+    }
+
+    @Test func macOSSourceLabelUsesUserFacingDisplayAndCompactDirectoryNames() throws {
+        let source = try PrivateHeaderGeneration.Source(
+            platform: .macOS,
+            version: "16.0",
+            build: "25A5279m"
+        )
+
+        #expect(source.label.displayName == "macOS 16.0 (25A5279m)")
+        #expect(source.label.directoryName == "macOS16.0(25A5279m)")
+    }
+
+    @Test func sourceLabelOmitsEmptyBuild() throws {
+        let source = try PrivateHeaderGeneration.Source(
+            platform: .iOS,
+            version: "27.0",
+            build: ""
+        )
+
+        #expect(source.label.displayName == "iOS 27.0")
+        #expect(source.label.directoryName == "iOS27.0")
+    }
+
+    @Test func sourceRejectsPathUnsafeVersionAndBuildComponents() throws {
+        #expect(throws: PrivateHeaderGeneration.Source.ValidationError.self) {
+            _ = try PrivateHeaderGeneration.Source(
+                platform: .iOS,
+                version: "../27.0",
+                build: "24A5355q"
+            )
+        }
+
+        #expect(throws: PrivateHeaderGeneration.Source.ValidationError.self) {
+            _ = try PrivateHeaderGeneration.Source(
+                platform: .iOS,
+                version: "27.0",
+                build: "24A/5355q"
+            )
+        }
+    }
+}
+
+@Suite
+struct PrivateHeaderGenerationPlanTests {
+    @Test func customOutputBaseKeepsStateOutsideArtifactDirectoryAndUsesSourceLabelAsResumeKey() throws {
+        let source = try PrivateHeaderGeneration.Source(
+            platform: .iOS,
+            version: "27.0",
+            build: "24A5355q"
+        )
+        let root = URL(fileURLWithPath: "/tmp/PrivateHeaderKit", isDirectory: true)
+        let output = PrivateHeaderGeneration.Output(baseDirectory: root)
+
+        let plan = PrivateHeaderGeneration.makePlan(
+            source: source,
+            output: output
+        )
+
+        #expect(plan.source == source)
+        #expect(plan.output == output)
+        #expect(plan.artifactDirectory.path == "/tmp/PrivateHeaderKit/iOS27.0(24A5355q)")
+        #expect(plan.stateDirectory.path == "/tmp/PrivateHeaderKit/.state/iOS27.0(24A5355q)")
+        #expect(plan.target == .allAvailable)
+    }
+
+    @Test func defaultOutputCanSeparateArtifactAndStateBases() throws {
+        let source = try PrivateHeaderGeneration.Source(
+            platform: .iOS,
+            version: "27.0",
+            build: "24A5355q"
+        )
+        let root = URL(fileURLWithPath: "/tmp/PrivateHeaderKit", isDirectory: true)
+        let output = PrivateHeaderGeneration.Output(
+            artifactBaseDirectory: root.appendingPathComponent("generated-headers", isDirectory: true),
+            stateBaseDirectory: root.appendingPathComponent(".state", isDirectory: true)
+        )
+
+        let plan = PrivateHeaderGeneration.makePlan(
+            source: source,
+            output: output
+        )
+
+        #expect(plan.artifactDirectory.path == "/tmp/PrivateHeaderKit/generated-headers/iOS27.0(24A5355q)")
+        #expect(plan.stateDirectory.path == "/tmp/PrivateHeaderKit/.state/iOS27.0(24A5355q)")
+    }
+
+    @Test func generatePrivateHeadersThrowsExplicitUnimplementedError() async throws {
+        let source = try PrivateHeaderGeneration.Source(
+            platform: .macOS,
+            version: "16.0",
+            build: "25A5279m"
+        )
+        let output = PrivateHeaderGeneration.Output(
+            baseDirectory: URL(fileURLWithPath: "/tmp/PrivateHeaderKit", isDirectory: true)
+        )
+
+        do {
+            _ = try await PrivateHeaderGeneration.generatePrivateHeaders(
+                source: source,
+                output: output
+            )
+            Issue.record("generatePrivateHeaders unexpectedly returned a result")
+        } catch let error as PrivateHeaderGeneration.GenerationError {
+            #expect(
+                error == .notImplemented(
+                    plan: PrivateHeaderGeneration.makePlan(
+                        source: source,
+                        output: output
+                    )
+                )
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Purpose

Add the state and manifest foundation for the PrivateHeaderKit rewrite on top of `main`.

## Changes

- Add manifest and run record models for persisted rewrite state.
- Add target, run-local, and phase status enums required by the rewrite flow.
- Add validated relative artifact paths that reject absolute paths, empty paths, and traversal components.
- Add pretty JSON encode/decode/read/write helpers with exact `Date` round-trip precision.
- Preserve and validate required nullable JSON fields instead of silently omitting or accepting missing keys.
- Record run execution metadata needed to distinguish simulator/runtime/device/helper context for resume and reproducibility.
- Add run history retention logic for keeping the latest 10 runs.
- Expose the documented top-level `generatePrivateHeaders(...)` forwarding entry point.
- Cover manifest/run JSON round-trips, artifact path validation, exact timestamp preservation, required nullable keys, execution metadata, and retention ordering.

## Verification

- `git diff --check`
- `swift test` (93 tests passed)
- `codex-review` against `main` (clean, no findings)

## Notes

This PR intentionally does not implement CLI wizard flow, cleanup/deletion executors, staging commits, simulator helpers, or legacy marker compatibility.