### PR TITLE
Add runtime resume foundations

### DIFF
--- a/Sources/PrivateHeaderKitCore/PrivateHeaderGenerationArtifactStore.swift
+++ b/Sources/PrivateHeaderKitCore/PrivateHeaderGenerationArtifactStore.swift
@@ -1,0 +1,215 @@
+import Foundation
+
+public extension PrivateHeaderGeneration {
+    struct ArtifactCleanupResult: Equatable, Sendable {
+        public let deletedArtifacts: [ArtifactPath]
+        public let missingArtifacts: [ArtifactPath]
+        public let prunedDirectories: [ArtifactPath]
+
+        public init(
+            deletedArtifacts: [ArtifactPath],
+            missingArtifacts: [ArtifactPath],
+            prunedDirectories: [ArtifactPath]
+        ) {
+            self.deletedArtifacts = deletedArtifacts
+            self.missingArtifacts = missingArtifacts
+            self.prunedDirectories = prunedDirectories
+        }
+    }
+
+    enum ArtifactStoreError: Error, Equatable, CustomStringConvertible, Sendable {
+        case nonFileArtifactRoot(String)
+        case artifactPathEscapesRoot(artifactPath: ArtifactPath, artifactRoot: String, resolvedPath: String)
+
+        public var description: String {
+            switch self {
+            case .nonFileArtifactRoot(let artifactRoot):
+                "artifact root must be a file URL: \(artifactRoot)"
+            case .artifactPathEscapesRoot(let artifactPath, let artifactRoot, let resolvedPath):
+                "artifact path escapes artifact root: \(artifactPath.rawValue) resolved to \(resolvedPath) outside \(artifactRoot)"
+            }
+        }
+    }
+
+    struct ArtifactStore: Sendable {
+        public let artifactRoot: URL
+
+        public init(artifactRoot: URL) {
+            self.artifactRoot = artifactRoot
+        }
+
+        @discardableResult
+        public func cleanupManagedArtifacts(
+            _ artifacts: [ArtifactPath],
+            fileManager: FileManager = .default
+        ) throws -> ArtifactCleanupResult {
+            try Self.cleanupManagedArtifacts(
+                in: artifactRoot,
+                artifacts: artifacts,
+                fileManager: fileManager
+            )
+        }
+
+        @discardableResult
+        public static func cleanupManagedArtifacts(
+            in artifactRoot: URL,
+            artifacts: [ArtifactPath],
+            fileManager: FileManager = .default
+        ) throws -> ArtifactCleanupResult {
+            let root = try artifactRootURLs(for: artifactRoot)
+            let candidates = cleanupCandidates(manifestArtifacts: artifacts)
+            let candidateSet = Set(candidates)
+            var deletedArtifacts: [ArtifactPath] = []
+            var missingArtifacts: [ArtifactPath] = []
+            var prunedDirectories: [ArtifactPath] = []
+            var prunedDirectorySet = Set<ArtifactPath>()
+
+            for artifact in cleanupOperationOrder(candidates) {
+                let artifactURL = try artifactFileURL(
+                    for: artifact,
+                    root: root
+                )
+
+                guard fileManager.fileExists(atPath: artifactURL.path) else {
+                    missingArtifacts.append(artifact)
+                    continue
+                }
+
+                try fileManager.removeItem(at: artifactURL)
+                deletedArtifacts.append(artifact)
+
+                let pruned = try pruneEmptyParentDirectories(
+                    afterDeleting: artifact,
+                    root: root,
+                    cleanupCandidates: candidateSet,
+                    fileManager: fileManager
+                )
+                for directory in pruned where prunedDirectorySet.insert(directory).inserted {
+                    prunedDirectories.append(directory)
+                }
+            }
+
+            return ArtifactCleanupResult(
+                deletedArtifacts: cleanupCandidates(manifestArtifacts: deletedArtifacts),
+                missingArtifacts: cleanupCandidates(manifestArtifacts: missingArtifacts),
+                prunedDirectories: cleanupCandidates(manifestArtifacts: prunedDirectories)
+            )
+        }
+
+        public static func cleanupCandidates(
+            manifestArtifacts: [ArtifactPath],
+            attemptedArtifacts: [ArtifactPath] = []
+        ) -> [ArtifactPath] {
+            Array(Set(manifestArtifacts + attemptedArtifacts))
+                .sorted { $0.rawValue < $1.rawValue }
+        }
+
+        private struct ArtifactRootURLs {
+            let unresolved: URL
+            let resolved: URL
+        }
+
+        private static func artifactRootURLs(for artifactRoot: URL) throws -> ArtifactRootURLs {
+            guard artifactRoot.isFileURL else {
+                throw ArtifactStoreError.nonFileArtifactRoot(artifactRoot.absoluteString)
+            }
+
+            let unresolved = artifactRoot.standardizedFileURL
+            return ArtifactRootURLs(
+                unresolved: unresolved,
+                resolved: unresolved.resolvingSymlinksInPath()
+            )
+        }
+
+        private static func artifactFileURL(
+            for artifact: ArtifactPath,
+            root: ArtifactRootURLs
+        ) throws -> URL {
+            var url = root.unresolved
+            for component in artifact.rawValue.split(separator: "/", omittingEmptySubsequences: false) {
+                url.appendPathComponent(String(component))
+            }
+
+            let resolvedURL = url.standardizedFileURL.resolvingSymlinksInPath()
+            guard isSameOrDescendant(resolvedURL, of: root.resolved) else {
+                throw ArtifactStoreError.artifactPathEscapesRoot(
+                    artifactPath: artifact,
+                    artifactRoot: root.resolved.path,
+                    resolvedPath: resolvedURL.path
+                )
+            }
+
+            return url
+        }
+
+        private static func cleanupOperationOrder(_ artifacts: [ArtifactPath]) -> [ArtifactPath] {
+            artifacts.sorted {
+                let leftDepth = pathDepth($0)
+                let rightDepth = pathDepth($1)
+                if leftDepth == rightDepth {
+                    return $0.rawValue < $1.rawValue
+                }
+                return leftDepth > rightDepth
+            }
+        }
+
+        private static func pathDepth(_ artifact: ArtifactPath) -> Int {
+            artifact.rawValue.split(separator: "/").count
+        }
+
+        private static func pruneEmptyParentDirectories(
+            afterDeleting artifact: ArtifactPath,
+            root: ArtifactRootURLs,
+            cleanupCandidates: Set<ArtifactPath>,
+            fileManager: FileManager
+        ) throws -> [ArtifactPath] {
+            var prunedDirectories: [ArtifactPath] = []
+
+            for parent in try parentDirectories(for: artifact) {
+                if cleanupCandidates.contains(parent) {
+                    break
+                }
+
+                let parentURL = try artifactFileURL(for: parent, root: root)
+                var isDirectory = ObjCBool(false)
+                guard fileManager.fileExists(atPath: parentURL.path, isDirectory: &isDirectory),
+                      isDirectory.boolValue
+                else {
+                    continue
+                }
+
+                guard try fileManager.contentsOfDirectory(atPath: parentURL.path).isEmpty else {
+                    break
+                }
+
+                try fileManager.removeItem(at: parentURL)
+                prunedDirectories.append(parent)
+            }
+
+            return prunedDirectories
+        }
+
+        private static func parentDirectories(for artifact: ArtifactPath) throws -> [ArtifactPath] {
+            let components = artifact.rawValue.split(separator: "/").map(String.init)
+            guard components.count > 1 else {
+                return []
+            }
+
+            return try stride(from: components.count - 1, through: 1, by: -1).map { count in
+                try ArtifactPath(components.prefix(count).joined(separator: "/"))
+            }
+        }
+
+        private static func isSameOrDescendant(_ url: URL, of root: URL) -> Bool {
+            let path = url.path
+            let rootPath = root.path
+            if path == rootPath {
+                return true
+            }
+            if rootPath == "/" {
+                return path.hasPrefix("/")
+            }
+            return path.hasPrefix(rootPath + "/")
+        }
+    }
+}

