### PR TITLE
Add simulator generation support

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "9199b78a08916c736ab18adf746345ceaba2e57e8172162f2aea606c090e4d94",
+  "originHash" : "5eca01dd1fab92aab183a92e49758b9678053fc856d369ebabf5164c4a5dda81",
   "pins" : [
     {
       "identity" : "associatedobject",

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "5eca01dd1fab92aab183a92e49758b9678053fc856d369ebabf5164c4a5dda81",
+  "originHash" : "e1890902106b78b1a23dd873a38dd5d33c6d1465e29bce4f7b9fb5b3ad4a2b83",
   "pins" : [
     {
       "identity" : "associatedobject",
@@ -8,15 +8,6 @@
       "state" : {
         "revision" : "9454715a21dfb346bf5d467da4e19b70a7f4ba87",
         "version" : "0.14.0"
-      }
-    },
-    {
-      "identity" : "binarycodable",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/christophhagen/BinaryCodable",
-      "state" : {
-        "revision" : "c2ef4834bf038a998c36301d910a8525de5e12b1",
-        "version" : "3.2.0"
       }
     },
     {
@@ -51,8 +42,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/lynnswap/MachOKit.git",
       "state" : {
-        "revision" : "25e56cbb2865ef4d00ea4f15501f29f65c4ca189",
-        "version" : "0.47.0"
+        "revision" : "006b7c88a62d086b5483f0277afade29ef8c687c"
       }
     },
     {
@@ -60,7 +50,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/lynnswap/MachOObjCSection.git",
       "state" : {
-        "revision" : "3dbf6a856cbdc856d4d7c1fe6bbf81161e0fbe9c"
+        "revision" : "46b96a919b7c305283659053476c8a3ebb274fce"
       }
     },
     {
@@ -68,16 +58,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/lynnswap/MachOSwiftSection.git",
       "state" : {
-        "revision" : "2fbb1a78e316a2beaf2911488ecda6455e205f84"
-      }
-    },
-    {
-      "identity" : "metacodable",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/SwiftyLab/MetaCodable",
-      "state" : {
-        "revision" : "c2a6cc907e2f95463ba8f2b55432bd2aee8a4bfd",
-        "version" : "1.6.0"
+        "revision" : "5b0ffcfde22caa6aeed971c9014db6d3075f5da7"
       }
     },
     {
@@ -85,8 +66,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/p-x9/ObjectArchiveKit.git",
       "state" : {
-        "revision" : "c47d1b2df06168bacb396a1765ae5bf7fa2868fb",
-        "version" : "0.3.0"
+        "revision" : "96d782a576273b73b277b577943a2a25b00b919e",
+        "version" : "0.5.0"
       }
     },
     {
@@ -99,30 +80,21 @@
       }
     },
     {
-      "identity" : "sourcekitd",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/lynnswap/SourceKitD.git",
-      "state" : {
-        "revision" : "47ddc958a3962f9bb0fe08de1c8f39723e472228",
-        "version" : "0.1.0"
-      }
-    },
-    {
-      "identity" : "swift-apinotes",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/lynnswap/swift-apinotes.git",
-      "state" : {
-        "revision" : "2fe208c1824f053c04778c5dad2a6fe93d8ab3bf",
-        "version" : "0.1.0"
-      }
-    },
-    {
       "identity" : "swift-argument-parser",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-argument-parser",
       "state" : {
         "revision" : "c5d11a805e765f52ba34ec7284bd4fcd6ba68615",
         "version" : "1.7.0"
+      }
+    },
+    {
+      "identity" : "swift-asn1",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-asn1.git",
+      "state" : {
+        "revision" : "a9a5efd40eaf558a2bcd48d64b1d1646be686008",
+        "version" : "1.7.1"
       }
     },
     {
@@ -141,15 +113,6 @@
       "state" : {
         "revision" : "5fb96b503672ea4752eded6b4e301fd87214b03b",
         "version" : "0.2.1"
-      }
-    },
-    {
-      "identity" : "swift-clang",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/MxIris-DeveloperTool-Forks/swift-clang",
-      "state" : {
-        "revision" : "3944b95e4458e1a1e52efcdd5ea1518fcb90a9a6",
-        "version" : "0.1.0"
       }
     },
     {
@@ -177,6 +140,15 @@
       "state" : {
         "revision" : "5a3825302b1a0d744183200915a47b508c828e6f",
         "version" : "1.3.2"
+      }
+    },
+    {
+      "identity" : "swift-crypto",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-crypto.git",
+      "state" : {
+        "revision" : "95ba0316a9b733e92bb6b071255ff46263bbe7dc",
+        "version" : "3.15.1"
       }
     },
     {
@@ -267,15 +239,6 @@
       "state" : {
         "revision" : "34e463e98ab8541c604af706c99bed7160f5ec70",
         "version" : "1.8.1"
-      }
-    },
-    {
-      "identity" : "yams",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/jpsim/Yams",
-      "state" : {
-        "revision" : "deaf82e867fa2cbd3cd865978b079bfcf384ac28",
-        "version" : "6.2.1"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -1,6 +1,52 @@
 // swift-tools-version: 6.2
 import PackageDescription
 
+let isSimulatorHelperBuild = Context.environment["PHK_SIMULATOR_HELPER_BUILD"] == "1"
+
+var packageDependencies: [Package.Dependency] = [
+    .package(
+        url: "https://github.com/lynnswap/MachOKit.git",
+        from: "0.47.0"
+    ),
+    .package(
+        url: "https://github.com/lynnswap/MachOObjCSection.git",
+        revision: "3dbf6a856cbdc856d4d7c1fe6bbf81161e0fbe9c"
+    ),
+    .package(
+        url: "https://github.com/p-x9/swift-objc-dump.git",
+        from: "0.8.0"
+    ),
+]
+
+if !isSimulatorHelperBuild {
+    packageDependencies.append(
+        .package(
+            url: "https://github.com/lynnswap/MachOSwiftSection.git",
+            revision: "2fbb1a78e316a2beaf2911488ecda6455e205f84"
+        )
+    )
+}
+
+var rawDumpCoreDependencies: [Target.Dependency] = [
+    .target(
+        name: "PrivateHeaderKitRawDumpRuntimeObjC",
+        condition: .when(platforms: [.macOS, .iOS])
+    ),
+    .product(name: "MachOKit", package: "MachOKit"),
+    .product(name: "MachOObjCSection", package: "MachOObjCSection"),
+    .product(name: "ObjCDump", package: "swift-objc-dump"),
+]
+
+if !isSimulatorHelperBuild {
+    rawDumpCoreDependencies.append(
+        .product(
+            name: "SwiftInterface",
+            package: "MachOSwiftSection",
+            condition: .when(platforms: [.macOS])
+        )
+    )
+}
+
 let package = Package(
     name: "PrivateHeaderKit",
     platforms: [
@@ -10,25 +56,9 @@ let package = Package(
     products: [
         .library(name: "PrivateHeaderKitCore", targets: ["PrivateHeaderKitCore"]),
         .executable(name: "privateheaderkit", targets: ["PrivateHeaderKitCLI"]),
+        .executable(name: "privateheaderkit-sim-helper", targets: ["PrivateHeaderKitSimulatorHelper"]),
     ],
-    dependencies: [
-        .package(
-            url: "https://github.com/lynnswap/MachOKit.git",
-            from: "0.47.0"
-        ),
-        .package(
-            url: "https://github.com/lynnswap/MachOObjCSection.git",
-            revision: "3dbf6a856cbdc856d4d7c1fe6bbf81161e0fbe9c"
-        ),
-        .package(
-            url: "https://github.com/lynnswap/MachOSwiftSection.git",
-            revision: "2fbb1a78e316a2beaf2911488ecda6455e205f84"
-        ),
-        .package(
-            url: "https://github.com/p-x9/swift-objc-dump.git",
-            from: "0.8.0"
-        ),
-    ],
+    dependencies: packageDependencies,
     targets: [
         .target(
             name: "PrivateHeaderKitRawDumpRuntimeObjC",
@@ -38,17 +68,7 @@ let package = Package(
         ),
         .target(
             name: "PrivateHeaderKitRawDumpCore",
-            dependencies: [
-                .target(
-                    name: "PrivateHeaderKitRawDumpRuntimeObjC",
-                    condition: .when(platforms: [.macOS, .iOS])
-                ),
-                .product(name: "MachOKit", package: "MachOKit"),
-                .product(name: "MachOObjCSection", package: "MachOObjCSection"),
-                .product(name: "ObjCDump", package: "swift-objc-dump"),
-                .product(name: "MachOSwiftSection", package: "MachOSwiftSection"),
-                .product(name: "SwiftInterface", package: "MachOSwiftSection"),
-            ],
+            dependencies: rawDumpCoreDependencies,
             path: "Sources/PrivateHeaderKitRawDumpCore"
         ),
         .target(
@@ -71,6 +91,13 @@ let package = Package(
                 "PrivateHeaderKitRawDumpCore",
                 "PrivateHeaderKitCore",
                 "PrivateHeaderKitInstall",
+                "PrivateHeaderKitTooling",
+            ]
+        ),
+        .executableTarget(
+            name: "PrivateHeaderKitSimulatorHelper",
+            dependencies: [
+                "PrivateHeaderKitRawDumpCore",
             ]
         ),
         .executableTarget(

--- a/Package.swift
+++ b/Package.swift
@@ -1,52 +1,6 @@
 // swift-tools-version: 6.2
 import PackageDescription
 
-let isSimulatorHelperBuild = Context.environment["PHK_SIMULATOR_HELPER_BUILD"] == "1"
-
-var packageDependencies: [Package.Dependency] = [
-    .package(
-        url: "https://github.com/lynnswap/MachOKit.git",
-        from: "0.47.0"
-    ),
-    .package(
-        url: "https://github.com/lynnswap/MachOObjCSection.git",
-        revision: "3dbf6a856cbdc856d4d7c1fe6bbf81161e0fbe9c"
-    ),
-    .package(
-        url: "https://github.com/p-x9/swift-objc-dump.git",
-        from: "0.8.0"
-    ),
-]
-
-if !isSimulatorHelperBuild {
-    packageDependencies.append(
-        .package(
-            url: "https://github.com/lynnswap/MachOSwiftSection.git",
-            revision: "2fbb1a78e316a2beaf2911488ecda6455e205f84"
-        )
-    )
-}
-
-var rawDumpCoreDependencies: [Target.Dependency] = [
-    .target(
-        name: "PrivateHeaderKitRawDumpRuntimeObjC",
-        condition: .when(platforms: [.macOS, .iOS])
-    ),
-    .product(name: "MachOKit", package: "MachOKit"),
-    .product(name: "MachOObjCSection", package: "MachOObjCSection"),
-    .product(name: "ObjCDump", package: "swift-objc-dump"),
-]
-
-if !isSimulatorHelperBuild {
-    rawDumpCoreDependencies.append(
-        .product(
-            name: "SwiftInterface",
-            package: "MachOSwiftSection",
-            condition: .when(platforms: [.macOS])
-        )
-    )
-}
-
 let package = Package(
     name: "PrivateHeaderKit",
     platforms: [
@@ -58,7 +12,24 @@ let package = Package(
         .executable(name: "privateheaderkit", targets: ["PrivateHeaderKitCLI"]),
         .executable(name: "privateheaderkit-sim-helper", targets: ["PrivateHeaderKitSimulatorHelper"]),
     ],
-    dependencies: packageDependencies,
+    dependencies: [
+        .package(
+            url: "https://github.com/lynnswap/MachOKit.git",
+            revision: "006b7c88a62d086b5483f0277afade29ef8c687c"
+        ),
+        .package(
+            url: "https://github.com/lynnswap/MachOObjCSection.git",
+            revision: "46b96a919b7c305283659053476c8a3ebb274fce"
+        ),
+        .package(
+            url: "https://github.com/p-x9/swift-objc-dump.git",
+            from: "0.8.0"
+        ),
+        .package(
+            url: "https://github.com/lynnswap/MachOSwiftSection.git",
+            revision: "5b0ffcfde22caa6aeed971c9014db6d3075f5da7"
+        ),
+    ],
     targets: [
         .target(
             name: "PrivateHeaderKitRawDumpRuntimeObjC",
@@ -68,7 +39,16 @@ let package = Package(
         ),
         .target(
             name: "PrivateHeaderKitRawDumpCore",
-            dependencies: rawDumpCoreDependencies,
+            dependencies: [
+                .target(
+                    name: "PrivateHeaderKitRawDumpRuntimeObjC",
+                    condition: .when(platforms: [.macOS, .iOS])
+                ),
+                .product(name: "MachOKit", package: "MachOKit"),
+                .product(name: "MachOObjCSection", package: "MachOObjCSection"),
+                .product(name: "ObjCDump", package: "swift-objc-dump"),
+                .product(name: "SwiftInterface", package: "MachOSwiftSection"),
+            ],
             path: "Sources/PrivateHeaderKitRawDumpCore"
         ),
         .target(

--- a/README.ja.md
+++ b/README.ja.md
@@ -23,7 +23,8 @@ privateheaderkit
 swift run -c release privateheaderkit install
 ```
 
-デフォルトでは、単一の `privateheaderkit` バイナリを `~/.local/bin` にインストールします。
+デフォルトでは、user-facing command として単一の `privateheaderkit` バイナリを `~/.local/bin` にインストールします。
+iOS Simulator raw dump 用の internal helper は `~/.local/libexec/privateheaderkit/privateheaderkit-sim-helper` にインストールします。
 
 `~/.local/bin` が `PATH` に入っていない場合は追加してください:
 
@@ -52,9 +53,20 @@ swift build -c release --product privateheaderkit
 ```bash
 privateheaderkit --help
 privateheaderkit install --help
+privateheaderkit generate --help
 ```
 
-`privateheaderkit generate` は rewrite execution integration 用に予約しています。旧 `<version>` positional style は新しい public surface には含めません。source selection は explicit option または interactive flow で扱う方針です。
+`privateheaderkit generate` は明示的な source / output / target flag を受け取ります。
+
+```bash
+privateheaderkit generate --platform iOS --version 27.0 --build 24A5355q --out "$HOME/PrivateHeaderKit" --target "SwiftUI,UIKit"
+privateheaderkit generate --platform iOS --version 27.0 --build 24A5355q --system-root /path/to/RuntimeRoot --device "iPhone 17" --out "$HOME/PrivateHeaderKit" --target "SwiftUI,UIKit"
+privateheaderkit generate --platform macOS --version 16.0 --system-root / --out "$HOME/PrivateHeaderKit" --target "AppKit,Foundation" --resume
+```
+
+iOS では `--version` / `--build` から利用可能な Simulator runtime を解決し、device を選択・boot して internal simulator helper で raw dump します。`--system-root` は iOS では任意です。指定した場合は、その runtime root を明示入力として使い、解決済み runtime root で黙って置き換えません。`--device <name-or-udid>` と `--sim-helper <path>` は automation 用の任意 flag です。
+
+`--target` は comma-separated target query です。`--resume` は明示的な non-interactive resume request です。旧 `<version>` positional style は新しい public surface には含めません。
 
 ## Output Layout Contract
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ The old `privateheaderkit-dump`, `headerdump`, and `headerdump-sim` names are no
 swift run -c release privateheaderkit install
 ```
 
-By default, this installs the single `privateheaderkit` binary to `~/.local/bin`.
+By default, this installs the single user-facing `privateheaderkit` binary to `~/.local/bin`.
+iOS simulator raw dumping also installs an internal helper to `~/.local/libexec/privateheaderkit/privateheaderkit-sim-helper`.
 
 If `~/.local/bin` is not in your `PATH`, add it:
 
@@ -58,9 +59,12 @@ privateheaderkit generate --help
 `privateheaderkit generate` accepts the non-interactive rewrite input contract with explicit source, output, and target flags:
 
 ```bash
-privateheaderkit generate --platform iOS --version 27.0 --build 24A5355q --system-root /path/to/RuntimeRoot --out "$HOME/PrivateHeaderKit" --target "SwiftUI,UIKit"
+privateheaderkit generate --platform iOS --version 27.0 --build 24A5355q --out "$HOME/PrivateHeaderKit" --target "SwiftUI,UIKit"
+privateheaderkit generate --platform iOS --version 27.0 --build 24A5355q --system-root /path/to/RuntimeRoot --device "iPhone 17" --out "$HOME/PrivateHeaderKit" --target "SwiftUI,UIKit"
 privateheaderkit generate --platform macOS --version 16.0 --system-root / --out "$HOME/PrivateHeaderKit" --target "AppKit,Foundation" --resume
 ```
+
+For iOS, `generate` resolves an available iOS simulator runtime from `--version`/`--build`, selects and boots a simulator device, and uses the internal simulator helper. `--system-root` is optional for iOS; when supplied, it is used as the runtime root instead of silently replacing it with the resolved runtime path. `--device <name-or-udid>` and `--sim-helper <path>` are optional automation flags.
 
 `--target` is a comma-separated target query, not a stable target ID list. `--resume` is an explicit non-interactive resume request. The old `<version>` positional style is not part of the new public surface.
 

--- a/Sources/PrivateHeaderKitCLI/PrivateHeaderKitMain.swift
+++ b/Sources/PrivateHeaderKitCLI/PrivateHeaderKitMain.swift
@@ -2,6 +2,7 @@ import Foundation
 import PrivateHeaderKitCore
 import PrivateHeaderKitInstall
 import PrivateHeaderKitRawDumpCore
+import PrivateHeaderKitTooling
 
 #if canImport(Darwin)
 import Darwin
@@ -76,6 +77,20 @@ struct PrivateHeaderKitGenerationRequest: Sendable {
             return false
         }
         return true
+    }
+
+    var simulatorDeviceUDID: String? {
+        guard case .simulator(let deviceUDID, _) = options.executionMode else {
+            return nil
+        }
+        return deviceUDID
+    }
+
+    var simulatorRuntimeRoot: String? {
+        guard case .simulator(_, let runtimeRoot) = options.executionMode else {
+            return nil
+        }
+        return runtimeRoot
     }
 
     var usesSharedCache: Bool {
@@ -162,10 +177,12 @@ struct PrivateHeaderKitGenerateCommand: Equatable, Sendable {
     let platform: Platform
     let version: String
     let build: String?
-    let systemRoot: String
+    let systemRoot: String?
     let outputBaseDirectory: String
     let targetQuery: String
     let resume: Bool
+    let device: String?
+    let simulatorHelperPath: String?
 
     var sourceDisplayName: String {
         sourceLabel(separator: " ")
@@ -196,6 +213,46 @@ struct PrivateHeaderKitGenerateCommand: Equatable, Sendable {
     }
 }
 
+struct PrivateHeaderKitSimulatorResolution: Equatable, Sendable {
+    let runtimeVersion: String
+    let runtimeBuild: String
+    let runtimeIdentifier: String
+    let resolvedRuntimeRoot: String
+    let deviceName: String
+    let deviceUDID: String
+
+    init(
+        runtimeVersion: String,
+        runtimeBuild: String,
+        runtimeIdentifier: String,
+        resolvedRuntimeRoot: String,
+        deviceName: String,
+        deviceUDID: String
+    ) {
+        self.runtimeVersion = runtimeVersion
+        self.runtimeBuild = runtimeBuild
+        self.runtimeIdentifier = runtimeIdentifier
+        self.resolvedRuntimeRoot = resolvedRuntimeRoot
+        self.deviceName = deviceName
+        self.deviceUDID = deviceUDID
+    }
+
+    init(runtime: RuntimeInfo, device: DeviceInfo) {
+        self.init(
+            runtimeVersion: runtime.version,
+            runtimeBuild: runtime.build,
+            runtimeIdentifier: runtime.identifier,
+            resolvedRuntimeRoot: runtime.runtimeRoot,
+            deviceName: device.name,
+            deviceUDID: device.udid
+        )
+    }
+}
+
+typealias PrivateHeaderKitSimulatorResolver = (
+    PrivateHeaderKitGenerateCommand
+) throws -> PrivateHeaderKitSimulatorResolution
+
 private let legacyPublicCommandNames: Set<String> = [
     "privateheaderkit-dump",
     "headerdump",
@@ -215,6 +272,7 @@ enum PrivateHeaderKitCLIError: Error, Equatable, CustomStringConvertible {
     case emptyOptionValue(String)
     case invalidSourceComponent(option: String, value: String)
     case invalidTargetQuery(String)
+    case missingSimulatorResolution
 
     var description: String {
         switch self {
@@ -242,6 +300,8 @@ enum PrivateHeaderKitCLIError: Error, Equatable, CustomStringConvertible {
             return "\(option) is not safe as a source label path component: \(value)"
         case .invalidTargetQuery(let value):
             return "target query must be a comma-separated list without empty entries: \(value)"
+        case .missingSimulatorResolution:
+            return "iOS generation requires a resolved simulator runtime and device"
         }
     }
 }
@@ -251,6 +311,7 @@ func runPrivateHeaderKitCommand(
     environment: [String: String] = ProcessInfo.processInfo.environment,
     currentExecutableURL: URL? = Bundle.main.executableURL,
     generationRunner: @escaping PrivateHeaderKitGenerationRunner = runPrivateHeaderGeneration,
+    simulatorResolver: @escaping PrivateHeaderKitSimulatorResolver = resolvePrivateHeaderKitSimulator,
     outputLogger: (String) -> Void = logCLIOutput,
     errorLogger: (String) -> Void = logCLIError
 ) async -> Int32 {
@@ -270,6 +331,7 @@ func runPrivateHeaderKitCommand(
                 invokedProgramName: args.first ?? "privateheaderkit",
                 currentExecutableURL: currentExecutableURL,
                 generationRunner: generationRunner,
+                simulatorResolver: simulatorResolver,
                 outputLogger: outputLogger,
                 errorLogger: errorLogger
             )
@@ -293,16 +355,32 @@ private func runPrivateHeaderKitGenerateCommand(
     invokedProgramName: String,
     currentExecutableURL: URL?,
     generationRunner: PrivateHeaderKitGenerationRunner,
+    simulatorResolver: PrivateHeaderKitSimulatorResolver,
     outputLogger: (String) -> Void,
     errorLogger: (String) -> Void
 ) async -> Int32 {
     do {
+        let hostHelperExecutableURL = privateHeaderKitExecutableURL(
+            currentExecutableURL: currentExecutableURL,
+            fallbackProgramName: invokedProgramName
+        )
+        let simulatorResolution: PrivateHeaderKitSimulatorResolution?
+        if command.platform == .iOS {
+            simulatorResolution = try simulatorResolver(command)
+            if let simulatorResolution {
+                logPrivateHeaderKitSimulatorSelection(
+                    simulatorResolution,
+                    command: command,
+                    outputLogger: outputLogger
+                )
+            }
+        } else {
+            simulatorResolution = nil
+        }
         let request = try makePrivateHeaderGenerationRequest(
             from: command,
-            helperExecutableURL: privateHeaderKitExecutableURL(
-                currentExecutableURL: currentExecutableURL,
-                fallbackProgramName: invokedProgramName
-            )
+            hostHelperExecutableURL: hostHelperExecutableURL,
+            simulatorResolution: simulatorResolution
         )
         let summary = try await generationRunner(request)
         logPrivateHeaderGenerationSuccess(summary, outputLogger: outputLogger)
@@ -332,7 +410,8 @@ private func runPrivateHeaderGeneration(
 
 private func makePrivateHeaderGenerationRequest(
     from command: PrivateHeaderKitGenerateCommand,
-    helperExecutableURL: URL
+    hostHelperExecutableURL: URL,
+    simulatorResolution: PrivateHeaderKitSimulatorResolution?
 ) throws -> PrivateHeaderKitGenerationRequest {
     let source = try PrivateHeaderGeneration.Source(
         platform: command.platform.corePlatform,
@@ -343,21 +422,41 @@ private func makePrivateHeaderGenerationRequest(
         fileURLWithPath: command.outputBaseDirectory,
         isDirectory: true
     )
-    let systemRoot = URL(fileURLWithPath: command.systemRoot, isDirectory: true)
+    let systemRoot = try effectiveSystemRootURL(from: command, simulatorResolution: simulatorResolution)
     let output = PrivateHeaderGeneration.Output(baseDirectory: outputBaseDirectory)
     let helperURLs = PrivateHeaderGeneration.RawDumping.HelperURLs(
-        host: helperExecutableURL,
-        simulator: helperExecutableURL
+        host: hostHelperExecutableURL,
+        simulator: simulatorHelperURL(
+            from: command,
+            hostHelperExecutableURL: hostHelperExecutableURL
+        )
     )
+    let executionMode: PrivateHeaderGeneration.RawDumping.ExecutionMode = try {
+        switch command.platform {
+        case .macOS:
+            return .host
+        case .iOS:
+            guard let simulatorResolution else {
+                throw PrivateHeaderKitCLIError.missingSimulatorResolution
+            }
+            return .simulator(
+                deviceUDID: simulatorResolution.deviceUDID,
+                runtimeRoot: systemRoot.path
+            )
+        }
+    }()
+    let helperEnvironment = [
+        "PH_RUNTIME_ROOT": systemRoot.path,
+    ]
     let options = PrivateHeaderGeneration.Options(
         targetRequest: .query(command.targetQuery),
         systemRoot: systemRoot,
         helperURLs: helperURLs,
-        executionMode: .host,
+        executionMode: executionMode,
         rawDumpingOptions: PrivateHeaderGeneration.RawDumping.Options(
             useSharedCache: true,
             preferRuntimeMetadata: true,
-            helperEnvironment: ["PH_RUNTIME_ROOT": systemRoot.path]
+            helperEnvironment: helperEnvironment
         ),
         resumeBehavior: .requireExplicitResume(resumeRequested: command.resume),
         outputBaseDirectory: outputBaseDirectory
@@ -370,6 +469,62 @@ private func makePrivateHeaderGenerationRequest(
     )
 }
 
+private func effectiveSystemRootURL(
+    from command: PrivateHeaderKitGenerateCommand,
+    simulatorResolution: PrivateHeaderKitSimulatorResolution?
+) throws -> URL {
+    if let systemRoot = command.systemRoot {
+        return URL(fileURLWithPath: systemRoot, isDirectory: true)
+    }
+
+    switch command.platform {
+    case .macOS:
+        throw PrivateHeaderKitCLIError.missingRequiredOption("--system-root")
+    case .iOS:
+        guard let simulatorResolution else {
+            throw PrivateHeaderKitCLIError.missingSimulatorResolution
+        }
+        return URL(fileURLWithPath: simulatorResolution.resolvedRuntimeRoot, isDirectory: true)
+    }
+}
+
+private func simulatorHelperURL(
+    from command: PrivateHeaderKitGenerateCommand,
+    hostHelperExecutableURL: URL
+) -> URL {
+    if let simulatorHelperPath = command.simulatorHelperPath {
+        return URL(fileURLWithPath: PathUtils.expandTilde(simulatorHelperPath), isDirectory: false)
+    }
+    return defaultSimulatorHelperURL(hostExecutableURL: hostHelperExecutableURL)
+}
+
+func defaultSimulatorHelperURL(hostExecutableURL: URL) -> URL {
+    let binDir = hostExecutableURL.deletingLastPathComponent()
+    if binDir.lastPathComponent == "bin" {
+        return binDir
+            .deletingLastPathComponent()
+            .appendingPathComponent("libexec/privateheaderkit/privateheaderkit-sim-helper", isDirectory: false)
+    }
+    return binDir.appendingPathComponent("privateheaderkit-sim-helper", isDirectory: false)
+}
+
+func resolvePrivateHeaderKitSimulator(
+    for command: PrivateHeaderKitGenerateCommand
+) throws -> PrivateHeaderKitSimulatorResolution {
+    let runner = ProcessRunner()
+    let runtime = try Simctl.findRuntime(
+        version: command.version,
+        build: command.build,
+        runner: runner
+    )
+    let device = try Simctl.resolveDevice(
+        runtime: runtime,
+        query: command.device,
+        runner: runner
+    )
+    return PrivateHeaderKitSimulatorResolution(runtime: runtime, device: device)
+}
+
 private func privateHeaderKitExecutableURL(
     currentExecutableURL: URL?,
     fallbackProgramName: String
@@ -378,6 +533,20 @@ private func privateHeaderKitExecutableURL(
         return currentExecutableURL
     }
     return URL(fileURLWithPath: fallbackProgramName, isDirectory: false)
+}
+
+private func logPrivateHeaderKitSimulatorSelection(
+    _ resolution: PrivateHeaderKitSimulatorResolution,
+    command: PrivateHeaderKitGenerateCommand,
+    outputLogger: (String) -> Void
+) {
+    outputLogger("selected simulator: \(resolution.deviceName) (\(resolution.deviceUDID))")
+    if let systemRoot = command.systemRoot,
+       URL(fileURLWithPath: systemRoot, isDirectory: true).standardizedFileURL.path
+        != URL(fileURLWithPath: resolution.resolvedRuntimeRoot, isDirectory: true).standardizedFileURL.path {
+        outputLogger("using explicit system root: \(systemRoot)")
+        outputLogger("resolved runtime root: \(resolution.resolvedRuntimeRoot)")
+    }
 }
 
 private func logPrivateHeaderGenerationSuccess(
@@ -438,6 +607,8 @@ private func parsePrivateHeaderKitGenerateCommand(_ args: [String]) throws -> Pr
     var systemRoot: String?
     var outputBaseDirectory: String?
     var targetQuery: String?
+    var device: String?
+    var simulatorHelperPath: String?
     var resume = false
     var seenOptions: Set<String> = []
 
@@ -506,6 +677,18 @@ private func parsePrivateHeaderKitGenerateCommand(_ args: [String]) throws -> Pr
             )
             try validateTargetQuery(value)
             targetQuery = value
+        case "--device":
+            try markOptionSeen(option, in: &seenOptions)
+            device = try nonEmptyOptionValue(
+                try readOptionValue(option: option, inlineValue: inlineValue, args: args, index: &index),
+                option: option
+            )
+        case "--sim-helper":
+            try markOptionSeen(option, in: &seenOptions)
+            simulatorHelperPath = try nonEmptyOptionValue(
+                try readOptionValue(option: option, inlineValue: inlineValue, args: args, index: &index),
+                option: option
+            )
         case "--resume":
             try markOptionSeen(option, in: &seenOptions)
             if inlineValue != nil {
@@ -524,7 +707,7 @@ private func parsePrivateHeaderKitGenerateCommand(_ args: [String]) throws -> Pr
     guard let version else {
         throw PrivateHeaderKitCLIError.missingRequiredOption("--version")
     }
-    guard let systemRoot else {
+    if platform == .macOS, systemRoot == nil {
         throw PrivateHeaderKitCLIError.missingRequiredOption("--system-root")
     }
     guard let outputBaseDirectory else {
@@ -542,7 +725,9 @@ private func parsePrivateHeaderKitGenerateCommand(_ args: [String]) throws -> Pr
             systemRoot: systemRoot,
             outputBaseDirectory: outputBaseDirectory,
             targetQuery: targetQuery,
-            resume: resume
+            resume: resume,
+            device: device,
+            simulatorHelperPath: simulatorHelperPath
         )
     )
 }
@@ -640,24 +825,26 @@ func privateHeaderKitUsageText() -> String {
 
     Examples:
       privateheaderkit install --bindir "$HOME/bin"
-      privateheaderkit generate --platform iOS --version 27.0 --build 24A5355q --system-root /path/to/RuntimeRoot --out "$HOME/PrivateHeaderKit" --target "SwiftUI,UIKit"
+      privateheaderkit generate --platform iOS --version 27.0 --build 24A5355q --out "$HOME/PrivateHeaderKit" --target "SwiftUI,UIKit"
     """
 }
 
 func privateHeaderKitGenerateUsageText() -> String {
     """
     Usage:
-      privateheaderkit generate --platform <iOS|macOS> --version <version> [--build <build>] --system-root <path> --out <path> --target <query> [--resume]
+      privateheaderkit generate --platform <iOS|macOS> --version <version> [--build <build>] [--system-root <path>] --out <path> --target <query> [--device <name-or-udid>] [--sim-helper <path>] [--resume]
 
     Required Options:
       --platform <iOS|macOS>  Source platform
       --version <version>     Source OS version
-      --system-root <path>    Mounted system root to scan
       --out <path>            Output base directory
       --target <query>        Comma-separated target query, for example SwiftUI,UIKit
 
     Optional Options:
       --build <build>         Source build train for labels and state keys
+      --system-root <path>    Mounted system root to scan; required for macOS, optional for iOS
+      --device <name-or-udid> iOS simulator device to use
+      --sim-helper <path>     iOS simulator raw-dump helper path
       --resume                Resume the matching explicit source/output/target run
       -h, --help              Show this help
 
@@ -666,7 +853,7 @@ func privateHeaderKitGenerateUsageText() -> String {
       State:   <out>/.state/<platform><version>(<build>)/
 
     Examples:
-      privateheaderkit generate --platform iOS --version 27.0 --build 24A5355q --system-root /path/to/RuntimeRoot --out "$HOME/PrivateHeaderKit" --target "SwiftUI,UIKit"
+      privateheaderkit generate --platform iOS --version 27.0 --build 24A5355q --out "$HOME/PrivateHeaderKit" --target "SwiftUI,UIKit"
       privateheaderkit generate --platform macOS --version 16.0 --system-root / --out "$HOME/PrivateHeaderKit" --target "AppKit,Foundation" --resume
     """
 }

--- a/Sources/PrivateHeaderKitCLI/PrivateHeaderKitMain.swift
+++ b/Sources/PrivateHeaderKitCLI/PrivateHeaderKitMain.swift
@@ -500,12 +500,9 @@ private func simulatorHelperURL(
 
 func defaultSimulatorHelperURL(hostExecutableURL: URL) -> URL {
     let binDir = hostExecutableURL.deletingLastPathComponent()
-    if binDir.lastPathComponent == "bin" {
-        return binDir
-            .deletingLastPathComponent()
-            .appendingPathComponent("libexec/privateheaderkit/privateheaderkit-sim-helper", isDirectory: false)
-    }
-    return binDir.appendingPathComponent("privateheaderkit-sim-helper", isDirectory: false)
+    return binDir
+        .deletingLastPathComponent()
+        .appendingPathComponent("libexec/privateheaderkit/privateheaderkit-sim-helper", isDirectory: false)
 }
 
 func resolvePrivateHeaderKitSimulator(

--- a/Sources/PrivateHeaderKitCore/PrivateHeaderGenerationExecutor.swift
+++ b/Sources/PrivateHeaderKitCore/PrivateHeaderGenerationExecutor.swift
@@ -355,6 +355,28 @@ private extension PrivateHeaderGeneration.GenerationExecutor {
             )
         }
 
+        if let missingArtifactSummary = Self.missingRequiredArtifactSummary(
+            in: attemptedArtifacts,
+            executionMode: executionMode
+        ) {
+            let status: PrivateHeaderGeneration.RunTargetStatus = attemptedArtifacts.isEmpty ? .failed : .partial
+            return failedTargetResult(
+                target: target,
+                runID: runID,
+                status: status,
+                phases: [
+                    PrivateHeaderGeneration.PhaseRecord(
+                        name: invocation.phaseLabel,
+                        status: .failed,
+                        failureSummary: missingArtifactSummary
+                    ),
+                ],
+                artifacts: preservedArtifacts,
+                attemptedArtifacts: attemptedArtifacts,
+                failureSummary: missingArtifactSummary
+            )
+        }
+
         guard !attemptedArtifacts.isEmpty, let stagedSourceDirectory = staged.sourceDirectory else {
             let failureSummary = "raw dump produced no header artifacts"
             return failedTargetResult(
@@ -786,6 +808,23 @@ private extension PrivateHeaderGeneration.GenerationExecutor {
         return artifacts.sorted { $0.rawValue < $1.rawValue }
     }
 
+    static func missingRequiredArtifactSummary(
+        in artifacts: [PrivateHeaderGeneration.ArtifactPath],
+        executionMode: PrivateHeaderGeneration.RawDumping.ExecutionMode
+    ) -> String? {
+        guard case .simulator = executionMode else { return nil }
+
+        var missing: [String] = []
+        if !artifacts.contains(where: { $0.rawValue.hasSuffix(".h") }) {
+            missing.append(".h")
+        }
+        if !artifacts.contains(where: { $0.rawValue.hasSuffix(".swiftinterface") }) {
+            missing.append(".swiftinterface")
+        }
+        guard !missing.isEmpty else { return nil }
+        return "raw dump missing required simulator artifacts: \(missing.joined(separator: ", "))"
+    }
+
     static func commit(
         stagedSourceDirectory: URL,
         artifactRoot: PrivateHeaderGeneration.ArtifactPath,
@@ -1025,6 +1064,7 @@ private extension PrivateHeaderGeneration.RawDumping.Options {
     ) -> [String: String] {
         var environment = helperEnvironment
         if case .simulator(_, let runtimeRoot) = executionMode {
+            environment["PH_RUNTIME_ROOT"] = runtimeRoot
             environment["SIMCTL_CHILD_PH_RUNTIME_ROOT"] = runtimeRoot
             environment["SIMCTL_CHILD_DYLD_ROOT_PATH"] = runtimeRoot
         }

--- a/Sources/PrivateHeaderKitCore/PrivateHeaderGenerationExecutor.swift
+++ b/Sources/PrivateHeaderKitCore/PrivateHeaderGenerationExecutor.swift
@@ -355,28 +355,6 @@ private extension PrivateHeaderGeneration.GenerationExecutor {
             )
         }
 
-        if let missingArtifactSummary = Self.missingRequiredArtifactSummary(
-            in: attemptedArtifacts,
-            executionMode: executionMode
-        ) {
-            let status: PrivateHeaderGeneration.RunTargetStatus = attemptedArtifacts.isEmpty ? .failed : .partial
-            return failedTargetResult(
-                target: target,
-                runID: runID,
-                status: status,
-                phases: [
-                    PrivateHeaderGeneration.PhaseRecord(
-                        name: invocation.phaseLabel,
-                        status: .failed,
-                        failureSummary: missingArtifactSummary
-                    ),
-                ],
-                artifacts: preservedArtifacts,
-                attemptedArtifacts: attemptedArtifacts,
-                failureSummary: missingArtifactSummary
-            )
-        }
-
         guard !attemptedArtifacts.isEmpty, let stagedSourceDirectory = staged.sourceDirectory else {
             let failureSummary = "raw dump produced no header artifacts"
             return failedTargetResult(
@@ -806,23 +784,6 @@ private extension PrivateHeaderGeneration.GenerationExecutor {
         }
 
         return artifacts.sorted { $0.rawValue < $1.rawValue }
-    }
-
-    static func missingRequiredArtifactSummary(
-        in artifacts: [PrivateHeaderGeneration.ArtifactPath],
-        executionMode: PrivateHeaderGeneration.RawDumping.ExecutionMode
-    ) -> String? {
-        guard case .simulator = executionMode else { return nil }
-
-        var missing: [String] = []
-        if !artifacts.contains(where: { $0.rawValue.hasSuffix(".h") }) {
-            missing.append(".h")
-        }
-        if !artifacts.contains(where: { $0.rawValue.hasSuffix(".swiftinterface") }) {
-            missing.append(".swiftinterface")
-        }
-        guard !missing.isEmpty else { return nil }
-        return "raw dump missing required simulator artifacts: \(missing.joined(separator: ", "))"
     }
 
     static func commit(

--- a/Sources/PrivateHeaderKitCore/PrivateHeaderGenerationExecutor.swift
+++ b/Sources/PrivateHeaderKitCore/PrivateHeaderGenerationExecutor.swift
@@ -334,29 +334,10 @@ private extension PrivateHeaderGeneration.GenerationExecutor {
         )
         let attemptedArtifacts = staged.artifacts
 
-        guard rawResult.succeeded else {
-            let failureSummary = rawResult.failureSummary
-                ?? "raw dump exited with status \(rawResult.terminationStatus)"
-            let status: PrivateHeaderGeneration.RunTargetStatus = attemptedArtifacts.isEmpty ? .failed : .partial
-            return failedTargetResult(
-                target: target,
-                runID: runID,
-                status: status,
-                phases: [
-                    PrivateHeaderGeneration.PhaseRecord(
-                        name: invocation.phaseLabel,
-                        status: .failed,
-                        failureSummary: failureSummary
-                    ),
-                ],
-                artifacts: preservedArtifacts,
-                attemptedArtifacts: attemptedArtifacts,
-                failureSummary: failureSummary
-            )
-        }
-
         guard !attemptedArtifacts.isEmpty, let stagedSourceDirectory = staged.sourceDirectory else {
-            let failureSummary = "raw dump produced no header artifacts"
+            let failureSummary = rawResult.succeeded
+                ? "raw dump produced no header artifacts"
+                : rawResult.failureSummary ?? "raw dump exited with status \(rawResult.terminationStatus)"
             return failedTargetResult(
                 target: target,
                 runID: runID,
@@ -374,6 +355,28 @@ private extension PrivateHeaderGeneration.GenerationExecutor {
             )
         }
 
+        let rawDumpPhase: PrivateHeaderGeneration.PhaseRecord
+        let targetStatus: PrivateHeaderGeneration.RunTargetStatus
+        let targetFailureSummary: String?
+        if rawResult.succeeded {
+            rawDumpPhase = PrivateHeaderGeneration.PhaseRecord(
+                name: invocation.phaseLabel,
+                status: .completed
+            )
+            targetStatus = .completed
+            targetFailureSummary = nil
+        } else {
+            let failureSummary = rawResult.failureSummary
+                ?? "raw dump exited with status \(rawResult.terminationStatus)"
+            rawDumpPhase = PrivateHeaderGeneration.PhaseRecord(
+                name: invocation.phaseLabel,
+                status: .failed,
+                failureSummary: failureSummary
+            )
+            targetStatus = .partial
+            targetFailureSummary = failureSummary
+        }
+
         do {
             try artifactStore.cleanupManagedArtifacts(
                 PrivateHeaderGeneration.ArtifactStore.cleanupCandidates(
@@ -388,10 +391,7 @@ private extension PrivateHeaderGeneration.GenerationExecutor {
                 runID: runID,
                 status: .commitFailed,
                 phases: [
-                    PrivateHeaderGeneration.PhaseRecord(
-                        name: invocation.phaseLabel,
-                        status: .completed
-                    ),
+                    rawDumpPhase,
                     PrivateHeaderGeneration.PhaseRecord(
                         name: "cleanup",
                         status: .failed,
@@ -417,10 +417,7 @@ private extension PrivateHeaderGeneration.GenerationExecutor {
                 runID: runID,
                 status: .commitFailed,
                 phases: [
-                    PrivateHeaderGeneration.PhaseRecord(
-                        name: invocation.phaseLabel,
-                        status: .completed
-                    ),
+                    rawDumpPhase,
                     PrivateHeaderGeneration.PhaseRecord(
                         name: "commit",
                         status: .failed,
@@ -434,10 +431,7 @@ private extension PrivateHeaderGeneration.GenerationExecutor {
         }
 
         let phases = [
-            PrivateHeaderGeneration.PhaseRecord(
-                name: invocation.phaseLabel,
-                status: .completed
-            ),
+            rawDumpPhase,
             PrivateHeaderGeneration.PhaseRecord(
                 name: "commit",
                 status: .completed
@@ -447,20 +441,20 @@ private extension PrivateHeaderGeneration.GenerationExecutor {
             id: targetID,
             displayName: target.candidate.displayName,
             kind: target.candidate.kind.rawValue,
-            status: .completed,
+            status: PrivateHeaderGeneration.TargetStatus(runStatus: targetStatus),
             phases: phases,
             artifacts: attemptedArtifacts,
             lastRunID: runID,
             updatedAt: dateProvider(),
-            failureSummary: nil
+            failureSummary: targetFailureSummary
         )
         let runTarget = PrivateHeaderGeneration.RunTargetRecord(
             targetID: targetID,
-            status: .completed,
+            status: targetStatus,
             phases: phases,
             artifacts: attemptedArtifacts,
             attemptedArtifacts: attemptedArtifacts,
-            failureSummary: nil
+            failureSummary: targetFailureSummary
         )
         return TargetExecutionResult(runTarget: runTarget, manifestTarget: manifestTarget)
     }

--- a/Sources/PrivateHeaderKitInstall/PrivateHeaderKitInstallMain.swift
+++ b/Sources/PrivateHeaderKitInstall/PrivateHeaderKitInstallMain.swift
@@ -449,12 +449,9 @@ func dryRunInstallMessages(layout: InstallLayout) -> [String] {
 
 func defaultInstalledSimulatorHelperURL(for executableURL: URL) -> URL {
     let binDir = executableURL.deletingLastPathComponent()
-    if binDir.lastPathComponent == "bin" {
-        return binDir
-            .deletingLastPathComponent()
-            .appendingPathComponent("libexec/privateheaderkit/privateheaderkit-sim-helper", isDirectory: false)
-    }
-    return binDir.appendingPathComponent("privateheaderkit-sim-helper", isDirectory: false)
+    return binDir
+        .deletingLastPathComponent()
+        .appendingPathComponent("libexec/privateheaderkit/privateheaderkit-sim-helper", isDirectory: false)
 }
 
 private func installExecutableFile(

--- a/Sources/PrivateHeaderKitInstall/PrivateHeaderKitInstallMain.swift
+++ b/Sources/PrivateHeaderKitInstall/PrivateHeaderKitInstallMain.swift
@@ -204,7 +204,7 @@ func buildProducts(_ products: [String], in directory: URL, runner: CommandRunni
     }
 }
 
-func currentProcessArchitectureName() -> String {
+func currentExecutableArchitectureName() -> String {
     #if arch(arm64)
     return "arm64"
     #elseif arch(x86_64)
@@ -214,15 +214,41 @@ func currentProcessArchitectureName() -> String {
     #endif
 }
 
-func defaultSimulatorHelperTriple(
-    processArchitecture: String = currentProcessArchitectureName()
+func hostSupportsNativeArm64() -> Bool {
+    #if canImport(Darwin)
+    var value: Int32 = 0
+    var size = MemoryLayout<Int32>.size
+    let result = sysctlbyname("hw.optional.arm64", &value, &size, nil, 0)
+    return result == 0 && value != 0
+    #else
+    return false
+    #endif
+}
+
+func nativeHostSimulatorArchitecture(
+    executableArchitecture: String,
+    supportsNativeArm64: Bool
 ) throws -> String {
-    switch processArchitecture {
-    case "arm64", "x86_64":
-        "\(processArchitecture)-apple-ios-simulator"
-    default:
-        throw InstallError.message("unsupported host architecture for iOS simulator helper: \(processArchitecture)")
+    if supportsNativeArm64 {
+        return "arm64"
     }
+    switch executableArchitecture {
+    case "arm64", "x86_64":
+        return executableArchitecture
+    default:
+        throw InstallError.message("unsupported host architecture for iOS simulator helper: \(executableArchitecture)")
+    }
+}
+
+func defaultSimulatorHelperTriple(
+    executableArchitecture: String = currentExecutableArchitectureName(),
+    supportsNativeArm64: Bool = hostSupportsNativeArm64()
+) throws -> String {
+    let architecture = try nativeHostSimulatorArchitecture(
+        executableArchitecture: executableArchitecture,
+        supportsNativeArm64: supportsNativeArm64
+    )
+    return "\(architecture)-apple-ios-simulator"
 }
 
 func buildSimulatorHelper(

--- a/Sources/PrivateHeaderKitInstall/PrivateHeaderKitInstallMain.swift
+++ b/Sources/PrivateHeaderKitInstall/PrivateHeaderKitInstallMain.swift
@@ -33,7 +33,6 @@ enum InstallConstants {
     static let publicCommandName = "privateheaderkit"
     static let simulatorHelperInstallName = "privateheaderkit-sim-helper"
     static let simulatorHelperBuildProductName = "privateheaderkit-sim-helper"
-    static let simulatorHelperTriple = "arm64-apple-ios-simulator"
 }
 
 enum InstallError: Error, CustomStringConvertible {
@@ -205,12 +204,53 @@ func buildProducts(_ products: [String], in directory: URL, runner: CommandRunni
     }
 }
 
-func buildSimulatorHelper(in directory: URL, runner: CommandRunning) throws {
-    let sdkPath = try resolveSimulatorSDKPath(runner: runner)
-    try buildSimulatorHelper(in: directory, sdkPath: sdkPath, runner: runner)
+func currentProcessArchitectureName() -> String {
+    #if arch(arm64)
+    return "arm64"
+    #elseif arch(x86_64)
+    return "x86_64"
+    #else
+    return "unknown"
+    #endif
 }
 
-func buildSimulatorHelper(in directory: URL, sdkPath: String, runner: CommandRunning) throws {
+func defaultSimulatorHelperTriple(
+    processArchitecture: String = currentProcessArchitectureName()
+) throws -> String {
+    switch processArchitecture {
+    case "arm64", "x86_64":
+        "\(processArchitecture)-apple-ios-simulator"
+    default:
+        throw InstallError.message("unsupported host architecture for iOS simulator helper: \(processArchitecture)")
+    }
+}
+
+func buildSimulatorHelper(
+    in directory: URL,
+    runner: CommandRunning,
+    simulatorHelperTriple: String? = nil
+) throws {
+    let sdkPath = try resolveSimulatorSDKPath(runner: runner)
+    try buildSimulatorHelper(
+        in: directory,
+        sdkPath: sdkPath,
+        runner: runner,
+        simulatorHelperTriple: simulatorHelperTriple
+    )
+}
+
+func buildSimulatorHelper(
+    in directory: URL,
+    sdkPath: String,
+    runner: CommandRunning,
+    simulatorHelperTriple: String? = nil
+) throws {
+    let triple: String
+    if let simulatorHelperTriple {
+        triple = simulatorHelperTriple
+    } else {
+        triple = try defaultSimulatorHelperTriple()
+    }
     try runner.runSimple(
         [
             "swift",
@@ -220,7 +260,7 @@ func buildSimulatorHelper(in directory: URL, sdkPath: String, runner: CommandRun
             "--sdk",
             sdkPath,
             "--triple",
-            InstallConstants.simulatorHelperTriple,
+            triple,
             "--product",
             InstallConstants.simulatorHelperBuildProductName,
         ],
@@ -296,7 +336,8 @@ func install(
     runner: CommandRunning,
     fileManager: FileManager,
     outputLogger: (String) -> Void,
-    errorLogger: (String) -> Void
+    errorLogger: (String) -> Void,
+    simulatorHelperTriple: String? = nil
 ) throws {
     let baseURL = selfURL.deletingLastPathComponent()
 
@@ -328,16 +369,31 @@ func install(
     }
 
     var simulatorSDKPath: String?
+    let resolvedSimulatorHelperTriple: String?
     if let repoRoot {
+        let triple: String
+        if let simulatorHelperTriple {
+            triple = simulatorHelperTriple
+        } else {
+            triple = try defaultSimulatorHelperTriple()
+        }
+        resolvedSimulatorHelperTriple = triple
         // Always build install artifacts when possible, so users get the latest binaries after pulling updates.
         do {
             try buildProducts([InstallConstants.publicCommandName], in: repoRoot, runner: runner)
             let sdkPath = try resolveSimulatorSDKPath(runner: runner)
             simulatorSDKPath = sdkPath
-            try buildSimulatorHelper(in: repoRoot, sdkPath: sdkPath, runner: runner)
+            try buildSimulatorHelper(
+                in: repoRoot,
+                sdkPath: sdkPath,
+                runner: runner,
+                simulatorHelperTriple: triple
+            )
         } catch {
             errorLogger("warning: swift build failed: \(error)")
         }
+    } else {
+        resolvedSimulatorHelperTriple = nil
     }
 
     let hostBinaryDir: URL
@@ -353,7 +409,7 @@ func install(
         let simulatorBinaryDir = resolveSwiftBinDir(
             repoRoot: repoRoot,
             runner: runner,
-            triple: InstallConstants.simulatorHelperTriple,
+            triple: resolvedSimulatorHelperTriple,
             sdkPath: sdkPath
         ) ?? baseURL
         simulatorHelperSourceURL = simulatorBinaryDir.appendingPathComponent(

--- a/Sources/PrivateHeaderKitInstall/PrivateHeaderKitInstallMain.swift
+++ b/Sources/PrivateHeaderKitInstall/PrivateHeaderKitInstallMain.swift
@@ -15,6 +15,28 @@ struct InstallOptions {
     var dryRun: Bool
 }
 
+struct InstallLayout: Equatable {
+    let prefix: URL
+    let binDir: URL
+    let libexecDir: URL
+
+    var publicCommandURL: URL {
+        binDir.appendingPathComponent(InstallConstants.publicCommandName, isDirectory: false)
+    }
+
+    var simulatorHelperURL: URL {
+        libexecDir.appendingPathComponent(InstallConstants.simulatorHelperInstallName, isDirectory: false)
+    }
+}
+
+enum InstallConstants {
+    static let publicCommandName = "privateheaderkit"
+    static let simulatorHelperInstallName = "privateheaderkit-sim-helper"
+    static let simulatorHelperBuildProductName = "privateheaderkit-sim-helper"
+    static let simulatorHelperTriple = "arm64-apple-ios-simulator"
+    static let simulatorHelperBuildEnvironment = ["PHK_SIMULATOR_HELPER_BUILD": "1"]
+}
+
 enum InstallError: Error, CustomStringConvertible {
     case message(String)
     case helpRequested
@@ -58,7 +80,7 @@ func printInstallUsage() {
 
     Options:
       --bindir path   Install to this directory (overrides --prefix)
-      --prefix path   Install to <prefix>/bin (default: ~/.local)
+      --prefix path   Install to <prefix>/bin and <prefix>/libexec/privateheaderkit (default: ~/.local)
       --dry-run       Print actions without copying files
       -h, --help      Show this help
 
@@ -127,13 +149,30 @@ func parseOptions(_ args: [String], environment: [String: String]) throws -> Ins
 }
 
 func resolveBinDir(prefix: String?, bindir: String?) -> URL {
+    resolveInstallLayout(prefix: prefix, bindir: bindir).binDir
+}
+
+func resolveInstallLayout(prefix: String?, bindir: String?) -> InstallLayout {
+    let resolvedPrefix = resolveInstallPrefix(prefix: prefix, bindir: bindir)
+    let binDir: URL
     if let bindir {
-        return URL(fileURLWithPath: PathUtils.expandTilde(bindir), isDirectory: true)
+        binDir = URL(fileURLWithPath: PathUtils.expandTilde(bindir), isDirectory: true)
+    } else {
+        binDir = resolvedPrefix.appendingPathComponent("bin", isDirectory: true)
+    }
+    let libexecDir = resolvedPrefix
+        .appendingPathComponent("libexec", isDirectory: true)
+        .appendingPathComponent("privateheaderkit", isDirectory: true)
+    return InstallLayout(prefix: resolvedPrefix, binDir: binDir, libexecDir: libexecDir)
+}
+
+private func resolveInstallPrefix(prefix: String?, bindir: String?) -> URL {
+    if let bindir {
+        let binDir = URL(fileURLWithPath: PathUtils.expandTilde(bindir), isDirectory: true)
+        return binDir.deletingLastPathComponent()
     }
     let defaultPrefix = prefix ?? "\(NSHomeDirectory())/.local"
-    let expandedPrefix = PathUtils.expandTilde(defaultPrefix)
-    return URL(fileURLWithPath: expandedPrefix, isDirectory: true)
-        .appendingPathComponent("bin", isDirectory: true)
+    return URL(fileURLWithPath: PathUtils.expandTilde(defaultPrefix), isDirectory: true)
 }
 
 private func logError(_ message: String) {
@@ -167,9 +206,64 @@ func buildProducts(_ products: [String], in directory: URL, runner: CommandRunni
     }
 }
 
-func resolveSwiftBinDir(repoRoot: URL, runner: CommandRunning) -> URL? {
+func buildSimulatorHelper(in directory: URL, runner: CommandRunning) throws {
+    let sdkPath = try resolveSimulatorSDKPath(runner: runner)
+    try buildSimulatorHelper(in: directory, sdkPath: sdkPath, runner: runner)
+}
+
+func buildSimulatorHelper(in directory: URL, sdkPath: String, runner: CommandRunning) throws {
+    try runner.runSimple(
+        [
+            "swift",
+            "build",
+            "-c",
+            "release",
+            "--sdk",
+            sdkPath,
+            "--triple",
+            InstallConstants.simulatorHelperTriple,
+            "--product",
+            InstallConstants.simulatorHelperBuildProductName,
+        ],
+        env: InstallConstants.simulatorHelperBuildEnvironment,
+        cwd: directory
+    )
+}
+
+func resolveSimulatorSDKPath(runner: CommandRunning) throws -> String {
+    let output = try runner.runCapture(
+        ["xcrun", "--sdk", "iphonesimulator", "--show-sdk-path"],
+        env: nil,
+        cwd: nil
+    )
+    let path = output
+        .split(separator: "\n")
+        .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+        .reversed()
+        .first(where: { !$0.isEmpty }) ?? ""
+    guard !path.isEmpty else {
+        throw InstallError.message("failed to resolve iPhone Simulator SDK path")
+    }
+    return path
+}
+
+func resolveSwiftBinDir(
+    repoRoot: URL,
+    runner: CommandRunning,
+    triple: String? = nil,
+    sdkPath: String? = nil,
+    env: [String: String]? = nil
+) -> URL? {
     // `swift build --show-bin-path` prints a single path line, but be defensive and pick the last non-empty line.
-    guard let output = try? runner.runCapture(["swift", "build", "-c", "release", "--show-bin-path"], env: nil, cwd: repoRoot) else {
+    var command = ["swift", "build", "-c", "release"]
+    if let sdkPath {
+        command += ["--sdk", sdkPath]
+    }
+    if let triple {
+        command += ["--triple", triple]
+    }
+    command.append("--show-bin-path")
+    guard let output = try? runner.runCapture(command, env: env, cwd: repoRoot) else {
         return nil
     }
     let path = output
@@ -185,28 +279,42 @@ private func install(options: InstallOptions) throws {
     guard let selfURL = Bundle.main.executableURL else {
         throw InstallError.message("failed to locate installer executable")
     }
+    try install(
+        options: options,
+        selfURL: selfURL,
+        currentDirectoryURL: URL(fileURLWithPath: FileManager.default.currentDirectoryPath, isDirectory: true),
+        runner: ProcessRunner(),
+        fileManager: .default,
+        outputLogger: { print($0) },
+        errorLogger: logError
+    )
+}
+
+func install(
+    options: InstallOptions,
+    selfURL: URL,
+    currentDirectoryURL: URL,
+    runner: CommandRunning,
+    fileManager: FileManager,
+    outputLogger: (String) -> Void,
+    errorLogger: (String) -> Void
+) throws {
     let baseURL = selfURL.deletingLastPathComponent()
-    let fileManager = FileManager.default
 
-    let binDir = resolveBinDir(prefix: options.prefix, bindir: options.bindir)
-
-    // The rewrite exposes a single user-facing command. Low-level dump helpers stay internal.
-    let installedBinaries = ["privateheaderkit"]
+    let layout = resolveInstallLayout(prefix: options.prefix, bindir: options.bindir)
 
     if options.dryRun {
-        print("Would create: \(binDir.path)")
-        for name in installedBinaries {
-            print("Would install: \(binDir.appendingPathComponent(name).path)")
+        for line in dryRunInstallMessages(layout: layout) {
+            outputLogger(line)
         }
         return
     }
 
-    try fileManager.createDirectory(at: binDir, withIntermediateDirectories: true)
+    try fileManager.createDirectory(at: layout.binDir, withIntermediateDirectories: true)
+    try fileManager.createDirectory(at: layout.libexecDir, withIntermediateDirectories: true)
 
-    let runner = ProcessRunner()
-    let cwdURL = URL(fileURLWithPath: FileManager.default.currentDirectoryPath, isDirectory: true)
     let repoRootFromSelf = repositoryRoot(from: selfURL)
-    let repoRootFromCwd = PathUtils.findRepositoryRoot(startingAt: cwdURL)
+    let repoRootFromCwd = PathUtils.findRepositoryRoot(startingAt: currentDirectoryURL)
     let repoRoot: URL?
     if let root = repoRootFromSelf, looksLikePrivateHeaderKitRepo(root, fileManager: fileManager) {
         repoRoot = root
@@ -215,17 +323,21 @@ private func install(options: InstallOptions) throws {
     } else {
         // If invoked from some other package's directory, skip building and install from existing binaries.
         if repoRootFromCwd != nil {
-            logError("warning: ignoring Package.swift found in current directory (not PrivateHeaderKit)")
+            errorLogger("warning: ignoring Package.swift found in current directory (not PrivateHeaderKit)")
         }
         repoRoot = nil
     }
 
+    var simulatorSDKPath: String?
     if let repoRoot {
-        // Always build the installed product when possible, so users get the latest binary after pulling updates.
+        // Always build install artifacts when possible, so users get the latest binaries after pulling updates.
         do {
-            try buildProducts(installedBinaries, in: repoRoot, runner: runner)
+            try buildProducts([InstallConstants.publicCommandName], in: repoRoot, runner: runner)
+            let sdkPath = try resolveSimulatorSDKPath(runner: runner)
+            simulatorSDKPath = sdkPath
+            try buildSimulatorHelper(in: repoRoot, sdkPath: sdkPath, runner: runner)
         } catch {
-            logError("warning: swift build failed: \(error)")
+            errorLogger("warning: swift build failed: \(error)")
         }
     }
 
@@ -236,24 +348,83 @@ private func install(options: InstallOptions) throws {
         hostBinaryDir = baseURL
     }
 
-    for name in installedBinaries {
-        let sourceURL = hostBinaryDir.appendingPathComponent(name)
-        guard fileManager.fileExists(atPath: sourceURL.path) else {
-            throw InstallError.message("\(name) not found next to installer (run with `swift run -c release` from the repo root)")
-        }
-        let destinationURL = binDir.appendingPathComponent(name)
-        if sourceURL.resolvingSymlinksInPath().path == destinationURL.resolvingSymlinksInPath().path {
-            try fileManager.setAttributes([.posixPermissions: 0o755], ofItemAtPath: destinationURL.path)
-            print("Already installed \(name) at \(destinationURL.path)")
-            continue
-        }
-        if fileManager.fileExists(atPath: destinationURL.path) {
-            try fileManager.removeItem(at: destinationURL)
-        }
-        try fileManager.copyItem(at: sourceURL, to: destinationURL)
-        try fileManager.setAttributes([.posixPermissions: 0o755], ofItemAtPath: destinationURL.path)
-        print("Installed \(name) to \(destinationURL.path)")
+    let simulatorHelperSourceURL: URL
+    if let repoRoot {
+        let sdkPath = simulatorSDKPath ?? (try? resolveSimulatorSDKPath(runner: runner))
+        let simulatorBinaryDir = resolveSwiftBinDir(
+            repoRoot: repoRoot,
+            runner: runner,
+            triple: InstallConstants.simulatorHelperTriple,
+            sdkPath: sdkPath,
+            env: InstallConstants.simulatorHelperBuildEnvironment
+        ) ?? baseURL
+        simulatorHelperSourceURL = simulatorBinaryDir.appendingPathComponent(
+            InstallConstants.simulatorHelperBuildProductName,
+            isDirectory: false
+        )
+    } else {
+        simulatorHelperSourceURL = defaultInstalledSimulatorHelperURL(for: selfURL)
     }
+
+    try installExecutableFile(
+        sourceURL: hostBinaryDir.appendingPathComponent(InstallConstants.publicCommandName, isDirectory: false),
+        destinationURL: layout.publicCommandURL,
+        displayName: InstallConstants.publicCommandName,
+        missingMessage: "\(InstallConstants.publicCommandName) not found next to installer (run with `swift run -c release` from the repo root)",
+        fileManager: fileManager,
+        outputLogger: outputLogger
+    )
+    try installExecutableFile(
+        sourceURL: simulatorHelperSourceURL,
+        destinationURL: layout.simulatorHelperURL,
+        displayName: InstallConstants.simulatorHelperInstallName,
+        missingMessage: "\(InstallConstants.simulatorHelperInstallName) not found (run install from the repo root so SwiftPM can build the iOS simulator helper)",
+        fileManager: fileManager,
+        outputLogger: outputLogger
+    )
+}
+
+func dryRunInstallMessages(layout: InstallLayout) -> [String] {
+    [
+        "Would create: \(layout.binDir.path)",
+        "Would create: \(layout.libexecDir.path)",
+        "Would install: \(layout.publicCommandURL.path)",
+        "Would install internal helper: \(layout.simulatorHelperURL.path)",
+    ]
+}
+
+func defaultInstalledSimulatorHelperURL(for executableURL: URL) -> URL {
+    let binDir = executableURL.deletingLastPathComponent()
+    if binDir.lastPathComponent == "bin" {
+        return binDir
+            .deletingLastPathComponent()
+            .appendingPathComponent("libexec/privateheaderkit/privateheaderkit-sim-helper", isDirectory: false)
+    }
+    return binDir.appendingPathComponent("privateheaderkit-sim-helper", isDirectory: false)
+}
+
+private func installExecutableFile(
+    sourceURL: URL,
+    destinationURL: URL,
+    displayName: String,
+    missingMessage: String,
+    fileManager: FileManager,
+    outputLogger: (String) -> Void
+) throws {
+    guard fileManager.fileExists(atPath: sourceURL.path) else {
+        throw InstallError.message(missingMessage)
+    }
+    if sourceURL.resolvingSymlinksInPath().path == destinationURL.resolvingSymlinksInPath().path {
+        try fileManager.setAttributes([.posixPermissions: 0o755], ofItemAtPath: destinationURL.path)
+        outputLogger("Already installed \(displayName) at \(destinationURL.path)")
+        return
+    }
+    if fileManager.fileExists(atPath: destinationURL.path) {
+        try fileManager.removeItem(at: destinationURL)
+    }
+    try fileManager.copyItem(at: sourceURL, to: destinationURL)
+    try fileManager.setAttributes([.posixPermissions: 0o755], ofItemAtPath: destinationURL.path)
+    outputLogger("Installed \(displayName) to \(destinationURL.path)")
 }
 
 #else

--- a/Sources/PrivateHeaderKitInstall/PrivateHeaderKitInstallMain.swift
+++ b/Sources/PrivateHeaderKitInstall/PrivateHeaderKitInstallMain.swift
@@ -34,7 +34,6 @@ enum InstallConstants {
     static let simulatorHelperInstallName = "privateheaderkit-sim-helper"
     static let simulatorHelperBuildProductName = "privateheaderkit-sim-helper"
     static let simulatorHelperTriple = "arm64-apple-ios-simulator"
-    static let simulatorHelperBuildEnvironment = ["PHK_SIMULATOR_HELPER_BUILD": "1"]
 }
 
 enum InstallError: Error, CustomStringConvertible {
@@ -225,7 +224,7 @@ func buildSimulatorHelper(in directory: URL, sdkPath: String, runner: CommandRun
             "--product",
             InstallConstants.simulatorHelperBuildProductName,
         ],
-        env: InstallConstants.simulatorHelperBuildEnvironment,
+        env: nil,
         cwd: directory
     )
 }
@@ -355,8 +354,7 @@ func install(
             repoRoot: repoRoot,
             runner: runner,
             triple: InstallConstants.simulatorHelperTriple,
-            sdkPath: sdkPath,
-            env: InstallConstants.simulatorHelperBuildEnvironment
+            sdkPath: sdkPath
         ) ?? baseURL
         simulatorHelperSourceURL = simulatorBinaryDir.appendingPathComponent(
             InstallConstants.simulatorHelperBuildProductName,

--- a/Sources/PrivateHeaderKitRawDumpCore/PrivateHeaderKitRawDumpMain.swift
+++ b/Sources/PrivateHeaderKitRawDumpCore/PrivateHeaderKitRawDumpMain.swift
@@ -3,8 +3,9 @@ import Dispatch
 import MachOKit
 import MachOObjCSection
 import ObjCDump
-import MachOSwiftSection
+#if canImport(SwiftInterface)
 @_spi(Support) import SwiftInterface
+#endif
 #if canImport(Darwin)
 import Darwin
 #elseif canImport(Glibc)
@@ -31,6 +32,7 @@ protocol SwiftInterfaceBuildingFactory {
 }
 
 struct DefaultSwiftInterfaceBuilderFactory: SwiftInterfaceBuildingFactory {
+    #if canImport(SwiftInterface)
     let configuration: SwiftInterfaceBuilderConfiguration
     let eventHandlers: [SwiftInterfaceEvents.Handler]
 
@@ -49,8 +51,16 @@ struct DefaultSwiftInterfaceBuilderFactory: SwiftInterfaceBuildingFactory {
             eventHandlers: eventHandlers
         )
     }
+    #else
+    init() {}
+
+    func makeBuilder(machO _: MachOFile) throws -> SwiftInterfaceBuilding {
+        throw SwiftInterfaceUnavailableError()
+    }
+    #endif
 }
 
+#if canImport(SwiftInterface)
 struct SwiftInterfaceBuilderAdapter: SwiftInterfaceBuilding {
     private let builder: SwiftInterfaceBuilder<MachOFile>
 
@@ -70,6 +80,9 @@ struct SwiftInterfaceBuilderAdapter: SwiftInterfaceBuilding {
         try await builder.printRoot().string
     }
 }
+#endif
+
+private struct SwiftInterfaceUnavailableError: Error {}
 
 struct DumpOptions {
     var outputDir: URL
@@ -378,24 +391,32 @@ private func dumpImage(
     try dumpObjC(machO: machO, imagePath: originalPath, outputDir: outputDir, options: options, fileManager: fileManager)
     profileLogDuration(enabled: options.profile, imagePath: originalPath, name: "dumpObjC", since: objcStart)
 
-    let swiftFactory: SwiftInterfaceBuildingFactory
-    if options.logSwiftEvents {
-        let moduleName = URL(fileURLWithPath: originalPath).lastPathComponent
-        swiftFactory = DefaultSwiftInterfaceBuilderFactory(
-            eventHandlers: [SwiftInterfaceTimingHandler(label: moduleName)]
-        )
-    } else {
-        swiftFactory = DefaultSwiftInterfaceBuilderFactory()
-    }
-
     try await dumpSwift(
         machO: machO,
         imagePath: originalPath,
         outputDir: outputDir,
         options: options,
-        interfaceBuilderFactory: swiftFactory,
+        interfaceBuilderFactory: defaultSwiftInterfaceBuilderFactory(
+            imagePath: originalPath,
+            options: options
+        ),
         fileManager: fileManager
     )
+}
+
+private func defaultSwiftInterfaceBuilderFactory(
+    imagePath: String,
+    options: DumpOptions
+) -> SwiftInterfaceBuildingFactory {
+    #if canImport(SwiftInterface)
+    if options.logSwiftEvents {
+        let moduleName = URL(fileURLWithPath: imagePath).lastPathComponent
+        return DefaultSwiftInterfaceBuilderFactory(
+            eventHandlers: [SwiftInterfaceTimingHandler(label: moduleName)]
+        )
+    }
+    #endif
+    return DefaultSwiftInterfaceBuilderFactory()
 }
 
 private func loadMachOFile(url: URL, options: DumpOptions) -> MachOFile? {
@@ -719,6 +740,7 @@ private func profileLogDuration(
     fputs("privateheaderkit __raw-dump: profile \(name) \(secondsText) \(imagePath)\n", stderr)
 }
 
+#if canImport(SwiftInterface)
 private final class SwiftInterfaceTimingHandler: SwiftInterfaceEvents.Handler {
     private struct OpKey: Hashable {
         let phase: SwiftInterfaceEvents.Phase
@@ -912,6 +934,7 @@ private final class SwiftInterfaceTimingHandler: SwiftInterfaceEvents.Handler {
         }
     }
 }
+#endif
 
 private struct PendingObjCHeaderFileName {
     let entry: ObjCHeaderEntry
@@ -1356,6 +1379,9 @@ func dumpSwift(
     interfaceBuilderFactory: SwiftInterfaceBuildingFactory = DefaultSwiftInterfaceBuilderFactory(),
     fileManager: FileManager
 ) async throws {
+    #if !canImport(SwiftInterface)
+    return
+    #else
     if shouldSkipSwiftInterface(imagePath: imagePath, outputDir: outputDir, options: options, fileManager: fileManager) {
         return
     }
@@ -1376,6 +1402,7 @@ func dumpSwift(
             return text
         }
     )
+    #endif
 }
 
 func swiftInterfaceOutputURL(imagePath: String, outputDir: URL) -> URL {

--- a/Sources/PrivateHeaderKitRawDumpCore/PrivateHeaderKitRawDumpMain.swift
+++ b/Sources/PrivateHeaderKitRawDumpCore/PrivateHeaderKitRawDumpMain.swift
@@ -3,9 +3,7 @@ import Dispatch
 import MachOKit
 import MachOObjCSection
 import ObjCDump
-#if canImport(SwiftInterface)
 @_spi(Support) import SwiftInterface
-#endif
 #if canImport(Darwin)
 import Darwin
 #elseif canImport(Glibc)
@@ -32,7 +30,6 @@ protocol SwiftInterfaceBuildingFactory {
 }
 
 struct DefaultSwiftInterfaceBuilderFactory: SwiftInterfaceBuildingFactory {
-    #if canImport(SwiftInterface)
     let configuration: SwiftInterfaceBuilderConfiguration
     let eventHandlers: [SwiftInterfaceEvents.Handler]
 
@@ -51,16 +48,8 @@ struct DefaultSwiftInterfaceBuilderFactory: SwiftInterfaceBuildingFactory {
             eventHandlers: eventHandlers
         )
     }
-    #else
-    init() {}
-
-    func makeBuilder(machO _: MachOFile) throws -> SwiftInterfaceBuilding {
-        throw SwiftInterfaceUnavailableError()
-    }
-    #endif
 }
 
-#if canImport(SwiftInterface)
 struct SwiftInterfaceBuilderAdapter: SwiftInterfaceBuilding {
     private let builder: SwiftInterfaceBuilder<MachOFile>
 
@@ -80,9 +69,6 @@ struct SwiftInterfaceBuilderAdapter: SwiftInterfaceBuilding {
         try await builder.printRoot().string
     }
 }
-#endif
-
-private struct SwiftInterfaceUnavailableError: Error {}
 
 struct DumpOptions {
     var outputDir: URL
@@ -408,14 +394,12 @@ private func defaultSwiftInterfaceBuilderFactory(
     imagePath: String,
     options: DumpOptions
 ) -> SwiftInterfaceBuildingFactory {
-    #if canImport(SwiftInterface)
     if options.logSwiftEvents {
         let moduleName = URL(fileURLWithPath: imagePath).lastPathComponent
         return DefaultSwiftInterfaceBuilderFactory(
             eventHandlers: [SwiftInterfaceTimingHandler(label: moduleName)]
         )
     }
-    #endif
     return DefaultSwiftInterfaceBuilderFactory()
 }
 
@@ -740,7 +724,6 @@ private func profileLogDuration(
     fputs("privateheaderkit __raw-dump: profile \(name) \(secondsText) \(imagePath)\n", stderr)
 }
 
-#if canImport(SwiftInterface)
 private final class SwiftInterfaceTimingHandler: SwiftInterfaceEvents.Handler {
     private struct OpKey: Hashable {
         let phase: SwiftInterfaceEvents.Phase
@@ -934,7 +917,6 @@ private final class SwiftInterfaceTimingHandler: SwiftInterfaceEvents.Handler {
         }
     }
 }
-#endif
 
 private struct PendingObjCHeaderFileName {
     let entry: ObjCHeaderEntry
@@ -1379,9 +1361,6 @@ func dumpSwift(
     interfaceBuilderFactory: SwiftInterfaceBuildingFactory = DefaultSwiftInterfaceBuilderFactory(),
     fileManager: FileManager
 ) async throws {
-    #if !canImport(SwiftInterface)
-    return
-    #else
     if shouldSkipSwiftInterface(imagePath: imagePath, outputDir: outputDir, options: options, fileManager: fileManager) {
         return
     }
@@ -1402,7 +1381,6 @@ func dumpSwift(
             return text
         }
     )
-    #endif
 }
 
 func swiftInterfaceOutputURL(imagePath: String, outputDir: URL) -> URL {
@@ -1447,6 +1425,7 @@ func dumpSwiftInterface(
         if options.verbose {
             fputs("Swift interface generation failed for \(imagePath): \(error)\n", stderr)
         }
+        throw error
     }
 }
 

--- a/Sources/PrivateHeaderKitSimulatorHelper/main.swift
+++ b/Sources/PrivateHeaderKitSimulatorHelper/main.swift
@@ -1,0 +1,12 @@
+import PrivateHeaderKitRawDumpCore
+
+@main
+struct PrivateHeaderKitSimulatorHelperMain {
+    static func main() async {
+        var arguments = Array(CommandLine.arguments.dropFirst())
+        if arguments.first == "__raw-dump" {
+            arguments.removeFirst()
+        }
+        await PrivateHeaderKitRawDumpCLI.main(arguments: arguments)
+    }
+}

--- a/Sources/PrivateHeaderKitTooling/Simctl.swift
+++ b/Sources/PrivateHeaderKitTooling/Simctl.swift
@@ -1,10 +1,53 @@
 import Foundation
 
+public struct DeviceTypeInfo: Codable, Equatable, Sendable {
+    public let name: String?
+    public let identifier: String?
+    public let productFamily: String?
+    public let minRuntimeVersionString: String?
+    public let maxRuntimeVersionString: String?
+    public let minRuntimeVersion: Int?
+    public let maxRuntimeVersion: Int?
+
+    public init(
+        name: String?,
+        identifier: String?,
+        productFamily: String?,
+        minRuntimeVersionString: String? = nil,
+        maxRuntimeVersionString: String? = nil,
+        minRuntimeVersion: Int? = nil,
+        maxRuntimeVersion: Int? = nil
+    ) {
+        self.name = name
+        self.identifier = identifier
+        self.productFamily = productFamily
+        self.minRuntimeVersionString = minRuntimeVersionString
+        self.maxRuntimeVersionString = maxRuntimeVersionString
+        self.minRuntimeVersion = minRuntimeVersion
+        self.maxRuntimeVersion = maxRuntimeVersion
+    }
+}
+
 public struct RuntimeInfo: Codable, Equatable, Sendable {
     public let version: String
     public let build: String
     public let identifier: String
     public let runtimeRoot: String
+    public let supportedDeviceTypes: [DeviceTypeInfo]
+
+    public init(
+        version: String,
+        build: String,
+        identifier: String,
+        runtimeRoot: String,
+        supportedDeviceTypes: [DeviceTypeInfo] = []
+    ) {
+        self.version = version
+        self.build = build
+        self.identifier = identifier
+        self.runtimeRoot = runtimeRoot
+        self.supportedDeviceTypes = supportedDeviceTypes
+    }
 }
 
 public struct DeviceInfo: Codable, Equatable, Sendable {
@@ -26,6 +69,7 @@ public enum Simctl {
             let runtimeRoot: String?
             let isAvailable: Bool?
             let buildversion: String?
+            let supportedDeviceTypes: [DeviceTypeInfo]?
         }
         let runtimes: [RuntimeEntry]?
     }
@@ -40,12 +84,7 @@ public enum Simctl {
     }
 
     private struct DeviceTypesList: Decodable {
-        struct DeviceTypeEntry: Decodable {
-            let name: String?
-            let identifier: String?
-            let productFamily: String?
-        }
-        let devicetypes: [DeviceTypeEntry]?
+        let devicetypes: [DeviceTypeInfo]?
     }
 
     public static func listRuntimes(runner: CommandRunning) throws -> [RuntimeInfo] {
@@ -62,7 +101,15 @@ public enum Simctl {
             guard let identifier = entry.identifier, !identifier.isEmpty else { continue }
             guard let runtimeRoot = entry.runtimeRoot, !runtimeRoot.isEmpty else { continue }
             let build = entry.buildversion ?? ""
-            results.append(RuntimeInfo(version: version, build: build, identifier: identifier, runtimeRoot: runtimeRoot))
+            results.append(
+                RuntimeInfo(
+                    version: version,
+                    build: build,
+                    identifier: identifier,
+                    runtimeRoot: runtimeRoot,
+                    supportedDeviceTypes: entry.supportedDeviceTypes ?? []
+                )
+            )
         }
 
         results.sort { VersionUtils.versionKey($0.version).lexicographicallyPrecedes(VersionUtils.versionKey($1.version)) }
@@ -168,10 +215,15 @@ public enum Simctl {
         return try cloneDevice(base: base, runtimeId: runtime.identifier, cloneName: cloneName, runner: runner)
     }
 
-    public static func resolveDevice(runtime: RuntimeInfo, query: String?, runner: CommandRunning) throws -> DeviceInfo {
+    public static func resolveDevice(
+        runtime: RuntimeInfo,
+        query: String?,
+        runner: CommandRunning,
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) throws -> DeviceInfo {
         var devices = try listDevices(runtimeId: runtime.identifier, runner: runner)
         if devices.isEmpty {
-            try createDefaultDevice(runtimeId: runtime.identifier, version: runtime.version, runner: runner)
+            try createDefaultDevice(runtime: runtime, runner: runner, environment: environment)
             devices = try listDevices(runtimeId: runtime.identifier, runner: runner)
         }
 
@@ -198,19 +250,33 @@ public enum Simctl {
         device.state = "Booted"
     }
 
-    public static func createDefaultDevice(runtimeId: String, version: String, runner: CommandRunning) throws {
-        let output = try runner.runCapture(["xcrun", "simctl", "list", "devicetypes", "-j"], env: nil, cwd: nil)
-        let data = Data(output.utf8)
-        let decoded = try JSONDecoder().decode(DeviceTypesList.self, from: data)
-        let deviceTypes = decoded.devicetypes ?? []
+    public static func createDefaultDevice(
+        runtimeId: String,
+        version: String,
+        runner: CommandRunning,
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) throws {
+        try createDefaultDevice(
+            runtime: RuntimeInfo(version: version, build: "", identifier: runtimeId, runtimeRoot: ""),
+            runner: runner,
+            environment: environment
+        )
+    }
 
-        func matchesEnv(_ entry: DeviceTypesList.DeviceTypeEntry, needle: String) -> Bool {
+    public static func createDefaultDevice(
+        runtime: RuntimeInfo,
+        runner: CommandRunning,
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) throws {
+        let deviceTypes = try defaultDeviceTypeCandidates(for: runtime, runner: runner)
+
+        func matchesEnv(_ entry: DeviceTypeInfo, needle: String) -> Bool {
             if entry.identifier == needle || entry.name == needle { return true }
             return (entry.identifier ?? "").lowercased() == needle.lowercased() || (entry.name ?? "").lowercased() == needle.lowercased()
         }
 
-        var choice: DeviceTypesList.DeviceTypeEntry?
-        if let envType = ProcessInfo.processInfo.environment["PH_DEVICE_TYPE"]?.trimmingCharacters(in: .whitespacesAndNewlines),
+        var choice: DeviceTypeInfo?
+        if let envType = environment["PH_DEVICE_TYPE"]?.trimmingCharacters(in: .whitespacesAndNewlines),
            !envType.isEmpty {
             choice = deviceTypes.first(where: { matchesEnv($0, needle: envType) })
             if choice == nil {
@@ -224,6 +290,9 @@ public enum Simctl {
         if choice == nil {
             choice = deviceTypes.first(where: { ($0.name ?? "").hasPrefix("iPhone") })
         }
+        if choice == nil {
+            choice = deviceTypes.first
+        }
         guard let picked = choice,
               let deviceName = picked.name, !deviceName.isEmpty,
               let deviceType = picked.identifier, !deviceType.isEmpty
@@ -231,8 +300,64 @@ public enum Simctl {
             throw ToolingError.message("no device types available")
         }
 
-        let createdName = "\(deviceName) (\(version))"
+        let createdName = "\(deviceName) (\(runtime.version))"
         print("Creating device: \(createdName)")
-        try runner.runSimple(["xcrun", "simctl", "create", createdName, deviceType, runtimeId], env: nil, cwd: nil)
+        try runner.runSimple(["xcrun", "simctl", "create", createdName, deviceType, runtime.identifier], env: nil, cwd: nil)
+    }
+
+    private static func defaultDeviceTypeCandidates(for runtime: RuntimeInfo, runner: CommandRunning) throws -> [DeviceTypeInfo] {
+        if !runtime.supportedDeviceTypes.isEmpty {
+            return runtime.supportedDeviceTypes
+        }
+
+        let output = try runner.runCapture(["xcrun", "simctl", "list", "devicetypes", "-j"], env: nil, cwd: nil)
+        let data = Data(output.utf8)
+        let decoded = try JSONDecoder().decode(DeviceTypesList.self, from: data)
+        let deviceTypes = decoded.devicetypes ?? []
+        return compatibleDeviceTypes(from: deviceTypes, runtime: runtime) ?? deviceTypes
+    }
+
+    private static func compatibleDeviceTypes(from deviceTypes: [DeviceTypeInfo], runtime: RuntimeInfo) -> [DeviceTypeInfo]? {
+        let hasRuntimeMetadata = deviceTypes.contains { deviceType in
+            hasText(deviceType.minRuntimeVersionString) || hasText(deviceType.maxRuntimeVersionString)
+        }
+        guard hasRuntimeMetadata else {
+            return nil
+        }
+        return deviceTypes.filter { supports(runtime: runtime, deviceType: $0) }
+    }
+
+    private static func supports(runtime: RuntimeInfo, deviceType: DeviceTypeInfo) -> Bool {
+        if let min = normalizedVersionString(deviceType.minRuntimeVersionString),
+           compareVersionStrings(runtime.version, min) == .orderedAscending {
+            return false
+        }
+        if let max = normalizedVersionString(deviceType.maxRuntimeVersionString),
+           compareVersionStrings(runtime.version, max) == .orderedDescending {
+            return false
+        }
+        return true
+    }
+
+    private static func normalizedVersionString(_ value: String?) -> String? {
+        let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private static func hasText(_ value: String?) -> Bool {
+        normalizedVersionString(value) != nil
+    }
+
+    private static func compareVersionStrings(_ lhs: String, _ rhs: String) -> ComparisonResult {
+        let left = VersionUtils.versionKey(lhs)
+        let right = VersionUtils.versionKey(rhs)
+        let count = max(left.count, right.count)
+        for index in 0..<count {
+            let leftValue = index < left.count ? left[index] : 0
+            let rightValue = index < right.count ? right[index] : 0
+            if leftValue < rightValue { return .orderedAscending }
+            if leftValue > rightValue { return .orderedDescending }
+        }
+        return .orderedSame
     }
 }

--- a/Sources/PrivateHeaderKitTooling/Simctl.swift
+++ b/Sources/PrivateHeaderKitTooling/Simctl.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-public struct RuntimeInfo: Codable, Equatable {
+public struct RuntimeInfo: Codable, Equatable, Sendable {
     public let version: String
     public let build: String
     public let identifier: String
     public let runtimeRoot: String
 }
 
-public struct DeviceInfo: Codable, Equatable {
+public struct DeviceInfo: Codable, Equatable, Sendable {
     public let name: String
     public let udid: String
     public var state: String
@@ -74,6 +74,21 @@ public enum Simctl {
             return runtime
         }
         throw ToolingError.message("iOS runtime not found or unavailable: \(version)")
+    }
+
+    public static func findRuntime(version: String, build: String?, runner: CommandRunning) throws -> RuntimeInfo {
+        let matches = try listRuntimes(runner: runner).filter { $0.version == version }
+        guard !matches.isEmpty else {
+            throw ToolingError.message("iOS runtime not found or unavailable: \(version)")
+        }
+
+        guard let build, !build.isEmpty else {
+            return matches[0]
+        }
+        if let match = matches.first(where: { $0.build == build }) {
+            return match
+        }
+        throw ToolingError.message("iOS runtime not found or unavailable: \(version) (\(build))")
     }
 
     public static func latestRuntime(runner: CommandRunning) throws -> RuntimeInfo {
@@ -153,8 +168,30 @@ public enum Simctl {
         return try cloneDevice(base: base, runtimeId: runtime.identifier, cloneName: cloneName, runner: runner)
     }
 
+    public static func resolveDevice(runtime: RuntimeInfo, query: String?, runner: CommandRunning) throws -> DeviceInfo {
+        var devices = try listDevices(runtimeId: runtime.identifier, runner: runner)
+        if devices.isEmpty {
+            try createDefaultDevice(runtimeId: runtime.identifier, version: runtime.version, runner: runner)
+            devices = try listDevices(runtimeId: runtime.identifier, runner: runner)
+        }
+
+        let selected: DeviceInfo
+        if let query = query?.trimmingCharacters(in: .whitespacesAndNewlines), !query.isEmpty {
+            guard let match = matchDevice(devices: devices, query: query) else {
+                throw ToolingError.message("simulator device not found for iOS \(runtime.version): \(query)")
+            }
+            selected = match
+        } else {
+            selected = try resolveDefaultDevice(runtime: runtime, devices: devices, runner: runner)
+        }
+
+        var booted = selected
+        try ensureDeviceBooted(&booted, runner: runner, force: false)
+        return booted
+    }
+
     public static func ensureDeviceBooted(_ device: inout DeviceInfo, runner: CommandRunning, force: Bool) throws {
-        if device.state == "Booted", !force { return }
+        if stateEquals(device.state, "Booted"), !force { return }
         print("Booting simulator: \(device.name) (\(device.udid))")
         try runner.runSimple(["xcrun", "simctl", "boot", device.udid], env: nil, cwd: nil)
         try runner.runSimple(["xcrun", "simctl", "bootstatus", device.udid, "-b"], env: nil, cwd: nil)

--- a/Tests/PrivateHeaderKitCLITests/PrivateHeaderKitCLITests.swift
+++ b/Tests/PrivateHeaderKitCLITests/PrivateHeaderKitCLITests.swift
@@ -55,7 +55,9 @@ struct PrivateHeaderKitCLIParsingTests {
                     systemRoot: "/tmp/RuntimeRoot",
                     outputBaseDirectory: "/tmp/PrivateHeaderKit",
                     targetQuery: "SwiftUI,UIKit",
-                    resume: false
+                    resume: false,
+                    device: nil,
+                    simulatorHelperPath: nil
                 )
             )
         )
@@ -85,7 +87,45 @@ struct PrivateHeaderKitCLIParsingTests {
                     systemRoot: "/",
                     outputBaseDirectory: "/tmp/PrivateHeaderKit",
                     targetQuery: "AppKit,Foundation",
-                    resume: true
+                    resume: true,
+                    device: nil,
+                    simulatorHelperPath: nil
+                )
+            )
+        )
+    }
+
+    @Test func generateParsesIOSInputWithoutSystemRootAndOptionalSimulatorFlags() throws {
+        #expect(
+            try parsePrivateHeaderKitCommand([
+                "privateheaderkit",
+                "generate",
+                "--platform",
+                "iOS",
+                "--version",
+                "27.0",
+                "--build",
+                "24A5355q",
+                "--out",
+                "/tmp/PrivateHeaderKit",
+                "--target",
+                "SwiftUI,UIKit",
+                "--device",
+                "SIM-001",
+                "--sim-helper",
+                "/opt/privateheaderkit/libexec/privateheaderkit/privateheaderkit-sim-helper",
+            ])
+            == .generate(
+                PrivateHeaderKitGenerateCommand(
+                    platform: .iOS,
+                    version: "27.0",
+                    build: "24A5355q",
+                    systemRoot: nil,
+                    outputBaseDirectory: "/tmp/PrivateHeaderKit",
+                    targetQuery: "SwiftUI,UIKit",
+                    resume: false,
+                    device: "SIM-001",
+                    simulatorHelperPath: "/opt/privateheaderkit/libexec/privateheaderkit/privateheaderkit-sim-helper"
                 )
             )
         )
@@ -126,6 +166,8 @@ struct PrivateHeaderKitCLIParsingTests {
         let usage = privateHeaderKitGenerateUsageText()
         #expect(usage.contains("--platform <iOS|macOS>"))
         #expect(usage.contains("--target <query>"))
+        #expect(usage.contains("--device <name-or-udid>"))
+        #expect(usage.contains("--sim-helper <path>"))
         #expect(!usage.contains("__raw-dump"))
     }
 
@@ -170,6 +212,28 @@ struct PrivateHeaderKitCLIParsingTests {
             Issue.record("expected missing target query to be rejected")
         } catch let error as PrivateHeaderKitCLIError {
             #expect(error == .missingRequiredOption("--target"))
+        } catch {
+            Issue.record("unexpected error: \(error)")
+        }
+    }
+
+    @Test func generateRejectsMissingMacOSSystemRoot() throws {
+        do {
+            _ = try parsePrivateHeaderKitCommand([
+                "privateheaderkit",
+                "generate",
+                "--platform",
+                "macOS",
+                "--version",
+                "16.0",
+                "--out",
+                "/tmp/PrivateHeaderKit",
+                "--target",
+                "AppKit",
+            ])
+            Issue.record("expected missing macOS system root to be rejected")
+        } catch let error as PrivateHeaderKitCLIError {
+            #expect(error == .missingRequiredOption("--system-root"))
         } catch {
             Issue.record("unexpected error: \(error)")
         }
@@ -256,47 +320,61 @@ struct PrivateHeaderKitCLIParsingTests {
     }
 
     @Test func validGenerateRunInvokesGenerationRunnerWithCoreRequestAndPrintsSuccessOutput() async throws {
-        let helperURL = URL(fileURLWithPath: "/tmp/privateheaderkit-test-helper", isDirectory: false)
+        let helperURL = URL(fileURLWithPath: "/opt/privateheaderkit/bin/privateheaderkit", isDirectory: false)
+        let simulatorHelperURL = URL(
+            fileURLWithPath: "/opt/privateheaderkit/libexec/privateheaderkit/privateheaderkit-sim-helper",
+            isDirectory: false
+        )
         let recorder = GenerationRequestRecorder()
         var outputMessages: [String] = []
         var loggedMessages: [String] = []
-        let exitCode = await runPrivateHeaderKitCommand([
-            "privateheaderkit",
-            "generate",
-            "--platform",
-            "iOS",
-            "--version",
-            "27.0",
-            "--build",
-            "24A5355q",
-            "--system-root",
-            "/tmp/RuntimeRoot",
-            "--out",
-            "/tmp/PrivateHeaderKit",
-            "--target",
-            "SwiftUI,UIKit",
-            "--resume",
-        ], currentExecutableURL: helperURL, generationRunner: { request in
-            recorder.request = request
-            return PrivateHeaderKitGenerationSummary(
-                sourceDisplayName: request.sourceDisplayName,
-                artifactDirectory: URL(
-                    fileURLWithPath: "/tmp/PrivateHeaderKit/iOS27.0(24A5355q)",
-                    isDirectory: true
-                ),
-                manifestURL: URL(
-                    fileURLWithPath: "/tmp/PrivateHeaderKit/.state/iOS27.0(24A5355q)/manifest.json",
-                    isDirectory: false
-                ),
-                runRecordURL: URL(
-                    fileURLWithPath: "/tmp/PrivateHeaderKit/.state/iOS27.0(24A5355q)/runs/run-test/run.json",
-                    isDirectory: false
-                ),
-                runID: "run-test",
-                generatedTargetCount: 2,
-                skippedTargetCount: 1
-            )
-        }, outputLogger: { outputMessages.append($0) }, errorLogger: { loggedMessages.append($0) })
+        let exitCode = await runPrivateHeaderKitCommand(
+            [
+                "privateheaderkit",
+                "generate",
+                "--platform",
+                "iOS",
+                "--version",
+                "27.0",
+                "--build",
+                "24A5355q",
+                "--system-root",
+                "/tmp/RuntimeRoot",
+                "--out",
+                "/tmp/PrivateHeaderKit",
+                "--target",
+                "SwiftUI,UIKit",
+                "--resume",
+            ],
+            currentExecutableURL: helperURL,
+            generationRunner: { request in
+                recorder.request = request
+                return PrivateHeaderKitGenerationSummary(
+                    sourceDisplayName: request.sourceDisplayName,
+                    artifactDirectory: URL(
+                        fileURLWithPath: "/tmp/PrivateHeaderKit/iOS27.0(24A5355q)",
+                        isDirectory: true
+                    ),
+                    manifestURL: URL(
+                        fileURLWithPath: "/tmp/PrivateHeaderKit/.state/iOS27.0(24A5355q)/manifest.json",
+                        isDirectory: false
+                    ),
+                    runRecordURL: URL(
+                        fileURLWithPath: "/tmp/PrivateHeaderKit/.state/iOS27.0(24A5355q)/runs/run-test/run.json",
+                        isDirectory: false
+                    ),
+                    runID: "run-test",
+                    generatedTargetCount: 2,
+                    skippedTargetCount: 1
+                )
+            },
+            simulatorResolver: { command in
+                #expect(command.device == nil)
+                return simulatorResolution()
+            },
+            outputLogger: { outputMessages.append($0) },
+            errorLogger: { loggedMessages.append($0) }
+        )
 
         let request = try #require(recorder.request)
         #expect(exitCode == 0)
@@ -309,12 +387,15 @@ struct PrivateHeaderKitCLIParsingTests {
         #expect(request.targetQuery == "SwiftUI,UIKit")
         #expect(request.resumeRequested == true)
         #expect(request.hostHelperURL == helperURL)
-        #expect(request.simulatorHelperURL == helperURL)
-        #expect(request.usesHostExecution)
+        #expect(request.simulatorHelperURL == simulatorHelperURL)
+        #expect(!request.usesHostExecution)
+        #expect(request.simulatorDeviceUDID == "SIM-001")
+        #expect(request.simulatorRuntimeRoot == "/tmp/RuntimeRoot")
         #expect(request.usesSharedCache)
         #expect(request.prefersRuntimeMetadata)
         #expect(request.helperEnvironment == ["PH_RUNTIME_ROOT": "/tmp/RuntimeRoot"])
         #expect(outputMessages == [
+            "selected simulator: iPhone 17 (SIM-001)",
             "private header generation completed",
             "source: iOS 27.0 (24A5355q)",
             "artifact directory: /tmp/PrivateHeaderKit/iOS27.0(24A5355q)",
@@ -323,6 +404,87 @@ struct PrivateHeaderKitCLIParsingTests {
             "run ID: run-test",
             "targets: generated 2, skipped 1",
         ])
+    }
+
+    @Test func iOSGenerateWithoutSystemRootUsesResolvedRuntimeRootAndExplicitSimulatorHelper() async throws {
+        let recorder = GenerationRequestRecorder()
+        let simulatorHelper = "/tmp/privateheaderkit-sim-helper"
+        let exitCode = await runPrivateHeaderKitCommand(
+            [
+                "privateheaderkit",
+                "generate",
+                "--platform",
+                "iOS",
+                "--version",
+                "27.0",
+                "--build",
+                "24A5355q",
+                "--out",
+                "/tmp/PrivateHeaderKit",
+                "--target",
+                "SwiftUI",
+                "--device",
+                "iPhone 17",
+                "--sim-helper",
+                simulatorHelper,
+            ],
+            currentExecutableURL: URL(fileURLWithPath: "/opt/privateheaderkit/bin/privateheaderkit", isDirectory: false),
+            generationRunner: { request in
+                recorder.request = request
+                return summaryFixture(for: request)
+            },
+            simulatorResolver: { command in
+                #expect(command.device == "iPhone 17")
+                return simulatorResolution(resolvedRuntimeRoot: "/Resolved/RuntimeRoot")
+            },
+            outputLogger: { _ in },
+            errorLogger: { _ in }
+        )
+
+        let request = try #require(recorder.request)
+        #expect(exitCode == 0)
+        #expect(request.systemRoot?.path == "/Resolved/RuntimeRoot")
+        #expect(request.simulatorRuntimeRoot == "/Resolved/RuntimeRoot")
+        #expect(request.simulatorHelperURL?.path == simulatorHelper)
+    }
+
+    @Test func macOSGenerateUsesHostExecutionAndDoesNotResolveSimulator() async throws {
+        let helperURL = URL(fileURLWithPath: "/tmp/privateheaderkit", isDirectory: false)
+        let recorder = GenerationRequestRecorder()
+        let exitCode = await runPrivateHeaderKitCommand(
+            [
+                "privateheaderkit",
+                "generate",
+                "--platform",
+                "macOS",
+                "--version",
+                "16.0",
+                "--system-root",
+                "/",
+                "--out",
+                "/tmp/PrivateHeaderKit",
+                "--target",
+                "AppKit",
+            ],
+            currentExecutableURL: helperURL,
+            generationRunner: { request in
+                recorder.request = request
+                return summaryFixture(for: request)
+            },
+            simulatorResolver: { _ in
+                Issue.record("macOS generation should not resolve a simulator")
+                return simulatorResolution()
+            },
+            outputLogger: { _ in },
+            errorLogger: { _ in }
+        )
+
+        let request = try #require(recorder.request)
+        #expect(exitCode == 0)
+        #expect(request.systemRoot?.path == "/")
+        #expect(request.hostHelperURL == helperURL)
+        #expect(request.usesHostExecution)
+        #expect(request.simulatorDeviceUDID == nil)
     }
 
     @Test func generateResumeRequiredErrorReturnsGuidance() async throws {
@@ -336,12 +498,15 @@ struct PrivateHeaderKitCLIParsingTests {
                     try resumeSummaryFixture(latestRunID: "run-previous")
                 )
             },
+            simulatorResolver: { _ in simulatorResolution() },
             outputLogger: { outputMessages.append($0) },
             errorLogger: { loggedMessages.append($0) }
         )
 
         #expect(exitCode == 2)
-        #expect(outputMessages.isEmpty)
+        #expect(outputMessages == [
+            "selected simulator: iPhone 17 (SIM-001)",
+        ])
         #expect(loggedMessages == [
             "error: existing generation state is unfinished; explicit resume is required for run-previous",
             "rerun with `--resume` to continue the unfinished generation state",
@@ -377,6 +542,40 @@ struct PrivateHeaderKitCLIParsingTests {
 
 private final class GenerationRequestRecorder {
     var request: PrivateHeaderKitGenerationRequest?
+}
+
+private func simulatorResolution(
+    resolvedRuntimeRoot: String = "/tmp/RuntimeRoot"
+) -> PrivateHeaderKitSimulatorResolution {
+    PrivateHeaderKitSimulatorResolution(
+        runtimeVersion: "27.0",
+        runtimeBuild: "24A5355q",
+        runtimeIdentifier: "com.apple.CoreSimulator.SimRuntime.iOS-27-0",
+        resolvedRuntimeRoot: resolvedRuntimeRoot,
+        deviceName: "iPhone 17",
+        deviceUDID: "SIM-001"
+    )
+}
+
+private func summaryFixture(
+    for request: PrivateHeaderKitGenerationRequest
+) -> PrivateHeaderKitGenerationSummary {
+    PrivateHeaderKitGenerationSummary(
+        sourceDisplayName: request.sourceDisplayName,
+        artifactDirectory: request.artifactBaseDirectory.appendingPathComponent(
+            request.sourceDirectoryName,
+            isDirectory: true
+        ),
+        manifestURL: request.stateBaseDirectory
+            .appendingPathComponent(request.sourceDirectoryName, isDirectory: true)
+            .appendingPathComponent("manifest.json", isDirectory: false),
+        runRecordURL: request.stateBaseDirectory
+            .appendingPathComponent(request.sourceDirectoryName, isDirectory: true)
+            .appendingPathComponent("runs/run-test/run.json", isDirectory: false),
+        runID: "run-test",
+        generatedTargetCount: 1,
+        skippedTargetCount: nil
+    )
 }
 
 private func validGenerateArguments() -> [String] {

--- a/Tests/PrivateHeaderKitCLITests/PrivateHeaderKitCLITests.swift
+++ b/Tests/PrivateHeaderKitCLITests/PrivateHeaderKitCLITests.swift
@@ -406,6 +406,27 @@ struct PrivateHeaderKitCLIParsingTests {
         ])
     }
 
+    @Test func iOSGenerateDefaultsSimulatorHelperToInstallLayoutForCustomBindir() async throws {
+        let helperURL = URL(fileURLWithPath: "/opt/phk/privateheaderkit", isDirectory: false)
+        let recorder = GenerationRequestRecorder()
+        let exitCode = await runPrivateHeaderKitCommand(
+            validGenerateArguments(),
+            currentExecutableURL: helperURL,
+            generationRunner: { request in
+                recorder.request = request
+                return summaryFixture(for: request)
+            },
+            simulatorResolver: { _ in simulatorResolution() },
+            outputLogger: { _ in },
+            errorLogger: { _ in }
+        )
+
+        let request = try #require(recorder.request)
+        #expect(exitCode == 0)
+        #expect(request.hostHelperURL == helperURL)
+        #expect(request.simulatorHelperURL?.path == "/opt/libexec/privateheaderkit/privateheaderkit-sim-helper")
+    }
+
     @Test func iOSGenerateWithoutSystemRootUsesResolvedRuntimeRootAndExplicitSimulatorHelper() async throws {
         let recorder = GenerationRequestRecorder()
         let simulatorHelper = "/tmp/privateheaderkit-sim-helper"

--- a/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationExecutorTests.swift
+++ b/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationExecutorTests.swift
@@ -298,7 +298,7 @@ struct PrivateHeaderGenerationExecutorTests {
         #expect(run.targetResults.first?.attemptedArtifacts.map(\.rawValue) == expectedArtifacts)
     }
 
-    @Test func simulatorExecutionFailsWhenSwiftInterfaceArtifactIsMissing() async throws {
+    @Test func simulatorExecutionCompletesWhenRawDumpProducesHeaderOnlyArtifacts() async throws {
         let fixture = try ExecutorFixture()
         defer { fixture.remove() }
         try fixture.createFramework("Foo.framework")
@@ -317,21 +317,25 @@ struct PrivateHeaderGenerationExecutorTests {
             dateProvider: fixedDates()
         )
 
-        await #expect(throws: PrivateHeaderGeneration.GenerationError.self) {
-            _ = try await executor.run(.init(plan: plan))
-        }
+        let result = try await executor.run(.init(plan: plan))
 
-        let runURL = plan.stateDirectory.appendingPathComponent("runs/run-001/run.json")
+        let manifest = try PrivateHeaderGeneration.StateJSON.read(
+            PrivateHeaderGeneration.Manifest.self,
+            from: result.manifestURL
+        )
         let run = try PrivateHeaderGeneration.StateJSON.read(
             PrivateHeaderGeneration.RunRecord.self,
-            from: runURL
+            from: result.runRecordURL
         )
         let target = try #require(run.targetResults.first)
         #expect(runner.invocations.map(\.phaseLabel) == ["raw-header-dump"])
-        #expect(target.status == .partial)
-        #expect(target.phases.map(\.name) == ["raw-header-dump"])
-        #expect(target.phases.map(\.status) == [.failed])
-        #expect(target.failureSummary?.contains(".swiftinterface") == true)
+        #expect(target.status == .completed)
+        #expect(target.phases.map(\.name) == ["raw-header-dump", "commit"])
+        #expect(target.phases.map(\.status) == [.completed, .completed])
+        #expect(target.failureSummary == nil)
+        #expect(manifest.targets.first?.artifacts.map(\.rawValue) == [
+            "Frameworks/Foo/Headers/Generated.h",
+        ])
         #expect(target.attemptedArtifacts.map(\.rawValue) == [
             "Frameworks/Foo/Headers/Generated.h",
         ])

--- a/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationExecutorTests.swift
+++ b/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationExecutorTests.swift
@@ -177,7 +177,8 @@ struct PrivateHeaderGenerationExecutorTests {
             result: PrivateHeaderGeneration.RawDumping.Result(
                 terminationStatus: 1,
                 failureSummary: "simulated raw failure"
-            )
+            ),
+            writesArtifacts: false
         )
         let executor = PrivateHeaderGeneration.GenerationExecutor(
             rawDumpRunner: { invocation in try await runner.run(invocation) },
@@ -203,10 +204,58 @@ struct PrivateHeaderGenerationExecutorTests {
         )
 
         #expect(finalText == "old")
-        #expect(manifest.targets.first?.status == .partial)
+        #expect(manifest.targets.first?.status == .failed)
         #expect(manifest.targets.first?.artifacts == [artifact])
-        #expect(run.targetResults.first?.status == .partial)
-        #expect(run.targetResults.first?.attemptedArtifacts.map(\.rawValue) == ["Frameworks/Foo/Headers/Generated.h"])
+        #expect(run.targetResults.first?.status == .failed)
+        #expect(run.targetResults.first?.attemptedArtifacts.isEmpty == true)
+    }
+
+    @Test func rawDumpFailureCommitsStagedArtifactsAsPartial() async throws {
+        let fixture = try ExecutorFixture()
+        defer { fixture.remove() }
+        try fixture.createFramework("Foo.framework")
+
+        let runner = RecordingRawDumpRunner(
+            result: PrivateHeaderGeneration.RawDumping.Result(
+                terminationStatus: 1,
+                failureSummary: "Swift interface generation failed"
+            )
+        )
+        let plan = try fixture.makePlan(targetRequest: .query("Foo"))
+        let executor = PrivateHeaderGeneration.GenerationExecutor(
+            rawDumpRunner: { invocation in try await runner.run(invocation) },
+            runIDGenerator: { "run-001" },
+            dateProvider: fixedDates()
+        )
+
+        await #expect(throws: PrivateHeaderGeneration.GenerationError.self) {
+            _ = try await executor.run(.init(plan: plan))
+        }
+
+        let artifact = try PrivateHeaderGeneration.ArtifactPath("Frameworks/Foo/Headers/Generated.h")
+        let manifest = try PrivateHeaderGeneration.StateJSON.read(
+            PrivateHeaderGeneration.Manifest.self,
+            from: plan.stateDirectory.appendingPathComponent("manifest.json")
+        )
+        let run = try PrivateHeaderGeneration.StateJSON.read(
+            PrivateHeaderGeneration.RunRecord.self,
+            from: plan.stateDirectory.appendingPathComponent("runs/run-001/run.json")
+        )
+        let manifestTarget = try #require(manifest.targets.first)
+        let runTarget = try #require(run.targetResults.first)
+
+        #expect(fileExists(plan.artifactDirectory.appendingPathComponent(artifact.rawValue)))
+        #expect(manifestTarget.status == .partial)
+        #expect(manifestTarget.artifacts == [artifact])
+        #expect(manifestTarget.failureSummary == "Swift interface generation failed")
+        #expect(run.status == .partial)
+        #expect(run.attemptedArtifacts == [artifact])
+        #expect(runTarget.status == .partial)
+        #expect(runTarget.phases.map(\.name) == ["raw-header-dump", "commit"])
+        #expect(runTarget.phases.map(\.status) == [.failed, .completed])
+        #expect(runTarget.artifacts == [artifact])
+        #expect(runTarget.attemptedArtifacts == [artifact])
+        #expect(runTarget.failureSummary == "Swift interface generation failed")
     }
 
     @Test func commitFailedResumeCleansManagedAndAttemptedArtifactsBeforeRerun() async throws {

--- a/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationExecutorTests.swift
+++ b/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationExecutorTests.swift
@@ -247,7 +247,7 @@ struct PrivateHeaderGenerationExecutorTests {
         #expect(fileExists(plan.artifactDirectory.appendingPathComponent("Frameworks/Foo/Headers/Generated.h")))
     }
 
-    @Test func simulatorExecutionUsesRuntimeInputPathAndChildEnvironment() async throws {
+    @Test func simulatorExecutionUsesRuntimeInputPathAndCommitsHeaderAndSwiftInterfaceArtifacts() async throws {
         let fixture = try ExecutorFixture()
         defer { fixture.remove() }
         try fixture.createFramework("Foo.framework")
@@ -267,14 +267,74 @@ struct PrivateHeaderGenerationExecutorTests {
             dateProvider: fixedDates()
         )
 
-        _ = try await executor.run(.init(plan: plan))
+        let result = try await executor.run(.init(plan: plan))
 
         let invocation = try #require(runner.invocations.first)
+        #expect(runner.invocations.count == 1)
+        #expect(invocation.phaseLabel == "raw-header-dump")
         #expect(invocation.inputPath == "/System/Library/Frameworks/Foo.framework")
         #expect(Array(invocation.command.prefix(4)) == ["xcrun", "simctl", "spawn", "SIM-001"])
+        #expect(invocation.command.contains(fixture.helperURLs.simulator.path))
         #expect(invocation.environment["SIMCTL_CHILD_PH_RUNTIME_ROOT"] == fixture.systemRoot.path)
         #expect(invocation.environment["SIMCTL_CHILD_DYLD_ROOT_PATH"] == fixture.systemRoot.path)
         #expect(invocation.environment["SIMCTL_CHILD_PH_PROFILE"] == "1")
+
+        let expectedArtifacts = [
+            "Frameworks/Foo/Headers/Foo.swiftinterface",
+            "Frameworks/Foo/Headers/Generated.h",
+        ]
+        #expect(fileExists(plan.artifactDirectory.appendingPathComponent("Frameworks/Foo/Headers/Generated.h")))
+        #expect(fileExists(plan.artifactDirectory.appendingPathComponent("Frameworks/Foo/Headers/Foo.swiftinterface")))
+
+        let manifest = try PrivateHeaderGeneration.StateJSON.read(
+            PrivateHeaderGeneration.Manifest.self,
+            from: result.manifestURL
+        )
+        let run = try PrivateHeaderGeneration.StateJSON.read(
+            PrivateHeaderGeneration.RunRecord.self,
+            from: result.runRecordURL
+        )
+        #expect(manifest.targets.first?.artifacts.map(\.rawValue) == expectedArtifacts)
+        #expect(run.targetResults.first?.attemptedArtifacts.map(\.rawValue) == expectedArtifacts)
+    }
+
+    @Test func simulatorExecutionFailsWhenSwiftInterfaceArtifactIsMissing() async throws {
+        let fixture = try ExecutorFixture()
+        defer { fixture.remove() }
+        try fixture.createFramework("Foo.framework")
+
+        let runner = RecordingRawDumpRunner(
+            writesSwiftInterfaceForSimulator: false
+        )
+        let plan = try fixture.makePlan(
+            targetRequest: .query("Foo"),
+            executionMode: .simulator(deviceUDID: "SIM-001", runtimeRoot: fixture.systemRoot.path),
+            rawDumpingOptions: PrivateHeaderGeneration.RawDumping.Options(useSharedCache: true)
+        )
+        let executor = PrivateHeaderGeneration.GenerationExecutor(
+            rawDumpRunner: { invocation in try await runner.run(invocation) },
+            runIDGenerator: { "run-001" },
+            dateProvider: fixedDates()
+        )
+
+        await #expect(throws: PrivateHeaderGeneration.GenerationError.self) {
+            _ = try await executor.run(.init(plan: plan))
+        }
+
+        let runURL = plan.stateDirectory.appendingPathComponent("runs/run-001/run.json")
+        let run = try PrivateHeaderGeneration.StateJSON.read(
+            PrivateHeaderGeneration.RunRecord.self,
+            from: runURL
+        )
+        let target = try #require(run.targetResults.first)
+        #expect(runner.invocations.map(\.phaseLabel) == ["raw-header-dump"])
+        #expect(target.status == .partial)
+        #expect(target.phases.map(\.name) == ["raw-header-dump"])
+        #expect(target.phases.map(\.status) == [.failed])
+        #expect(target.failureSummary?.contains(".swiftinterface") == true)
+        #expect(target.attemptedArtifacts.map(\.rawValue) == [
+            "Frameworks/Foo/Headers/Generated.h",
+        ])
     }
 }
 
@@ -282,13 +342,16 @@ private final class RecordingRawDumpRunner: @unchecked Sendable {
     var invocations: [PrivateHeaderGeneration.RawDumping.Invocation] = []
     var result: PrivateHeaderGeneration.RawDumping.Result
     var writesArtifacts: Bool
+    var writesSwiftInterfaceForSimulator: Bool
 
     init(
         result: PrivateHeaderGeneration.RawDumping.Result = PrivateHeaderGeneration.RawDumping.Result(terminationStatus: 0),
-        writesArtifacts: Bool = true
+        writesArtifacts: Bool = true,
+        writesSwiftInterfaceForSimulator: Bool = true
     ) {
         self.result = result
         self.writesArtifacts = writesArtifacts
+        self.writesSwiftInterfaceForSimulator = writesSwiftInterfaceForSimulator
     }
 
     func run(
@@ -306,6 +369,10 @@ private final class RecordingRawDumpRunner: @unchecked Sendable {
             )
             try Data("// generated\n".utf8)
                 .write(to: outputDirectory.appendingPathComponent("Generated.h"))
+            if case .simulator = invocation.executionMode, writesSwiftInterfaceForSimulator {
+                try Data("// generated\n".utf8)
+                    .write(to: outputDirectory.appendingPathComponent("Foo.swiftinterface"))
+            }
         }
         return result
     }
@@ -341,9 +408,10 @@ private struct ExecutorFixture {
         systemRoot = root.appendingPathComponent("RuntimeRoot", isDirectory: true)
         outputBase = root.appendingPathComponent("Output", isDirectory: true)
         let helperURL = root.appendingPathComponent("bin/privateheaderkit")
+        let simulatorHelperURL = root.appendingPathComponent("libexec/privateheaderkit/privateheaderkit-sim-helper")
         helperURLs = PrivateHeaderGeneration.RawDumping.HelperURLs(
             host: helperURL,
-            simulator: helperURL
+            simulator: simulatorHelperURL
         )
         try FileManager.default.createDirectory(at: systemRoot, withIntermediateDirectories: true)
     }

--- a/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationRawDumpingTests.swift
+++ b/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationRawDumpingTests.swift
@@ -104,6 +104,8 @@ struct PrivateHeaderGenerationRawDumpingTests {
             )
         )
 
+        #expect(invocation.phaseLabel == "raw-header-dump")
+        #expect(invocation.executionMode == .simulator(deviceUDID: "A1B2C3D4-E5F6-7890-ABCD-111111111111", runtimeRoot: runtimeRoot))
         #expect(invocation.helperURL.path == "/opt/privateheaderkit/bin/privateheaderkit-sim")
         #expect(invocation.inputPath == inputPath)
         #expect(invocation.command == [

--- a/Tests/PrivateHeaderKitInstallTests/PrivateHeaderKitInstallTests.swift
+++ b/Tests/PrivateHeaderKitInstallTests/PrivateHeaderKitInstallTests.swift
@@ -113,7 +113,7 @@ struct InstallCommandResolutionTests {
         ])
         #expect(runner.simpleCommands.allSatisfy { $0.cwd == dirs.root })
         #expect(runner.simpleCommands[0].env == nil)
-        #expect(runner.simpleCommands[1].env == ["PHK_SIMULATOR_HELPER_BUILD": "1"])
+        #expect(runner.simpleCommands[1].env == nil)
     }
 
     @Test func resolveSwiftBinDirUsesLastNonEmptyOutputLine() throws {
@@ -239,10 +239,8 @@ struct InstallCommandResolutionTests {
                 "privateheaderkit-sim-helper",
             ],
         ])
-        #expect(runner.simpleCommands[1].env == ["PHK_SIMULATOR_HELPER_BUILD": "1"])
-        #expect(runner.captureCommands.first(where: { $0.command.contains("--triple") })?.env == [
-            "PHK_SIMULATOR_HELPER_BUILD": "1",
-        ])
+        #expect(runner.simpleCommands[1].env == nil)
+        #expect(runner.captureCommands.first(where: { $0.command.contains("--triple") })?.env == nil)
         #expect(outputMessages == [
             "Installed privateheaderkit to \(layout.publicCommandURL.path)",
             "Installed privateheaderkit-sim-helper to \(layout.simulatorHelperURL.path)",

--- a/Tests/PrivateHeaderKitInstallTests/PrivateHeaderKitInstallTests.swift
+++ b/Tests/PrivateHeaderKitInstallTests/PrivateHeaderKitInstallTests.swift
@@ -55,6 +55,11 @@ struct InstallOptionTests {
         let bindirLayout = resolveInstallLayout(prefix: "/ignored", bindir: "/custom/bin")
         #expect(bindirLayout.publicCommandURL.path == "/custom/bin/privateheaderkit")
         #expect(bindirLayout.simulatorHelperURL.path == "/custom/libexec/privateheaderkit/privateheaderkit-sim-helper")
+
+        let installedHelper = defaultInstalledSimulatorHelperURL(
+            for: URL(fileURLWithPath: "/custom/phk/privateheaderkit", isDirectory: false)
+        )
+        #expect(installedHelper.path == "/custom/libexec/privateheaderkit/privateheaderkit-sim-helper")
     }
 }
 

--- a/Tests/PrivateHeaderKitInstallTests/PrivateHeaderKitInstallTests.swift
+++ b/Tests/PrivateHeaderKitInstallTests/PrivateHeaderKitInstallTests.swift
@@ -88,11 +88,30 @@ struct InstallCommandResolutionTests {
         #expect(looksLikePrivateHeaderKitRepo(repoRoot, fileManager: .default) == true)
     }
 
-    @Test func defaultSimulatorHelperTripleUsesProcessArchitecture() throws {
-        #expect(try defaultSimulatorHelperTriple(processArchitecture: "arm64") == "arm64-apple-ios-simulator")
-        #expect(try defaultSimulatorHelperTriple(processArchitecture: "x86_64") == "x86_64-apple-ios-simulator")
+    @Test func defaultSimulatorHelperTripleUsesNativeHostArchitecture() throws {
+        #expect(
+            try defaultSimulatorHelperTriple(
+                executableArchitecture: "x86_64",
+                supportsNativeArm64: true
+            ) == "arm64-apple-ios-simulator"
+        )
+        #expect(
+            try defaultSimulatorHelperTriple(
+                executableArchitecture: "x86_64",
+                supportsNativeArm64: false
+            ) == "x86_64-apple-ios-simulator"
+        )
+        #expect(
+            try defaultSimulatorHelperTriple(
+                executableArchitecture: "arm64",
+                supportsNativeArm64: true
+            ) == "arm64-apple-ios-simulator"
+        )
         #expect(throws: InstallError.self) {
-            _ = try defaultSimulatorHelperTriple(processArchitecture: "ppc")
+            _ = try defaultSimulatorHelperTriple(
+                executableArchitecture: "ppc",
+                supportsNativeArm64: false
+            )
         }
     }
 

--- a/Tests/PrivateHeaderKitInstallTests/PrivateHeaderKitInstallTests.swift
+++ b/Tests/PrivateHeaderKitInstallTests/PrivateHeaderKitInstallTests.swift
@@ -46,6 +46,16 @@ struct InstallOptionTests {
         #expect(resolveBinDir(prefix: "/prefix", bindir: "/custom/bin").path == "/custom/bin")
         #expect(resolveBinDir(prefix: "/prefix", bindir: nil).path == "/prefix/bin")
     }
+
+    @Test func resolveInstallLayoutPlacesHelperUnderLibexec() {
+        let prefixLayout = resolveInstallLayout(prefix: "/prefix", bindir: nil)
+        #expect(prefixLayout.publicCommandURL.path == "/prefix/bin/privateheaderkit")
+        #expect(prefixLayout.simulatorHelperURL.path == "/prefix/libexec/privateheaderkit/privateheaderkit-sim-helper")
+
+        let bindirLayout = resolveInstallLayout(prefix: "/ignored", bindir: "/custom/bin")
+        #expect(bindirLayout.publicCommandURL.path == "/custom/bin/privateheaderkit")
+        #expect(bindirLayout.simulatorHelperURL.path == "/custom/libexec/privateheaderkit/privateheaderkit-sim-helper")
+    }
 }
 
 @Suite
@@ -76,13 +86,34 @@ struct InstallCommandResolutionTests {
     @Test func buildProductsRecordsReleaseBuildCommands() throws {
         let dirs = try makeTemporaryTestDirectories()
         let runner = RecordingCommandRunner()
+        runner.setCaptureOutput("/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk\n", for: [
+            "xcrun",
+            "--sdk",
+            "iphonesimulator",
+            "--show-sdk-path",
+        ])
 
         try buildProducts(["privateheaderkit"], in: dirs.root, runner: runner)
+        try buildSimulatorHelper(in: dirs.root, runner: runner)
 
         #expect(runner.simpleCommands.map(\.command) == [
             ["swift", "build", "-c", "release", "--product", "privateheaderkit"],
+            [
+                "swift",
+                "build",
+                "-c",
+                "release",
+                "--sdk",
+                "/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk",
+                "--triple",
+                "arm64-apple-ios-simulator",
+                "--product",
+                "privateheaderkit-sim-helper",
+            ],
         ])
         #expect(runner.simpleCommands.allSatisfy { $0.cwd == dirs.root })
+        #expect(runner.simpleCommands[0].env == nil)
+        #expect(runner.simpleCommands[1].env == ["PHK_SIMULATOR_HELPER_BUILD": "1"])
     }
 
     @Test func resolveSwiftBinDirUsesLastNonEmptyOutputLine() throws {
@@ -97,4 +128,138 @@ struct InstallCommandResolutionTests {
 
         #expect(binDir?.path == dirs.root.appendingPathComponent(".build/release").path)
     }
+
+    @Test func resolveSwiftBinDirCanUseSimulatorTriple() throws {
+        let dirs = try makeTemporaryTestDirectories()
+        let runner = RecordingCommandRunner()
+        runner.setCaptureOutput(
+            "\(dirs.root.appendingPathComponent(".build/arm64-apple-ios-simulator/release").path)\n",
+            for: [
+                "swift",
+                "build",
+                "-c",
+                "release",
+                "--sdk",
+                "/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk",
+                "--triple",
+                "arm64-apple-ios-simulator",
+                "--show-bin-path",
+            ]
+        )
+
+        let binDir = resolveSwiftBinDir(
+            repoRoot: dirs.root,
+            runner: runner,
+            triple: "arm64-apple-ios-simulator",
+            sdkPath: "/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk"
+        )
+
+        #expect(binDir?.path == dirs.root.appendingPathComponent(".build/arm64-apple-ios-simulator/release").path)
+    }
+
+    @Test func dryRunInstallMessagesIncludeInternalHelper() {
+        let layout = resolveInstallLayout(prefix: "/prefix", bindir: nil)
+
+        #expect(dryRunInstallMessages(layout: layout) == [
+            "Would create: /prefix/bin",
+            "Would create: /prefix/libexec/privateheaderkit",
+            "Would install: /prefix/bin/privateheaderkit",
+            "Would install internal helper: /prefix/libexec/privateheaderkit/privateheaderkit-sim-helper",
+        ])
+    }
+
+    @Test func installFromRepoBuildsAndCopiesPublicCommandAndSimulatorHelper() throws {
+        let dirs = try makeTemporaryTestDirectories()
+        let repoRoot = dirs.root.appendingPathComponent("Repo", isDirectory: true)
+        let installPrefix = dirs.root.appendingPathComponent("Install", isDirectory: true)
+        let hostBinDir = repoRoot.appendingPathComponent(".build/release", isDirectory: true)
+        let simulatorBinDir = repoRoot.appendingPathComponent(
+            ".build/arm64-apple-ios-simulator/release",
+            isDirectory: true
+        )
+        try makePrivateHeaderKitRepoMarkers(in: repoRoot)
+        try FileManager.default.createDirectory(at: hostBinDir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: simulatorBinDir, withIntermediateDirectories: true)
+        try Data("host".utf8).write(to: hostBinDir.appendingPathComponent("privateheaderkit"))
+        try Data("sim".utf8).write(to: simulatorBinDir.appendingPathComponent("privateheaderkit-sim-helper"))
+
+        let runner = RecordingCommandRunner()
+        runner.setCaptureOutput("/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk\n", for: [
+            "xcrun",
+            "--sdk",
+            "iphonesimulator",
+            "--show-sdk-path",
+        ])
+        runner.setCaptureOutput(
+            "\(hostBinDir.path)\n",
+            for: ["swift", "build", "-c", "release", "--show-bin-path"]
+        )
+        runner.setCaptureOutput(
+            "\(simulatorBinDir.path)\n",
+            for: [
+                "swift",
+                "build",
+                "-c",
+                "release",
+                "--sdk",
+                "/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk",
+                "--triple",
+                "arm64-apple-ios-simulator",
+                "--show-bin-path",
+            ]
+        )
+        var outputMessages: [String] = []
+        var errorMessages: [String] = []
+
+        try install(
+            options: InstallOptions(prefix: installPrefix.path, bindir: nil, dryRun: false),
+            selfURL: hostBinDir.appendingPathComponent("privateheaderkit"),
+            currentDirectoryURL: repoRoot,
+            runner: runner,
+            fileManager: .default,
+            outputLogger: { outputMessages.append($0) },
+            errorLogger: { errorMessages.append($0) }
+        )
+
+        let layout = resolveInstallLayout(prefix: installPrefix.path, bindir: nil)
+        #expect(try String(contentsOf: layout.publicCommandURL, encoding: .utf8) == "host")
+        #expect(try String(contentsOf: layout.simulatorHelperURL, encoding: .utf8) == "sim")
+        #expect(runner.simpleCommands.map(\.command) == [
+            ["swift", "build", "-c", "release", "--product", "privateheaderkit"],
+            [
+                "swift",
+                "build",
+                "-c",
+                "release",
+                "--sdk",
+                "/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk",
+                "--triple",
+                "arm64-apple-ios-simulator",
+                "--product",
+                "privateheaderkit-sim-helper",
+            ],
+        ])
+        #expect(runner.simpleCommands[1].env == ["PHK_SIMULATOR_HELPER_BUILD": "1"])
+        #expect(runner.captureCommands.first(where: { $0.command.contains("--triple") })?.env == [
+            "PHK_SIMULATOR_HELPER_BUILD": "1",
+        ])
+        #expect(outputMessages == [
+            "Installed privateheaderkit to \(layout.publicCommandURL.path)",
+            "Installed privateheaderkit-sim-helper to \(layout.simulatorHelperURL.path)",
+        ])
+        #expect(errorMessages.isEmpty)
+    }
+}
+
+private func makePrivateHeaderKitRepoMarkers(in repoRoot: URL) throws {
+    try FileManager.default.createDirectory(
+        at: repoRoot.appendingPathComponent("Sources/PrivateHeaderKitCore", isDirectory: true),
+        withIntermediateDirectories: true
+    )
+    try Data().write(to: repoRoot.appendingPathComponent("Sources/PrivateHeaderKitCore/PrivateHeaderGeneration.swift"))
+    try FileManager.default.createDirectory(
+        at: repoRoot.appendingPathComponent("Sources/PrivateHeaderKitCLI", isDirectory: true),
+        withIntermediateDirectories: true
+    )
+    try Data().write(to: repoRoot.appendingPathComponent("Sources/PrivateHeaderKitCLI/PrivateHeaderKitMain.swift"))
 }

--- a/Tests/PrivateHeaderKitInstallTests/PrivateHeaderKitInstallTests.swift
+++ b/Tests/PrivateHeaderKitInstallTests/PrivateHeaderKitInstallTests.swift
@@ -83,6 +83,14 @@ struct InstallCommandResolutionTests {
         #expect(looksLikePrivateHeaderKitRepo(repoRoot, fileManager: .default) == true)
     }
 
+    @Test func defaultSimulatorHelperTripleUsesProcessArchitecture() throws {
+        #expect(try defaultSimulatorHelperTriple(processArchitecture: "arm64") == "arm64-apple-ios-simulator")
+        #expect(try defaultSimulatorHelperTriple(processArchitecture: "x86_64") == "x86_64-apple-ios-simulator")
+        #expect(throws: InstallError.self) {
+            _ = try defaultSimulatorHelperTriple(processArchitecture: "ppc")
+        }
+    }
+
     @Test func buildProductsRecordsReleaseBuildCommands() throws {
         let dirs = try makeTemporaryTestDirectories()
         let runner = RecordingCommandRunner()
@@ -94,7 +102,11 @@ struct InstallCommandResolutionTests {
         ])
 
         try buildProducts(["privateheaderkit"], in: dirs.root, runner: runner)
-        try buildSimulatorHelper(in: dirs.root, runner: runner)
+        try buildSimulatorHelper(
+            in: dirs.root,
+            runner: runner,
+            simulatorHelperTriple: "x86_64-apple-ios-simulator"
+        )
 
         #expect(runner.simpleCommands.map(\.command) == [
             ["swift", "build", "-c", "release", "--product", "privateheaderkit"],
@@ -106,7 +118,7 @@ struct InstallCommandResolutionTests {
                 "--sdk",
                 "/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk",
                 "--triple",
-                "arm64-apple-ios-simulator",
+                "x86_64-apple-ios-simulator",
                 "--product",
                 "privateheaderkit-sim-helper",
             ],
@@ -174,7 +186,7 @@ struct InstallCommandResolutionTests {
         let installPrefix = dirs.root.appendingPathComponent("Install", isDirectory: true)
         let hostBinDir = repoRoot.appendingPathComponent(".build/release", isDirectory: true)
         let simulatorBinDir = repoRoot.appendingPathComponent(
-            ".build/arm64-apple-ios-simulator/release",
+            ".build/x86_64-apple-ios-simulator/release",
             isDirectory: true
         )
         try makePrivateHeaderKitRepoMarkers(in: repoRoot)
@@ -204,7 +216,7 @@ struct InstallCommandResolutionTests {
                 "--sdk",
                 "/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk",
                 "--triple",
-                "arm64-apple-ios-simulator",
+                "x86_64-apple-ios-simulator",
                 "--show-bin-path",
             ]
         )
@@ -218,7 +230,8 @@ struct InstallCommandResolutionTests {
             runner: runner,
             fileManager: .default,
             outputLogger: { outputMessages.append($0) },
-            errorLogger: { errorMessages.append($0) }
+            errorLogger: { errorMessages.append($0) },
+            simulatorHelperTriple: "x86_64-apple-ios-simulator"
         )
 
         let layout = resolveInstallLayout(prefix: installPrefix.path, bindir: nil)
@@ -234,7 +247,7 @@ struct InstallCommandResolutionTests {
                 "--sdk",
                 "/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk",
                 "--triple",
-                "arm64-apple-ios-simulator",
+                "x86_64-apple-ios-simulator",
                 "--product",
                 "privateheaderkit-sim-helper",
             ],

--- a/Tests/PrivateHeaderKitRawDumpTests/PrivateHeaderKitRawDumpTests.swift
+++ b/Tests/PrivateHeaderKitRawDumpTests/PrivateHeaderKitRawDumpTests.swift
@@ -478,6 +478,26 @@ struct PrivateHeaderKitRawDumpSwiftInterfaceTests {
         #expect(FileManager.default.fileExists(atPath: outputURL.path) == true)
         #expect(try String(contentsOf: outputURL, encoding: .utf8) == "public struct Foo {}")
     }
+
+    @Test func dumpSwiftInterfacePropagatesBuildFailure() async throws {
+        let dirs = try makeTemporaryTestDirectories()
+        let outputDir = dirs.root.appendingPathComponent("out", isDirectory: true)
+        let options = DumpOptions(outputDir: outputDir)
+
+        await #expect(throws: FixtureSwiftInterfaceError.self) {
+            try await dumpSwiftInterface(
+                imagePath: "/tmp/FixtureFailure",
+                outputDir: outputDir,
+                options: options,
+                fileManager: FileManager.default,
+                buildInterface: { throw FixtureSwiftInterfaceError.failed }
+            )
+        }
+    }
+
+    private enum FixtureSwiftInterfaceError: Error {
+        case failed
+    }
 }
 
 @Suite

--- a/Tests/PrivateHeaderKitTestSupport/TestSupport.swift
+++ b/Tests/PrivateHeaderKitTestSupport/TestSupport.swift
@@ -19,6 +19,7 @@ public final class RecordingCommandRunner: CommandRunning {
     public private(set) var streamingCommands: [RecordedCommand] = []
 
     public var captureOutputs: [String: String] = [:]
+    private var captureOutputQueues: [String: [String]] = [:]
     public var simpleHandler: (([String], [String: String]?, URL?) throws -> Void)?
     public var streamingHandler: (([String], [String: String]?, URL?) throws -> StreamingCommandResult)?
 
@@ -28,8 +29,18 @@ public final class RecordingCommandRunner: CommandRunning {
         captureOutputs[key(for: command)] = output
     }
 
+    public func setCaptureOutputs(_ outputs: [String], for command: [String]) {
+        captureOutputQueues[key(for: command)] = outputs
+    }
+
     public func runCapture(_ command: [String], env: [String: String]?, cwd: URL?) throws -> String {
         captureCommands.append(RecordedCommand(command: command, env: env, cwd: cwd))
+        let commandKey = key(for: command)
+        if var outputs = captureOutputQueues[commandKey], !outputs.isEmpty {
+            let output = outputs.removeFirst()
+            captureOutputQueues[commandKey] = outputs
+            return output
+        }
         guard let output = captureOutputs[key(for: command)] else {
             throw ToolingError.message("unexpected runCapture command: \(command.joined(separator: " "))")
         }

--- a/Tests/PrivateHeaderKitToolingTests/ToolingDeterministicTests.swift
+++ b/Tests/PrivateHeaderKitToolingTests/ToolingDeterministicTests.swift
@@ -80,7 +80,17 @@ struct SimctlDeterministicTests {
             """
             {
               "runtimes": [
-                {"name": "iOS 26.10", "version": "26.10", "identifier": "ios-26-10", "runtimeRoot": "/runtimes/26.10", "isAvailable": true, "buildversion": "23Z1"},
+                {
+                  "name": "iOS 26.10",
+                  "version": "26.10",
+                  "identifier": "ios-26-10",
+                  "runtimeRoot": "/runtimes/26.10",
+                  "isAvailable": true,
+                  "buildversion": "23Z1",
+                  "supportedDeviceTypes": [
+                    {"name":"iPhone 17","identifier":"com.apple.CoreSimulator.SimDeviceType.iPhone-17","productFamily":"iPhone"}
+                  ]
+                },
                 {"name": "iOS 26.2", "version": "26.2", "identifier": "ios-26-2", "runtimeRoot": "/runtimes/26.2", "isAvailable": true, "buildversion": "23C54"},
                 {"name": "iOS 25.0", "version": "25.0", "identifier": "ios-25-0", "runtimeRoot": "/runtimes/25.0", "isAvailable": false},
                 {"name": "watchOS 26.0", "version": "26.0", "identifier": "watch-26-0", "runtimeRoot": "/runtimes/watch", "isAvailable": true}
@@ -94,6 +104,7 @@ struct SimctlDeterministicTests {
 
         #expect(runtimes.map(\.version) == ["26.2", "26.10"])
         #expect(runtimes.first?.build == "23C54")
+        #expect(runtimes.last?.supportedDeviceTypes.first?.identifier == "com.apple.CoreSimulator.SimDeviceType.iPhone-17")
         #expect(runner.captureCommands.map(\.command) == [["xcrun", "simctl", "list", "runtimes", "-j"]])
     }
 
@@ -162,7 +173,19 @@ struct SimctlDeterministicTests {
             version: "27.0",
             build: "24A5355q",
             identifier: "ios-27",
-            runtimeRoot: "/runtimes/27"
+            runtimeRoot: "/runtimes/27",
+            supportedDeviceTypes: [
+                DeviceTypeInfo(
+                    name: "iPad Pro",
+                    identifier: "com.apple.CoreSimulator.SimDeviceType.iPad-Pro",
+                    productFamily: "iPad"
+                ),
+                DeviceTypeInfo(
+                    name: "iPhone 17",
+                    identifier: "com.apple.CoreSimulator.SimDeviceType.iPhone-17",
+                    productFamily: "iPhone"
+                ),
+            ]
         )
         runner.setCaptureOutputs(
             [
@@ -176,17 +199,11 @@ struct SimctlDeterministicTests {
             for: ["xcrun", "simctl", "list", "devices", "-j"]
         )
         runner.setCaptureOutput(
-            """
-            {"devicetypes":[{"name":"iPhone 17","identifier":"com.apple.CoreSimulator.SimDeviceType.iPhone-17","productFamily":"iPhone"}]}
-            """,
-            for: ["xcrun", "simctl", "list", "devicetypes", "-j"]
-        )
-        runner.setCaptureOutput(
             "CLONE-001\n",
             for: ["xcrun", "simctl", "clone", "BASE-001", "Dumping Device (iOS 27.0)"]
         )
 
-        let device = try Simctl.resolveDevice(runtime: runtime, query: nil, runner: runner)
+        let device = try Simctl.resolveDevice(runtime: runtime, query: nil, runner: runner, environment: [:])
 
         #expect(device.name == "Dumping Device (iOS 27.0)")
         #expect(device.udid == "CLONE-001")
@@ -202,6 +219,102 @@ struct SimctlDeterministicTests {
             ],
             ["xcrun", "simctl", "boot", "CLONE-001"],
             ["xcrun", "simctl", "bootstatus", "CLONE-001", "-b"],
+        ])
+        #expect(!runner.captureCommands.map(\.command).contains(["xcrun", "simctl", "list", "devicetypes", "-j"]))
+    }
+
+    @Test func createDefaultDeviceFallsBackToRuntimeCompatibleDeviceTypes() throws {
+        let runner = RecordingCommandRunner()
+        let runtime = RuntimeInfo(
+            version: "27.0",
+            build: "24A5355q",
+            identifier: "ios-27",
+            runtimeRoot: "/runtimes/27"
+        )
+        runner.setCaptureOutput(
+            """
+            {
+              "devicetypes": [
+                {
+                  "name": "iPhone 14",
+                  "identifier": "com.apple.CoreSimulator.SimDeviceType.iPhone-14",
+                  "productFamily": "iPhone",
+                  "minRuntimeVersionString": "16.0",
+                  "maxRuntimeVersionString": "26.4"
+                },
+                {
+                  "name": "iPhone 17",
+                  "identifier": "com.apple.CoreSimulator.SimDeviceType.iPhone-17",
+                  "productFamily": "iPhone",
+                  "minRuntimeVersionString": "27.0",
+                  "maxRuntimeVersionString": "28.0"
+                },
+                {
+                  "name": "iPad Pro",
+                  "identifier": "com.apple.CoreSimulator.SimDeviceType.iPad-Pro",
+                  "productFamily": "iPad",
+                  "minRuntimeVersionString": "27.0",
+                  "maxRuntimeVersionString": "28.0"
+                }
+              ]
+            }
+            """,
+            for: ["xcrun", "simctl", "list", "devicetypes", "-j"]
+        )
+
+        try Simctl.createDefaultDevice(runtime: runtime, runner: runner, environment: [:])
+
+        #expect(runner.simpleCommands.map(\.command) == [
+            [
+                "xcrun",
+                "simctl",
+                "create",
+                "iPhone 17 (27.0)",
+                "com.apple.CoreSimulator.SimDeviceType.iPhone-17",
+                "ios-27",
+            ],
+        ])
+    }
+
+    @Test func createDefaultDeviceFallsBackToFirstIPhoneWhenCompatibilityMetadataIsAbsent() throws {
+        let runner = RecordingCommandRunner()
+        let runtime = RuntimeInfo(
+            version: "27.0",
+            build: "24A5355q",
+            identifier: "ios-27",
+            runtimeRoot: "/runtimes/27"
+        )
+        runner.setCaptureOutput(
+            """
+            {
+              "devicetypes": [
+                {
+                  "name": "iPad Pro",
+                  "identifier": "com.apple.CoreSimulator.SimDeviceType.iPad-Pro",
+                  "productFamily": "iPad"
+                },
+                {
+                  "name": "iPhone 16",
+                  "identifier": "com.apple.CoreSimulator.SimDeviceType.iPhone-16",
+                  "productFamily": "iPhone"
+                }
+              ]
+            }
+            """,
+            for: ["xcrun", "simctl", "list", "devicetypes", "-j"]
+        )
+
+        try Simctl.createDefaultDevice(runtime: runtime, runner: runner, environment: [:])
+
+        #expect(runner.simpleCommands.map(\.command) == [
+            [
+                "xcrun",
+                "simctl",
+                "create",
+                "iPhone 16 (27.0)",
+                "com.apple.CoreSimulator.SimDeviceType.iPhone-16",
+                "ios-27",
+            ],
         ])
     }
 }

--- a/Tests/PrivateHeaderKitToolingTests/ToolingDeterministicTests.swift
+++ b/Tests/PrivateHeaderKitToolingTests/ToolingDeterministicTests.swift
@@ -97,6 +97,26 @@ struct SimctlDeterministicTests {
         #expect(runner.captureCommands.map(\.command) == [["xcrun", "simctl", "list", "runtimes", "-j"]])
     }
 
+    @Test func findRuntimeMatchesExplicitBuildWhenProvided() throws {
+        let runner = RecordingCommandRunner()
+        runner.setCaptureOutput(
+            """
+            {
+              "runtimes": [
+                {"name": "iOS 27.0", "version": "27.0", "identifier": "ios-27-a", "runtimeRoot": "/runtimes/27A", "isAvailable": true, "buildversion": "24A1"},
+                {"name": "iOS 27.0", "version": "27.0", "identifier": "ios-27-b", "runtimeRoot": "/runtimes/27B", "isAvailable": true, "buildversion": "24B2"}
+              ]
+            }
+            """,
+            for: ["xcrun", "simctl", "list", "runtimes", "-j"]
+        )
+
+        let runtime = try Simctl.findRuntime(version: "27.0", build: "24B2", runner: runner)
+
+        #expect(runtime.identifier == "ios-27-b")
+        #expect(runtime.runtimeRoot == "/runtimes/27B")
+    }
+
     @Test func listDevicesParsesDevicesForRuntime() throws {
         let runner = RecordingCommandRunner()
         runner.setCaptureOutput(
@@ -133,6 +153,55 @@ struct SimctlDeterministicTests {
         #expect(runner.simpleCommands.map(\.command) == [
             ["xcrun", "simctl", "boot", "BOOTED"],
             ["xcrun", "simctl", "bootstatus", "BOOTED", "-b"],
+        ])
+    }
+
+    @Test func resolveDeviceCreatesRelistsClonesAndBootsWhenRuntimeHasNoDevices() throws {
+        let runner = RecordingCommandRunner()
+        let runtime = RuntimeInfo(
+            version: "27.0",
+            build: "24A5355q",
+            identifier: "ios-27",
+            runtimeRoot: "/runtimes/27"
+        )
+        runner.setCaptureOutputs(
+            [
+                """
+                {"devices":{"ios-27":[]}}
+                """,
+                """
+                {"devices":{"ios-27":[{"name":"iPhone 17 (27.0)","udid":"BASE-001","state":"Shutdown"}]}}
+                """,
+            ],
+            for: ["xcrun", "simctl", "list", "devices", "-j"]
+        )
+        runner.setCaptureOutput(
+            """
+            {"devicetypes":[{"name":"iPhone 17","identifier":"com.apple.CoreSimulator.SimDeviceType.iPhone-17","productFamily":"iPhone"}]}
+            """,
+            for: ["xcrun", "simctl", "list", "devicetypes", "-j"]
+        )
+        runner.setCaptureOutput(
+            "CLONE-001\n",
+            for: ["xcrun", "simctl", "clone", "BASE-001", "Dumping Device (iOS 27.0)"]
+        )
+
+        let device = try Simctl.resolveDevice(runtime: runtime, query: nil, runner: runner)
+
+        #expect(device.name == "Dumping Device (iOS 27.0)")
+        #expect(device.udid == "CLONE-001")
+        #expect(device.state == "Booted")
+        #expect(runner.simpleCommands.map(\.command) == [
+            [
+                "xcrun",
+                "simctl",
+                "create",
+                "iPhone 17 (27.0)",
+                "com.apple.CoreSimulator.SimDeviceType.iPhone-17",
+                "ios-27",
+            ],
+            ["xcrun", "simctl", "boot", "CLONE-001"],
+            ["xcrun", "simctl", "bootstatus", "CLONE-001", "-b"],
         ])
     }
 }


### PR DESCRIPTION
## Purpose
Add iOS simulator execution support to the rewrite branch while keeping Swift interface generation enabled in the simulator helper.

## Changes
- Add the `privateheaderkit-sim-helper` executable product and install it under `libexec/privateheaderkit`.
- Resolve iOS runtimes/devices through `simctl`, boot a simulator, and run raw dumping with `simctl spawn`.
- Pin refreshed fork dependencies for MachOKit, MachOObjCSection, and MachOSwiftSection.
- Keep `SwiftInterface` linked in the simulator helper and propagate Swift interface generation failures instead of silently skipping them.
- Record `.swiftinterface` artifacts when emitted while still allowing valid header-only targets.
- Extend CLI, installer, tooling, raw dump, and executor tests.

## Testing
- `swift test`
- `SDK=$(xcrun --sdk iphonesimulator --show-sdk-path) && swift build -c release --sdk "$SDK" --triple arm64-apple-ios-simulator --product privateheaderkit-sim-helper --skip-update --force-resolved-versions`
- `git diff --check`

## Related
- Depends on merged dependency refresh PRs:
  - lynnswap/MachOKit#2
  - lynnswap/MachOObjCSection#2
  - lynnswap/MachOSwiftSection#2
