### PR TITLE
Honor numeric simulator runtime bounds

### DIFF
--- a/Sources/PrivateHeaderKitTooling/Simctl.swift
+++ b/Sources/PrivateHeaderKitTooling/Simctl.swift
@@ -319,7 +319,7 @@ public enum Simctl {
 
     private static func compatibleDeviceTypes(from deviceTypes: [DeviceTypeInfo], runtime: RuntimeInfo) -> [DeviceTypeInfo]? {
         let hasRuntimeMetadata = deviceTypes.contains { deviceType in
-            hasText(deviceType.minRuntimeVersionString) || hasText(deviceType.maxRuntimeVersionString)
+            hasRuntimeBoundMetadata(deviceType)
         }
         guard hasRuntimeMetadata else {
             return nil
@@ -328,6 +328,7 @@ public enum Simctl {
     }
 
     private static func supports(runtime: RuntimeInfo, deviceType: DeviceTypeInfo) -> Bool {
+        let runtimeVersionKey = VersionUtils.versionKey(runtime.version)
         if let min = normalizedVersionString(deviceType.minRuntimeVersionString),
            compareVersionStrings(runtime.version, min) == .orderedAscending {
             return false
@@ -336,7 +337,22 @@ public enum Simctl {
            compareVersionStrings(runtime.version, max) == .orderedDescending {
             return false
         }
+        if let min = coreSimulatorVersionKey(deviceType.minRuntimeVersion),
+           compareVersionKeys(runtimeVersionKey, min) == .orderedAscending {
+            return false
+        }
+        if let max = coreSimulatorVersionKey(deviceType.maxRuntimeVersion),
+           compareVersionKeys(runtimeVersionKey, max) == .orderedDescending {
+            return false
+        }
         return true
+    }
+
+    private static func hasRuntimeBoundMetadata(_ deviceType: DeviceTypeInfo) -> Bool {
+        hasText(deviceType.minRuntimeVersionString)
+            || hasText(deviceType.maxRuntimeVersionString)
+            || deviceType.minRuntimeVersion != nil
+            || deviceType.maxRuntimeVersion != nil
     }
 
     private static func normalizedVersionString(_ value: String?) -> String? {
@@ -349,8 +365,10 @@ public enum Simctl {
     }
 
     private static func compareVersionStrings(_ lhs: String, _ rhs: String) -> ComparisonResult {
-        let left = VersionUtils.versionKey(lhs)
-        let right = VersionUtils.versionKey(rhs)
+        compareVersionKeys(VersionUtils.versionKey(lhs), VersionUtils.versionKey(rhs))
+    }
+
+    private static func compareVersionKeys(_ left: [Int], _ right: [Int]) -> ComparisonResult {
         let count = max(left.count, right.count)
         for index in 0..<count {
             let leftValue = index < left.count ? left[index] : 0
@@ -359,5 +377,14 @@ public enum Simctl {
             if leftValue > rightValue { return .orderedDescending }
         }
         return .orderedSame
+    }
+
+    private static func coreSimulatorVersionKey(_ value: Int?) -> [Int]? {
+        guard let value else { return nil }
+        return [
+            (value >> 16) & 0xffff,
+            (value >> 8) & 0xff,
+            value & 0xff,
+        ]
     }
 }

--- a/Tests/PrivateHeaderKitToolingTests/ToolingDeterministicTests.swift
+++ b/Tests/PrivateHeaderKitToolingTests/ToolingDeterministicTests.swift
@@ -276,6 +276,66 @@ struct SimctlDeterministicTests {
         ])
     }
 
+    @Test func createDefaultDeviceFallsBackToNumericRuntimeCompatibleDeviceTypes() throws {
+        let runner = RecordingCommandRunner()
+        let runtime = RuntimeInfo(
+            version: "27.0",
+            build: "24A5355q",
+            identifier: "ios-27",
+            runtimeRoot: "/runtimes/27"
+        )
+        runner.setCaptureOutput(
+            """
+            {
+              "devicetypes": [
+                {
+                  "name": "iPhone 14",
+                  "identifier": "com.apple.CoreSimulator.SimDeviceType.iPhone-14",
+                  "productFamily": "iPhone",
+                  "minRuntimeVersion": \(coreSimulatorRuntimeVersion(16)),
+                  "maxRuntimeVersion": \(coreSimulatorRuntimeVersion(26, 4))
+                },
+                {
+                  "name": "iPhone 17e",
+                  "identifier": "com.apple.CoreSimulator.SimDeviceType.iPhone-17e",
+                  "productFamily": "iPhone",
+                  "minRuntimeVersion": \(coreSimulatorRuntimeVersion(27, 1)),
+                  "maxRuntimeVersion": \(coreSimulatorRuntimeVersion(28))
+                },
+                {
+                  "name": "iPhone 17",
+                  "identifier": "com.apple.CoreSimulator.SimDeviceType.iPhone-17",
+                  "productFamily": "iPhone",
+                  "minRuntimeVersion": \(coreSimulatorRuntimeVersion(27)),
+                  "maxRuntimeVersion": \(coreSimulatorRuntimeVersion(28))
+                },
+                {
+                  "name": "iPad Pro",
+                  "identifier": "com.apple.CoreSimulator.SimDeviceType.iPad-Pro",
+                  "productFamily": "iPad",
+                  "minRuntimeVersion": \(coreSimulatorRuntimeVersion(27)),
+                  "maxRuntimeVersion": \(coreSimulatorRuntimeVersion(28))
+                }
+              ]
+            }
+            """,
+            for: ["xcrun", "simctl", "list", "devicetypes", "-j"]
+        )
+
+        try Simctl.createDefaultDevice(runtime: runtime, runner: runner, environment: [:])
+
+        #expect(runner.simpleCommands.map(\.command) == [
+            [
+                "xcrun",
+                "simctl",
+                "create",
+                "iPhone 17 (27.0)",
+                "com.apple.CoreSimulator.SimDeviceType.iPhone-17",
+                "ios-27",
+            ],
+        ])
+    }
+
     @Test func createDefaultDeviceFallsBackToFirstIPhoneWhenCompatibilityMetadataIsAbsent() throws {
         let runner = RecordingCommandRunner()
         let runtime = RuntimeInfo(
@@ -317,4 +377,8 @@ struct SimctlDeterministicTests {
             ],
         ])
     }
+}
+
+private func coreSimulatorRuntimeVersion(_ major: Int, _ minor: Int = 0, _ patch: Int = 0) -> Int {
+    (major << 16) | (minor << 8) | patch
 }


### PR DESCRIPTION
## Purpose

Fix simulator device type selection when `simctl list devicetypes -j` exposes runtime compatibility bounds only as numeric `minRuntimeVersion` / `maxRuntimeVersion` values.

## Changes

- Treat either string or numeric runtime bounds as compatibility metadata before falling back to unfiltered device types.
- Decode CoreSimulator packed numeric runtime versions for min/max comparisons.
- Add a deterministic tooling test for numeric-only bounds while preserving the no-metadata fallback behavior.

## Testing

- `swift test --filter PrivateHeaderKitToolingTests`
- `git diff --check`
- codex-review against `codex/rewrite-review-base`: clean, finding count 0