--- a/Sources/PrivateHeaderKitCore/PrivateHeaderGenerationResume.swift
+++ b/Sources/PrivateHeaderKitCore/PrivateHeaderGenerationResume.swift
@@ -1,0 +1,458 @@
+import Foundation
+
+public extension PrivateHeaderGeneration {
+    typealias ArtifactExistence = @Sendable (ArtifactPath) -> Bool
+
+    enum ResumeCompatibilityRecord: String, Hashable, Sendable {
+        case manifest
+        case run
+    }
+
+    enum ResumeCompatibilityReason: Equatable, Sendable {
+        case unsupportedManifestSchema(actual: Int, supported: [Int])
+        case unsupportedRunSchema(actual: Int, supported: [Int])
+        case sourceBuildMismatch(
+            expected: SourceRecord,
+            actual: SourceRecord,
+            record: ResumeCompatibilityRecord
+        )
+        case outputMismatch(
+            expected: OutputRecord,
+            actual: OutputRecord,
+            record: ResumeCompatibilityRecord
+        )
+        case layoutMismatch(
+            expected: Layout,
+            actual: Layout,
+            record: ResumeCompatibilityRecord
+        )
+        case selectedTargetSetMismatch(
+            expected: [String],
+            actual: [String],
+            record: ResumeCompatibilityRecord
+        )
+        case missingLatestRun(runID: String)
+    }
+
+    enum ResumeCompatibility: Equatable, Sendable {
+        case compatible
+        case incompatible([ResumeCompatibilityReason])
+
+        public var isCompatible: Bool {
+            self == .compatible
+        }
+    }
+
+    enum ResumeTargetStatus: String, Hashable, Sendable {
+        case completed
+        case partial
+        case failed
+        case interrupted
+        case commitFailed
+        case stale
+        case pending
+    }
+
+    struct ResumeTargetDecision: Equatable, Sendable {
+        public let targetID: String
+        public let status: ResumeTargetStatus
+
+        public init(targetID: String, status: ResumeTargetStatus) {
+            self.targetID = targetID
+            self.status = status
+        }
+
+        public var shouldRun: Bool {
+            status != .completed
+        }
+    }
+
+    struct ResumeTargetCounts: Equatable, Sendable {
+        public let total: Int
+        public let completed: Int
+        public let partial: Int
+        public let failed: Int
+        public let interrupted: Int
+        public let commitFailed: Int
+        public let stale: Int
+        public let pending: Int
+
+        public init(
+            total: Int,
+            completed: Int,
+            partial: Int,
+            failed: Int,
+            interrupted: Int,
+            commitFailed: Int,
+            stale: Int,
+            pending: Int
+        ) {
+            self.total = total
+            self.completed = completed
+            self.partial = partial
+            self.failed = failed
+            self.interrupted = interrupted
+            self.commitFailed = commitFailed
+            self.stale = stale
+            self.pending = pending
+        }
+
+        public var unfinished: Int {
+            partial + failed + interrupted + commitFailed + stale + pending
+        }
+
+        fileprivate init(targets: [ResumeTargetDecision]) {
+            var completed = 0
+            var partial = 0
+            var failed = 0
+            var interrupted = 0
+            var commitFailed = 0
+            var stale = 0
+            var pending = 0
+
+            for target in targets {
+                switch target.status {
+                case .completed:
+                    completed += 1
+                case .partial:
+                    partial += 1
+                case .failed:
+                    failed += 1
+                case .interrupted:
+                    interrupted += 1
+                case .commitFailed:
+                    commitFailed += 1
+                case .stale:
+                    stale += 1
+                case .pending:
+                    pending += 1
+                }
+            }
+
+            self.init(
+                total: targets.count,
+                completed: completed,
+                partial: partial,
+                failed: failed,
+                interrupted: interrupted,
+                commitFailed: commitFailed,
+                stale: stale,
+                pending: pending
+            )
+        }
+    }
+
+    struct ResumeSummary: Equatable, Sendable {
+        public let source: SourceRecord
+        public let output: OutputRecord
+        public let layout: Layout
+        public let latestRunID: String?
+        public let startedAt: Date?
+        public let updatedAt: Date
+        public let counts: ResumeTargetCounts
+        public let targets: [ResumeTargetDecision]
+
+        public init(
+            source: SourceRecord,
+            output: OutputRecord,
+            layout: Layout,
+            latestRunID: String?,
+            startedAt: Date?,
+            updatedAt: Date,
+            counts: ResumeTargetCounts,
+            targets: [ResumeTargetDecision]
+        ) {
+            self.source = source
+            self.output = output
+            self.layout = layout
+            self.latestRunID = latestRunID
+            self.startedAt = startedAt
+            self.updatedAt = updatedAt
+            self.counts = counts
+            self.targets = targets
+        }
+
+        public var targetIDsToRun: [String] {
+            targets.filter(\.shouldRun).map(\.targetID)
+        }
+
+        public var isUnfinished: Bool {
+            counts.unfinished > 0
+        }
+    }
+
+    enum NonInteractiveResumeDecision: Equatable, Sendable {
+        case proceed
+        case resume(ResumeSummary)
+        case resumeRequired(ResumeSummary)
+        case incompatible([ResumeCompatibilityReason])
+    }
+}
+
+public extension PrivateHeaderGeneration {
+    static func evaluateResumeCompatibility(
+        plan: RunPlanRecord,
+        manifest: Manifest,
+        latestRun: RunRecord? = nil,
+        supportedSchemaVersions: Set<Int> = [1]
+    ) -> ResumeCompatibility {
+        let supported = supportedSchemaVersions.sorted()
+        var reasons: [ResumeCompatibilityReason] = []
+
+        if !supportedSchemaVersions.contains(manifest.schemaVersion) {
+            reasons.append(
+                .unsupportedManifestSchema(
+                    actual: manifest.schemaVersion,
+                    supported: supported
+                )
+            )
+        }
+
+        let manifestPlan = RunPlanRecord(
+            source: manifest.source,
+            output: manifest.output,
+            layout: manifest.layout,
+            targetIDs: manifest.targets.map(\.id)
+        )
+        appendCompatibilityMismatches(
+            to: &reasons,
+            expected: plan,
+            actual: manifestPlan,
+            record: .manifest,
+            compareTargetSet: false
+        )
+
+        if let latestRun {
+            if !supportedSchemaVersions.contains(latestRun.schemaVersion) {
+                reasons.append(
+                    .unsupportedRunSchema(
+                        actual: latestRun.schemaVersion,
+                        supported: supported
+                    )
+                )
+            }
+
+            appendCompatibilityMismatches(
+                to: &reasons,
+                expected: plan,
+                actual: latestRun.plan,
+                record: .run,
+                compareTargetSet: true
+            )
+        } else if reasons.isEmpty, let latestRunID = manifest.latestRunID {
+            reasons.append(.missingLatestRun(runID: latestRunID))
+        }
+
+        if reasons.isEmpty {
+            return .compatible
+        }
+        return .incompatible(reasons)
+    }
+
+    static func makeResumeSummary(
+        plan: RunPlanRecord,
+        manifest: Manifest,
+        latestRun: RunRecord? = nil,
+        artifactExists: ArtifactExistence
+    ) -> ResumeSummary {
+        let targets = resumeTargetDecisions(
+            plan: plan,
+            manifest: manifest,
+            artifactExists: artifactExists
+        )
+
+        return ResumeSummary(
+            source: manifest.source,
+            output: manifest.output,
+            layout: manifest.layout,
+            latestRunID: manifest.latestRunID,
+            startedAt: latestRun?.startedAt,
+            updatedAt: manifest.updatedAt,
+            counts: ResumeTargetCounts(targets: targets),
+            targets: targets
+        )
+    }
+
+    static func resumeTargetDecisions(
+        plan: RunPlanRecord,
+        manifest: Manifest,
+        artifactExists: ArtifactExistence
+    ) -> [ResumeTargetDecision] {
+        let targetsByID = manifestTargetsByID(manifest.targets)
+        return deduplicatedTargetIDs(plan.targetIDs).map { targetID in
+            let status: ResumeTargetStatus
+            if let target = targetsByID[targetID] {
+                status = resumeStatus(for: target, artifactExists: artifactExists)
+            } else {
+                status = .pending
+            }
+            return ResumeTargetDecision(targetID: targetID, status: status)
+        }
+    }
+
+    static func targetIDsToRunOnResume(
+        plan: RunPlanRecord,
+        manifest: Manifest,
+        artifactExists: ArtifactExistence
+    ) -> [String] {
+        resumeTargetDecisions(
+            plan: plan,
+            manifest: manifest,
+            artifactExists: artifactExists
+        )
+        .filter(\.shouldRun)
+        .map(\.targetID)
+    }
+
+    static func nonInteractiveResumeDecision(
+        plan: RunPlanRecord,
+        manifest: Manifest,
+        latestRun: RunRecord? = nil,
+        resumeRequested: Bool,
+        artifactExists: ArtifactExistence,
+        supportedSchemaVersions: Set<Int> = [1]
+    ) -> NonInteractiveResumeDecision {
+        let compatibility = evaluateResumeCompatibility(
+            plan: plan,
+            manifest: manifest,
+            latestRun: latestRun,
+            supportedSchemaVersions: supportedSchemaVersions
+        )
+        if case .incompatible(let reasons) = compatibility {
+            return .incompatible(reasons)
+        }
+
+        let summary = makeResumeSummary(
+            plan: plan,
+            manifest: manifest,
+            latestRun: latestRun,
+            artifactExists: artifactExists
+        )
+        if resumeRequested {
+            return .resume(summary)
+        }
+        if summary.isUnfinished {
+            return .resumeRequired(summary)
+        }
+        return .proceed
+    }
+}
+
+private extension PrivateHeaderGeneration {
+    static func appendCompatibilityMismatches(
+        to reasons: inout [ResumeCompatibilityReason],
+        expected: RunPlanRecord,
+        actual: RunPlanRecord,
+        record: ResumeCompatibilityRecord,
+        compareTargetSet: Bool
+    ) {
+        if expected.source != actual.source {
+            reasons.append(
+                .sourceBuildMismatch(
+                    expected: expected.source,
+                    actual: actual.source,
+                    record: record
+                )
+            )
+        }
+
+        if expected.output != actual.output {
+            reasons.append(
+                .outputMismatch(
+                    expected: expected.output,
+                    actual: actual.output,
+                    record: record
+                )
+            )
+        }
+
+        if expected.layout != actual.layout {
+            reasons.append(
+                .layoutMismatch(
+                    expected: expected.layout,
+                    actual: actual.layout,
+                    record: record
+                )
+            )
+        }
+
+        if compareTargetSet {
+            let expectedIDs = normalizedTargetIDs(expected.targetIDs)
+            let actualIDs = normalizedTargetIDs(actual.targetIDs)
+            if expectedIDs != actualIDs {
+                reasons.append(
+                    .selectedTargetSetMismatch(
+                        expected: expectedIDs,
+                        actual: actualIDs,
+                        record: record
+                    )
+                )
+            }
+        }
+    }
+
+    static func resumeStatus(
+        for target: TargetRecord,
+        artifactExists: ArtifactExistence
+    ) -> ResumeTargetStatus {
+        switch target.status {
+        case .completed:
+            return hasCompleteManagedArtifacts(target, artifactExists: artifactExists) ? .completed : .stale
+        case .partial:
+            return .partial
+        case .failed:
+            return .failed
+        case .interrupted:
+            return .interrupted
+        case .commitFailed:
+            return .commitFailed
+        case .stale:
+            return .stale
+        }
+    }
+
+    static func hasCompleteManagedArtifacts(
+        _ target: TargetRecord,
+        artifactExists: ArtifactExistence
+    ) -> Bool {
+        guard !target.artifacts.isEmpty else {
+            return false
+        }
+
+        var hasGeneratedHeaderOrInterface = false
+        for artifact in target.artifacts {
+            guard artifactExists(artifact) else {
+                return false
+            }
+            if isGeneratedHeaderOrInterface(artifact) {
+                hasGeneratedHeaderOrInterface = true
+            }
+        }
+        return hasGeneratedHeaderOrInterface
+    }
+
+    static func isGeneratedHeaderOrInterface(_ artifact: ArtifactPath) -> Bool {
+        artifact.rawValue.hasSuffix(".h") || artifact.rawValue.hasSuffix(".swiftinterface")
+    }
+
+    static func manifestTargetsByID(_ targets: [TargetRecord]) -> [String: TargetRecord] {
+        var targetsByID: [String: TargetRecord] = [:]
+        for target in targets {
+            targetsByID[target.id] = target
+        }
+        return targetsByID
+    }
+
+    static func normalizedTargetIDs(_ targetIDs: [String]) -> [String] {
+        Array(Set(targetIDs)).sorted()
+    }
+
+    static func deduplicatedTargetIDs(_ targetIDs: [String]) -> [String] {
+        var seen: Set<String> = []
+        var deduplicated: [String] = []
+        for targetID in targetIDs where seen.insert(targetID).inserted {
+            deduplicated.append(targetID)
+        }
+        return deduplicated
+    }
+}

--- a/Sources/PrivateHeaderKitCore/PrivateHeaderGenerationSourceDiscovery.swift
+++ b/Sources/PrivateHeaderKitCore/PrivateHeaderGenerationSourceDiscovery.swift
@@ -1,0 +1,238 @@
+import Foundation
+
+public extension PrivateHeaderGeneration {
+    struct SourceCandidate: Hashable, Sendable {
+        public let source: Source
+        public let runtimeName: String
+        public let runtimeIdentifier: String?
+        public let runtimeRoot: String?
+
+        public init(
+            source: Source,
+            runtimeName: String? = nil,
+            runtimeIdentifier: String? = nil,
+            runtimeRoot: String? = nil
+        ) {
+            self.source = source
+            self.runtimeName = runtimeName.trimmedNonEmpty ?? source.label.displayName
+            self.runtimeIdentifier = runtimeIdentifier.trimmedNonEmpty
+            self.runtimeRoot = runtimeRoot.trimmedNonEmpty
+        }
+    }
+
+    enum SourceDiscovery {
+        public static func iOSRuntimeSourceCandidates(
+            fromSimctlListRuntimesJSON json: String
+        ) throws -> [SourceCandidate] {
+            try iOSRuntimeSourceCandidates(fromSimctlListRuntimesJSON: Data(json.utf8))
+        }
+
+        public static func iOSRuntimeSourceCandidates(
+            fromSimctlListRuntimesJSON data: Data
+        ) throws -> [SourceCandidate] {
+            let decoded = try JSONDecoder().decode(SimctlRuntimeList.self, from: data)
+            let candidates = try (decoded.runtimes ?? []).compactMap { entry -> SourceCandidate? in
+                guard entry.isAvailableForUse, entry.isIOSRuntime else {
+                    return nil
+                }
+                guard let version = entry.version.trimmedNonEmpty,
+                      let build = entry.buildversion.trimmedNonEmpty else {
+                    return nil
+                }
+
+                return SourceCandidate(
+                    source: try Source(platform: .iOS, version: version, build: build),
+                    runtimeName: entry.name,
+                    runtimeIdentifier: entry.identifier,
+                    runtimeRoot: entry.runtimeRoot
+                )
+            }
+
+            return deduplicatedBySource(sortedIOSRuntimeSourceCandidates(candidates))
+        }
+
+        public static func sortedIOSRuntimeSourceCandidates(
+            _ candidates: [SourceCandidate]
+        ) -> [SourceCandidate] {
+            candidates.sorted(by: SourceCandidateOrdering.isOrderedBefore)
+        }
+
+        public static func latestIOSRuntimeSourceCandidate(
+            from candidates: [SourceCandidate]
+        ) -> SourceCandidate? {
+            sortedIOSRuntimeSourceCandidates(candidates).last
+        }
+
+        private static func deduplicatedBySource(
+            _ candidates: [SourceCandidate]
+        ) -> [SourceCandidate] {
+            var seenSources: Set<Source> = []
+            var uniqueCandidates: [SourceCandidate] = []
+            for candidate in candidates where seenSources.insert(candidate.source).inserted {
+                uniqueCandidates.append(candidate)
+            }
+            return uniqueCandidates
+        }
+    }
+}
+
+private struct SimctlRuntimeList: Decodable {
+    struct RuntimeEntry: Decodable {
+        let name: String?
+        let platform: String?
+        let version: String?
+        let buildversion: String?
+        let identifier: String?
+        let runtimeRoot: String?
+        let isAvailable: Bool?
+        let availability: String?
+
+        var isAvailableForUse: Bool {
+            if let isAvailable {
+                return isAvailable
+            }
+
+            guard let availability = availability.trimmedNonEmpty?.lowercased() else {
+                return false
+            }
+            return availability == "available" || availability == "(available)"
+        }
+
+        var isIOSRuntime: Bool {
+            if let platform = platform.trimmedNonEmpty {
+                return platform.caseInsensitiveCompare("iOS") == .orderedSame
+            }
+            if let name = name.trimmedNonEmpty {
+                let lowercasedName = name.lowercased()
+                return lowercasedName == "ios" || lowercasedName.hasPrefix("ios ")
+            }
+            if let identifier = identifier.trimmedNonEmpty {
+                return identifier.contains(".SimRuntime.iOS-")
+                    || identifier.hasSuffix(".SimRuntime.iOS")
+            }
+            return false
+        }
+    }
+
+    let runtimes: [RuntimeEntry]?
+}
+
+private enum SourceCandidateOrdering {
+    static func isOrderedBefore(
+        _ lhs: PrivateHeaderGeneration.SourceCandidate,
+        _ rhs: PrivateHeaderGeneration.SourceCandidate
+    ) -> Bool {
+        compare(lhs, rhs) == .orderedAscending
+    }
+
+    private static func compare(
+        _ lhs: PrivateHeaderGeneration.SourceCandidate,
+        _ rhs: PrivateHeaderGeneration.SourceCandidate
+    ) -> ComparisonResult {
+        compareSortTokens(lhs.source.version, rhs.source.version)
+            .orElse(compareSortTokens(lhs.source.build ?? "", rhs.source.build ?? ""))
+            .orElse(compareSortTokens(lhs.runtimeName, rhs.runtimeName))
+            .orElse(compareOptionalSortStrings(lhs.runtimeIdentifier, rhs.runtimeIdentifier))
+            .orElse(compareOptionalSortStrings(lhs.runtimeRoot, rhs.runtimeRoot))
+    }
+
+    private static func compareOptionalSortStrings(_ lhs: String?, _ rhs: String?) -> ComparisonResult {
+        switch (lhs, rhs) {
+        case (nil, nil):
+            return .orderedSame
+        case (.some, nil):
+            return .orderedAscending
+        case (nil, .some):
+            return .orderedDescending
+        case let (.some(lhs), .some(rhs)):
+            return compareSortTokens(lhs, rhs)
+        }
+    }
+
+    private static func compareSortTokens(_ lhs: String, _ rhs: String) -> ComparisonResult {
+        let lhsTokens = NaturalSortToken.tokenize(lhs)
+        let rhsTokens = NaturalSortToken.tokenize(rhs)
+        let count = min(lhsTokens.count, rhsTokens.count)
+
+        for index in 0..<count {
+            if lhsTokens[index] < rhsTokens[index] {
+                return .orderedAscending
+            }
+            if rhsTokens[index] < lhsTokens[index] {
+                return .orderedDescending
+            }
+        }
+
+        if lhsTokens.count == rhsTokens.count {
+            return .orderedSame
+        }
+        return lhsTokens.count < rhsTokens.count ? .orderedAscending : .orderedDescending
+    }
+}
+
+private enum NaturalSortToken: Comparable {
+    case number(Int)
+    case text(String)
+
+    static func tokenize(_ value: String) -> [NaturalSortToken] {
+        var tokens: [NaturalSortToken] = []
+        var current = ""
+        var currentIsNumber: Bool?
+
+        for scalar in value.unicodeScalars {
+            let isNumber = CharacterSet.decimalDigits.contains(scalar)
+            if currentIsNumber == nil || currentIsNumber == isNumber {
+                current.unicodeScalars.append(scalar)
+                currentIsNumber = isNumber
+            } else {
+                tokens.append(token(from: current, isNumber: currentIsNumber == true))
+                current = String(scalar)
+                currentIsNumber = isNumber
+            }
+        }
+
+        if let currentIsNumber {
+            tokens.append(token(from: current, isNumber: currentIsNumber))
+        }
+
+        return tokens
+    }
+
+    static func < (lhs: NaturalSortToken, rhs: NaturalSortToken) -> Bool {
+        switch (lhs, rhs) {
+        case let (.number(lhs), .number(rhs)):
+            return lhs < rhs
+        case let (.text(lhs), .text(rhs)):
+            return lhs.lowercased() < rhs.lowercased()
+        case (.number, .text):
+            return true
+        case (.text, .number):
+            return false
+        }
+    }
+
+    private static func token(from value: String, isNumber: Bool) -> NaturalSortToken {
+        if isNumber, let number = Int(value) {
+            return .number(number)
+        }
+        return .text(value)
+    }
+}
+
+private extension ComparisonResult {
+    func orElse(_ fallback: @autoclosure () -> ComparisonResult) -> ComparisonResult {
+        self == .orderedSame ? fallback() : self
+    }
+}
+
+private extension Optional where Wrapped == String {
+    var trimmedNonEmpty: String? {
+        switch self {
+        case .none:
+            return nil
+        case .some(let value):
+            let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+            return trimmed.isEmpty ? nil : trimmed
+        }
+    }
+}

--- a/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationArtifactStoreTests.swift
+++ b/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationArtifactStoreTests.swift
@@ -1,0 +1,179 @@
+import Foundation
+import Testing
+
+import PrivateHeaderKitCore
+
+@Suite
+struct PrivateHeaderGenerationArtifactStoreTests {
+    @Test func cleanupPreservesUnknownFilesInManagedParentDirectories() throws {
+        let root = try makeTemporaryDirectory()
+        defer {
+            try? FileManager.default.removeItem(at: root)
+        }
+        let managed = try PrivateHeaderGeneration.ArtifactPath("Frameworks/Foo/Foo.h")
+
+        try writeFile("Frameworks/Foo/Foo.h", in: root)
+        try writeFile("Frameworks/Foo/Notes.txt", in: root)
+
+        let result = try PrivateHeaderGeneration.ArtifactStore.cleanupManagedArtifacts(
+            in: root,
+            artifacts: [managed]
+        )
+
+        #expect(result.deletedArtifacts == [managed])
+        #expect(result.missingArtifacts.isEmpty)
+        #expect(!pathExists("Frameworks/Foo/Foo.h", in: root))
+        #expect(pathExists("Frameworks/Foo/Notes.txt", in: root))
+        #expect(directoryExists("Frameworks/Foo", in: root))
+    }
+
+    @Test func cleanupPrunesEmptyParentDirectoriesUpToArtifactRoot() throws {
+        let root = try makeTemporaryDirectory()
+        defer {
+            try? FileManager.default.removeItem(at: root)
+        }
+        let managed = try PrivateHeaderGeneration.ArtifactPath("Frameworks/Foo/Foo.h")
+
+        try writeFile("Frameworks/Foo/Foo.h", in: root)
+
+        let result = try PrivateHeaderGeneration.ArtifactStore.cleanupManagedArtifacts(
+            in: root,
+            artifacts: [managed]
+        )
+
+        #expect(result.prunedDirectories.map(\.rawValue) == ["Frameworks", "Frameworks/Foo"])
+        #expect(!pathExists("Frameworks/Foo/Foo.h", in: root))
+        #expect(!pathExists("Frameworks/Foo", in: root))
+        #expect(!pathExists("Frameworks", in: root))
+        #expect(directoryExists(root))
+    }
+
+    @Test func cleanupPreservesArtifactRootItself() throws {
+        let root = try makeTemporaryDirectory()
+        defer {
+            try? FileManager.default.removeItem(at: root)
+        }
+
+        try writeFile("Root.h", in: root)
+
+        try PrivateHeaderGeneration.ArtifactStore.cleanupManagedArtifacts(
+            in: root,
+            artifacts: [try PrivateHeaderGeneration.ArtifactPath("Root.h")]
+        )
+
+        #expect(directoryExists(root))
+        #expect(try FileManager.default.contentsOfDirectory(atPath: root.path).isEmpty)
+    }
+
+    @Test func cleanupTreatsMissingManagedPathsAsSuccess() throws {
+        let root = try makeTemporaryDirectory()
+        defer {
+            try? FileManager.default.removeItem(at: root)
+        }
+        let missing = try PrivateHeaderGeneration.ArtifactPath("Frameworks/Missing/Missing.h")
+
+        let result = try PrivateHeaderGeneration.ArtifactStore.cleanupManagedArtifacts(
+            in: root,
+            artifacts: [missing]
+        )
+
+        #expect(result.deletedArtifacts.isEmpty)
+        #expect(result.missingArtifacts == [missing])
+        #expect(result.prunedDirectories.isEmpty)
+        #expect(directoryExists(root))
+    }
+
+    @Test func cleanupCandidatesDedupeManifestAndAttemptedArtifactsDeterministically() throws {
+        let alpha = try PrivateHeaderGeneration.ArtifactPath("Frameworks/Alpha/Alpha.h")
+        let beta = try PrivateHeaderGeneration.ArtifactPath("Frameworks/Beta/Beta.h")
+        let gamma = try PrivateHeaderGeneration.ArtifactPath("Frameworks/Gamma/Gamma.h")
+
+        let candidates = PrivateHeaderGeneration.ArtifactStore.cleanupCandidates(
+            manifestArtifacts: [beta, alpha, beta],
+            attemptedArtifacts: [gamma, alpha]
+        )
+
+        #expect(candidates.map(\.rawValue) == [
+            "Frameworks/Alpha/Alpha.h",
+            "Frameworks/Beta/Beta.h",
+            "Frameworks/Gamma/Gamma.h",
+        ])
+    }
+
+    @Test func cleanupCanRemoveManagedDirectories() throws {
+        let root = try makeTemporaryDirectory()
+        defer {
+            try? FileManager.default.removeItem(at: root)
+        }
+        let managedDirectory = try PrivateHeaderGeneration.ArtifactPath("SystemLibrary/Foo.bundle")
+
+        try writeFile("SystemLibrary/Foo.bundle/Headers/Foo.h", in: root)
+        try writeFile("SystemLibrary/Foo.bundle/Modules/Foo.swiftinterface", in: root)
+
+        let result = try PrivateHeaderGeneration.ArtifactStore.cleanupManagedArtifacts(
+            in: root,
+            artifacts: [managedDirectory]
+        )
+
+        #expect(result.deletedArtifacts == [managedDirectory])
+        #expect(!pathExists("SystemLibrary/Foo.bundle", in: root))
+        #expect(!pathExists("SystemLibrary", in: root))
+        #expect(directoryExists(root))
+    }
+
+    @Test func cleanupRejectsResolvedPathsOutsideArtifactRoot() throws {
+        let base = try makeTemporaryDirectory()
+        defer {
+            try? FileManager.default.removeItem(at: base)
+        }
+        let root = base.appendingPathComponent("artifacts", isDirectory: true)
+        let outside = base.appendingPathComponent("outside", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: outside, withIntermediateDirectories: true)
+        try writeFile("Outside.h", in: outside)
+        try FileManager.default.createSymbolicLink(
+            at: root.appendingPathComponent("link"),
+            withDestinationURL: outside
+        )
+
+        #expect(throws: PrivateHeaderGeneration.ArtifactStoreError.self) {
+            try PrivateHeaderGeneration.ArtifactStore.cleanupManagedArtifacts(
+                in: root,
+                artifacts: [try PrivateHeaderGeneration.ArtifactPath("link/Outside.h")]
+            )
+        }
+        #expect(pathExists("Outside.h", in: outside))
+    }
+}
+
+private func makeTemporaryDirectory() throws -> URL {
+    let directory = FileManager.default.temporaryDirectory
+        .appendingPathComponent("PrivateHeaderGenerationArtifactStoreTests-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    return directory
+}
+
+private func writeFile(_ relativePath: String, in root: URL) throws {
+    let url = root.appendingPathComponent(relativePath)
+    try FileManager.default.createDirectory(
+        at: url.deletingLastPathComponent(),
+        withIntermediateDirectories: true
+    )
+    try Data("contents".utf8).write(to: url)
+}
+
+private func pathExists(_ relativePath: String, in root: URL) -> Bool {
+    FileManager.default.fileExists(
+        atPath: root.appendingPathComponent(relativePath).path
+    )
+}
+
+private func directoryExists(_ relativePath: String, in root: URL) -> Bool {
+    directoryExists(root.appendingPathComponent(relativePath, isDirectory: true))
+}
+
+private func directoryExists(_ url: URL) -> Bool {
+    var isDirectory = ObjCBool(false)
+    return FileManager.default.fileExists(atPath: url.path, isDirectory: &isDirectory)
+        && isDirectory.boolValue
+}

--- a/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationResumeTests.swift
+++ b/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationResumeTests.swift
@@ -1,0 +1,458 @@
+import Foundation
+import Testing
+
+import PrivateHeaderKitCore
+
+@Suite
+struct PrivateHeaderGenerationResumeTests {
+    @Test func completedTargetsWithExistingManagedArtifactsAreSkipped() throws {
+        let plan = try makeRunPlan(targetIDs: ["framework:Foo", "framework:Bar"])
+        let manifest = try makeManifest(
+            targets: [
+                makeTarget("framework:Foo", status: .completed),
+                makeTarget("framework:Bar", status: .completed),
+            ]
+        )
+
+        let summary = PrivateHeaderGeneration.makeResumeSummary(
+            plan: plan,
+            manifest: manifest,
+            artifactExists: existingArtifacts([
+                "Frameworks/Foo/Foo.h",
+                "Frameworks/Bar/Bar.h",
+            ])
+        )
+
+        #expect(summary.targetIDsToRun == [])
+        #expect(
+            summary.counts == PrivateHeaderGeneration.ResumeTargetCounts(
+                total: 2,
+                completed: 2,
+                partial: 0,
+                failed: 0,
+                interrupted: 0,
+                commitFailed: 0,
+                stale: 0,
+                pending: 0
+            )
+        )
+    }
+
+    @Test func failedPartialInterruptedCommitFailedAndStaleTargetsRerun() throws {
+        let targetIDs = [
+            "framework:Failed",
+            "framework:Partial",
+            "framework:Interrupted",
+            "framework:CommitFailed",
+            "framework:Stale",
+        ]
+        let plan = try makeRunPlan(targetIDs: targetIDs)
+        let manifest = try makeManifest(
+            targets: [
+                makeTarget("framework:Failed", status: .failed),
+                makeTarget("framework:Partial", status: .partial),
+                makeTarget("framework:Interrupted", status: .interrupted),
+                makeTarget("framework:CommitFailed", status: .commitFailed),
+                makeTarget("framework:Stale", status: .stale),
+            ]
+        )
+
+        let summary = PrivateHeaderGeneration.makeResumeSummary(
+            plan: plan,
+            manifest: manifest,
+            artifactExists: existingArtifacts([])
+        )
+
+        #expect(summary.targetIDsToRun == targetIDs)
+        #expect(summary.counts.failed == 1)
+        #expect(summary.counts.partial == 1)
+        #expect(summary.counts.interrupted == 1)
+        #expect(summary.counts.commitFailed == 1)
+        #expect(summary.counts.stale == 1)
+        #expect(summary.counts.unfinished == 5)
+    }
+
+    @Test func missingManagedArtifactMakesCompletedTargetStale() throws {
+        let plan = try makeRunPlan(targetIDs: ["framework:Foo"])
+        let manifest = try makeManifest(
+            targets: [
+                makeTarget(
+                    "framework:Foo",
+                    status: .completed,
+                    artifacts: [
+                        "Frameworks/Foo/Foo.h",
+                        "Frameworks/Foo/Foo.swiftinterface",
+                    ]
+                ),
+            ]
+        )
+
+        let summary = PrivateHeaderGeneration.makeResumeSummary(
+            plan: plan,
+            manifest: manifest,
+            artifactExists: existingArtifacts([
+                "Frameworks/Foo/Foo.h",
+            ])
+        )
+
+        #expect(summary.targets == [
+            PrivateHeaderGeneration.ResumeTargetDecision(
+                targetID: "framework:Foo",
+                status: .stale
+            ),
+        ])
+        #expect(summary.targetIDsToRun == ["framework:Foo"])
+        #expect(summary.counts.completed == 0)
+        #expect(summary.counts.stale == 1)
+    }
+
+    @Test func missingManifestEntryIsPendingAndReruns() throws {
+        let plan = try makeRunPlan(targetIDs: ["framework:Foo", "framework:New"])
+        let manifest = try makeManifest(
+            targets: [
+                makeTarget("framework:Foo", status: .completed),
+            ]
+        )
+
+        let summary = PrivateHeaderGeneration.makeResumeSummary(
+            plan: plan,
+            manifest: manifest,
+            artifactExists: existingArtifacts([
+                "Frameworks/Foo/Foo.h",
+            ])
+        )
+
+        #expect(summary.targetIDsToRun == ["framework:New"])
+        #expect(summary.counts.completed == 1)
+        #expect(summary.counts.pending == 1)
+    }
+
+    @Test func selectedTargetSetMismatchReturnsStructuredReason() throws {
+        let plan = try makeRunPlan(targetIDs: ["framework:Foo", "framework:Bar"])
+        let manifest = try makeManifest(
+            targets: [
+                makeTarget("framework:Foo", status: .partial),
+            ]
+        )
+        let latestRun = try makeRunRecord(
+            plan: makeRunPlan(targetIDs: ["framework:Foo"])
+        )
+
+        #expect(
+            PrivateHeaderGeneration.evaluateResumeCompatibility(
+                plan: plan,
+                manifest: manifest,
+                latestRun: latestRun
+            ) == .incompatible(
+                [
+                    .selectedTargetSetMismatch(
+                        expected: ["framework:Bar", "framework:Foo"],
+                        actual: ["framework:Foo"],
+                        record: .run
+                    ),
+                ]
+            )
+        )
+    }
+
+    @Test func selectedTargetSetIsNotInferredFromManifestWithoutLatestRun() throws {
+        let plan = try makeRunPlan(targetIDs: ["framework:Foo", "framework:Bar"])
+        let manifest = try makeManifest(
+            targets: [
+                makeTarget("framework:Foo", status: .partial),
+            ]
+        )
+
+        #expect(
+            PrivateHeaderGeneration.evaluateResumeCompatibility(
+                plan: plan,
+                manifest: manifest
+            ) == .incompatible(
+                [
+                    .missingLatestRun(runID: "run-001"),
+                ]
+            )
+        )
+    }
+
+    @Test func sourceBuildMismatchReturnsStructuredReason() throws {
+        let plan = try makeRunPlan(targetIDs: ["framework:Foo"])
+        let expectedSource = try makeSource()
+        let actualSource = try makeSource(build: "24B1")
+        let manifest = try makeManifest(
+            source: actualSource,
+            targets: [
+                makeTarget("framework:Foo", status: .completed),
+            ]
+        )
+
+        #expect(
+            PrivateHeaderGeneration.evaluateResumeCompatibility(
+                plan: plan,
+                manifest: manifest
+            ) == .incompatible(
+                [
+                    .sourceBuildMismatch(
+                        expected: expectedSource,
+                        actual: actualSource,
+                        record: .manifest
+                    ),
+                ]
+            )
+        )
+    }
+
+    @Test func layoutMismatchReturnsStructuredReason() throws {
+        let plan = try makeRunPlan(targetIDs: ["framework:Foo"])
+        let manifest = try makeManifest(
+            layout: .bundle,
+            targets: [
+                makeTarget("framework:Foo", status: .completed),
+            ]
+        )
+
+        #expect(
+            PrivateHeaderGeneration.evaluateResumeCompatibility(
+                plan: plan,
+                manifest: manifest
+            ) == .incompatible(
+                [
+                    .layoutMismatch(
+                        expected: .headers,
+                        actual: .bundle,
+                        record: .manifest
+                    ),
+                ]
+            )
+        )
+    }
+
+    @Test func outputMismatchReturnsStructuredReason() throws {
+        let plan = try makeRunPlan(targetIDs: ["framework:Foo"])
+        let mismatchedOutput = makeOutput(baseDirectory: "/Volumes/Data/Headers")
+        let manifest = try makeManifest(
+            output: mismatchedOutput,
+            targets: [
+                makeTarget("framework:Foo", status: .completed),
+            ]
+        )
+
+        #expect(
+            PrivateHeaderGeneration.evaluateResumeCompatibility(
+                plan: plan,
+                manifest: manifest
+            ) == .incompatible(
+                [
+                    .outputMismatch(
+                        expected: makeOutput(),
+                        actual: mismatchedOutput,
+                        record: .manifest
+                    ),
+                ]
+            )
+        )
+    }
+
+    @Test func unsupportedManifestSchemaReturnsStructuredReason() throws {
+        let plan = try makeRunPlan(targetIDs: ["framework:Foo"])
+        let manifest = try makeManifest(
+            schemaVersion: 99,
+            targets: [
+                makeTarget("framework:Foo", status: .completed),
+            ]
+        )
+
+        #expect(
+            PrivateHeaderGeneration.evaluateResumeCompatibility(
+                plan: plan,
+                manifest: manifest,
+                supportedSchemaVersions: [1]
+            ) == .incompatible(
+                [
+                    .unsupportedManifestSchema(actual: 99, supported: [1]),
+                ]
+            )
+        )
+    }
+
+    @Test func unsupportedRunSchemaReturnsStructuredReason() throws {
+        let plan = try makeRunPlan(targetIDs: ["framework:Foo"])
+        let manifest = try makeManifest(
+            targets: [
+                makeTarget("framework:Foo", status: .completed),
+            ]
+        )
+        let latestRun = try makeRunRecord(plan: plan, schemaVersion: 99)
+
+        #expect(
+            PrivateHeaderGeneration.evaluateResumeCompatibility(
+                plan: plan,
+                manifest: manifest,
+                latestRun: latestRun,
+                supportedSchemaVersions: [1]
+            ) == .incompatible(
+                [
+                    .unsupportedRunSchema(actual: 99, supported: [1]),
+                ]
+            )
+        )
+    }
+
+    @Test func nonInteractiveUnfinishedCompatibleRunRequiresExplicitResume() throws {
+        let plan = try makeRunPlan(targetIDs: ["framework:Foo"])
+        let manifest = try makeManifest(
+            targets: [
+                makeTarget("framework:Foo", status: .partial),
+            ]
+        )
+        let latestRun = try makeRunRecord(plan: plan)
+        let summary = PrivateHeaderGeneration.makeResumeSummary(
+            plan: plan,
+            manifest: manifest,
+            latestRun: latestRun,
+            artifactExists: existingArtifacts([])
+        )
+
+        #expect(
+            PrivateHeaderGeneration.nonInteractiveResumeDecision(
+                plan: plan,
+                manifest: manifest,
+                latestRun: latestRun,
+                resumeRequested: false,
+                artifactExists: existingArtifacts([])
+            ) == .resumeRequired(summary)
+        )
+    }
+
+    @Test func nonInteractiveExplicitResumeAllowsCompatibleUnfinishedRun() throws {
+        let plan = try makeRunPlan(targetIDs: ["framework:Foo"])
+        let manifest = try makeManifest(
+            targets: [
+                makeTarget("framework:Foo", status: .partial),
+            ]
+        )
+        let latestRun = try makeRunRecord(plan: plan)
+        let summary = PrivateHeaderGeneration.makeResumeSummary(
+            plan: plan,
+            manifest: manifest,
+            latestRun: latestRun,
+            artifactExists: existingArtifacts([])
+        )
+
+        #expect(
+            PrivateHeaderGeneration.nonInteractiveResumeDecision(
+                plan: plan,
+                manifest: manifest,
+                latestRun: latestRun,
+                resumeRequested: true,
+                artifactExists: existingArtifacts([])
+            ) == .resume(summary)
+        )
+    }
+}
+
+private func makeSource(
+    build: String = "24A5355q"
+) throws -> PrivateHeaderGeneration.SourceRecord {
+    let source = try PrivateHeaderGeneration.Source(
+        platform: .iOS,
+        version: "27.0",
+        build: build
+    )
+    return PrivateHeaderGeneration.SourceRecord(source: source)
+}
+
+private func makeOutput(
+    baseDirectory: String = "/tmp/PrivateHeaderKit"
+) -> PrivateHeaderGeneration.OutputRecord {
+    PrivateHeaderGeneration.OutputRecord(
+        baseDirectory: baseDirectory,
+        artifactDirectory: "\(baseDirectory)/iOS27.0(24A5355q)",
+        stateDirectory: "\(baseDirectory)/.state/iOS27.0(24A5355q)"
+    )
+}
+
+private func makeRunPlan(
+    targetIDs: [String],
+    source: PrivateHeaderGeneration.SourceRecord? = nil,
+    output: PrivateHeaderGeneration.OutputRecord? = nil,
+    layout: PrivateHeaderGeneration.Layout = .headers
+) throws -> PrivateHeaderGeneration.RunPlanRecord {
+    try PrivateHeaderGeneration.RunPlanRecord(
+        source: source ?? makeSource(),
+        output: output ?? makeOutput(),
+        layout: layout,
+        targetIDs: targetIDs
+    )
+}
+
+private func makeManifest(
+    schemaVersion: Int = 1,
+    source: PrivateHeaderGeneration.SourceRecord? = nil,
+    output: PrivateHeaderGeneration.OutputRecord? = nil,
+    layout: PrivateHeaderGeneration.Layout = .headers,
+    targets: [PrivateHeaderGeneration.TargetRecord]
+) throws -> PrivateHeaderGeneration.Manifest {
+    PrivateHeaderGeneration.Manifest(
+        schemaVersion: schemaVersion,
+        toolVersion: "0.1.0",
+        source: try source ?? makeSource(),
+        output: output ?? makeOutput(),
+        layout: layout,
+        latestRunID: "run-001",
+        targets: targets,
+        updatedAt: Date(timeIntervalSince1970: 1_100)
+    )
+}
+
+private func makeRunRecord(
+    plan: PrivateHeaderGeneration.RunPlanRecord,
+    schemaVersion: Int = 1
+) throws -> PrivateHeaderGeneration.RunRecord {
+    PrivateHeaderGeneration.RunRecord(
+        runID: "run-001",
+        schemaVersion: schemaVersion,
+        toolVersion: "0.1.0",
+        plan: plan,
+        startedAt: Date(timeIntervalSince1970: 1_000),
+        endedAt: nil,
+        status: .running,
+        targetResults: [],
+        attemptedArtifacts: [],
+        logs: []
+    )
+}
+
+private func makeTarget(
+    _ id: String,
+    status: PrivateHeaderGeneration.TargetStatus,
+    artifacts: [String]? = nil
+) throws -> PrivateHeaderGeneration.TargetRecord {
+    let displayName = String(id.split(separator: ":").last ?? Substring(id))
+    let artifactPaths = try (artifacts ?? ["Frameworks/\(displayName)/\(displayName).h"]).map {
+        try PrivateHeaderGeneration.ArtifactPath($0)
+    }
+    return PrivateHeaderGeneration.TargetRecord(
+        id: id,
+        displayName: "\(displayName).framework",
+        kind: "framework",
+        status: status,
+        phases: [],
+        artifacts: artifactPaths,
+        lastRunID: "run-001",
+        updatedAt: Date(timeIntervalSince1970: 1_100),
+        failureSummary: status == .completed ? nil : "\(status.rawValue) target"
+    )
+}
+
+private func existingArtifacts(
+    _ paths: Set<String>
+) -> PrivateHeaderGeneration.ArtifactExistence {
+    { paths.contains($0.rawValue) }
+}
+
+private func existingArtifacts(
+    _ paths: [String]
+) -> PrivateHeaderGeneration.ArtifactExistence {
+    existingArtifacts(Set(paths))
+}

--- a/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationSourceDiscoveryTests.swift
+++ b/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationSourceDiscoveryTests.swift
@@ -1,0 +1,132 @@
+import Testing
+
+import PrivateHeaderKitCore
+
+@Suite
+struct PrivateHeaderGenerationSourceDiscoveryTests {
+    @Test func parsesAvailableIOSRuntimeSourcesAndUsesSourceLabels() throws {
+        let candidates = try PrivateHeaderGeneration.SourceDiscovery.iOSRuntimeSourceCandidates(
+            fromSimctlListRuntimesJSON: """
+            {
+              "runtimes": [
+                {"name": "watchOS 27.0", "platform": "watchOS", "version": "27.0", "buildversion": "24A1", "isAvailable": true},
+                {"name": "iOS 26.0", "platform": "iOS", "version": "26.0", "buildversion": "23A1", "isAvailable": false},
+                {"name": "iOS Missing Build", "platform": "iOS", "version": "26.1", "isAvailable": true},
+                {"name": "iOS Missing Version", "platform": "iOS", "buildversion": "23B1", "isAvailable": true},
+                {
+                  "name": "iOS 27.0",
+                  "platform": "iOS",
+                  "version": "27.0",
+                  "buildversion": "24A5355q",
+                  "identifier": "com.apple.CoreSimulator.SimRuntime.iOS-27-0",
+                  "runtimeRoot": "/runtimes/iOS-27.0",
+                  "isAvailable": true
+                }
+              ]
+            }
+            """
+        )
+
+        let candidate = try #require(candidates.only)
+        #expect(candidate.source.platform == .iOS)
+        #expect(candidate.source.version == "27.0")
+        #expect(candidate.source.build == "24A5355q")
+        #expect(candidate.source.label.displayName == "iOS 27.0 (24A5355q)")
+        #expect(candidate.source.label.directoryName == "iOS27.0(24A5355q)")
+        #expect(candidate.runtimeName == "iOS 27.0")
+        #expect(candidate.runtimeIdentifier == "com.apple.CoreSimulator.SimRuntime.iOS-27-0")
+        #expect(candidate.runtimeRoot == "/runtimes/iOS-27.0")
+    }
+
+    @Test func candidatesUseExplicitVersionBuildAndNameOrderForLatestSelection() throws {
+        let candidates = try PrivateHeaderGeneration.SourceDiscovery.iOSRuntimeSourceCandidates(
+            fromSimctlListRuntimesJSON: """
+            {
+              "runtimes": [
+                {"name": "iOS 26.10 B", "platform": "iOS", "version": "26.10", "buildversion": "23Z10", "identifier": "ios-26-10-b", "isAvailable": true},
+                {"name": "iOS 27.0", "platform": "iOS", "version": "27.0", "buildversion": "24A5355q", "identifier": "ios-27-0", "isAvailable": true},
+                {"name": "iOS 26.2", "platform": "iOS", "version": "26.2", "buildversion": "23C54", "identifier": "ios-26-2", "isAvailable": true},
+                {"name": "iOS 26.10", "platform": "iOS", "version": "26.10", "buildversion": "23Z9", "identifier": "ios-26-10-z9", "isAvailable": true},
+                {"name": "iOS 26.10 A", "platform": "iOS", "version": "26.10", "buildversion": "23Z10", "identifier": "ios-26-10-a", "isAvailable": true}
+              ]
+            }
+            """
+        )
+
+        #expect(candidates.map(\.source.label.displayName) == [
+            "iOS 26.2 (23C54)",
+            "iOS 26.10 (23Z9)",
+            "iOS 26.10 (23Z10)",
+            "iOS 27.0 (24A5355q)",
+        ])
+        #expect(candidates.map(\.runtimeName) == [
+            "iOS 26.2",
+            "iOS 26.10",
+            "iOS 26.10 A",
+            "iOS 27.0",
+        ])
+
+        let latest = try #require(
+            PrivateHeaderGeneration.SourceDiscovery.latestIOSRuntimeSourceCandidate(from: candidates)
+        )
+        #expect(latest.source.label.displayName == "iOS 27.0 (24A5355q)")
+    }
+
+    @Test func duplicateRuntimeSourcesAreCanonicalizedWithoutDependingOnJSONOrder() throws {
+        let firstOrder = """
+        {
+          "runtimes": [
+            {"name": "iOS 26.2 B", "platform": "iOS", "version": "26.2", "buildversion": "23C54", "identifier": "ios-26-2-b", "isAvailable": true},
+            {"name": "iOS 26.2 A", "platform": "iOS", "version": "26.2", "buildversion": "23C54", "identifier": "ios-26-2-a", "isAvailable": true}
+          ]
+        }
+        """
+        let secondOrder = """
+        {
+          "runtimes": [
+            {"name": "iOS 26.2 A", "platform": "iOS", "version": "26.2", "buildversion": "23C54", "identifier": "ios-26-2-a", "isAvailable": true},
+            {"name": "iOS 26.2 B", "platform": "iOS", "version": "26.2", "buildversion": "23C54", "identifier": "ios-26-2-b", "isAvailable": true}
+          ]
+        }
+        """
+
+        let first = try PrivateHeaderGeneration.SourceDiscovery.iOSRuntimeSourceCandidates(
+            fromSimctlListRuntimesJSON: firstOrder
+        )
+        let second = try PrivateHeaderGeneration.SourceDiscovery.iOSRuntimeSourceCandidates(
+            fromSimctlListRuntimesJSON: secondOrder
+        )
+
+        #expect(first == second)
+        #expect(first.map(\.source.label.displayName) == ["iOS 26.2 (23C54)"])
+        #expect(first.map(\.runtimeIdentifier) == ["ios-26-2-a"])
+    }
+
+    @Test func recognizesIOSRuntimeFromNameOrIdentifierWhenPlatformIsMissing() throws {
+        let candidates = try PrivateHeaderGeneration.SourceDiscovery.iOSRuntimeSourceCandidates(
+            fromSimctlListRuntimesJSON: """
+            {
+              "runtimes": [
+                {"name": "iOS 26.2", "version": "26.2", "buildversion": "23C54", "isAvailable": true},
+                {"identifier": "com.apple.CoreSimulator.SimRuntime.iOS-27-0", "version": "27.0", "buildversion": "24A5355q", "isAvailable": true}
+              ]
+            }
+            """
+        )
+
+        #expect(candidates.map(\.source.label.displayName) == [
+            "iOS 26.2 (23C54)",
+            "iOS 27.0 (24A5355q)",
+        ])
+        #expect(candidates.map(\.runtimeName) == [
+            "iOS 26.2",
+            "iOS 27.0 (24A5355q)",
+        ])
+    }
+}
+
+private extension Collection {
+    var only: Element? {
+        count == 1 ? first : nil
+    }
+}


### PR DESCRIPTION
Purpose
- Add the next Core contracts on top of the rewrite foundation branch for source discovery, resume decisions, and managed artifact cleanup.

Changes
- Parse available iOS simulator runtimes from `simctl list runtimes -j` into `PrivateHeaderGeneration.SourceCandidate` values using version/build source labels.
- Add resume compatibility and non-interactive resume decision contracts, including schema/source/output/layout/target-set checks.
- Add managed artifact cleanup that deletes only manifest-managed paths, preserves unknown files, prunes empty parents, and rejects root escapes.
- Add focused Swift Testing coverage for source discovery, resume planning, and artifact cleanup.

Testing
- `swift test --filter PrivateHeaderGenerationResumeTests`
- `swift test --filter PrivateHeaderGeneration`
- `swift test`
- `git diff --check`
- `codex-review` for uncommitted changes: no findings

Notes
- A second codex-review run against base `codex/rewrite-foundation-stack` was cancelled from the Review Monitor after commit; no findings were returned before cancellation.