### PR TITLE
Serialize generation state updates

### DIFF
--- a/Sources/PrivateHeaderKitCore/PrivateHeaderGenerationExecutor.swift
+++ b/Sources/PrivateHeaderKitCore/PrivateHeaderGenerationExecutor.swift
@@ -58,172 +58,17 @@ public extension PrivateHeaderGeneration {
 
             let repository = RunRepository(plan: plan)
             let artifactStore = ArtifactStore(artifactRoot: plan.artifactDirectory)
-            let existingManifest = try repository.readManifest()
-            let latestRun = try existingManifest.flatMap { try repository.readLatestRun(from: $0) }
-            let runPlan = Self.runPlanRecord(
-                plan: plan,
-                selectedTargets: selectedTargets,
-                executionMode: executionMode,
-                helperEnvironment: options.rawDumpingOptions.recordedHelperEnvironment(
-                    for: executionMode
-                )
-            )
-
-            let resumeSummary = try Self.resumeSummary(
-                for: options.resumeBehavior,
-                runPlan: runPlan,
-                manifest: existingManifest,
-                latestRun: latestRun,
-                artifactStore: artifactStore
-            )
-            let targetIDsToRun = Self.targetIDsToRun(
-                resumeBehavior: options.resumeBehavior,
-                selectedTargets: selectedTargets,
-                resumeSummary: resumeSummary
-            )
-            let targetsToRun = selectedTargets.filter { targetIDsToRun.contains($0.candidate.identifier) }
-
-            try repository.prepareStateDirectory()
-            let runID = runIDGenerator()
-            let runDirectories = try repository.prepareRunDirectories(for: runID)
-            try FileManager.default.createDirectory(
-                at: plan.artifactDirectory,
-                withIntermediateDirectories: true
-            )
-
-            var targetRecords = existingManifest?.targets ?? []
-            if case .fresh = options.resumeBehavior {
-                targetRecords = targetRecords.filter { record in
-                    !selectedTargets.contains { $0.candidate.identifier == record.id }
-                }
-            }
-
-            let startedAt = dateProvider()
-            var runRecord = RunRecord(
-                runID: runID,
-                schemaVersion: 1,
-                toolVersion: options.toolVersion,
-                plan: runPlan,
-                startedAt: startedAt,
-                endedAt: nil,
-                status: .running,
-                targetResults: [],
-                attemptedArtifacts: [],
-                logs: []
-            )
-            try repository.writeRun(runRecord)
-            try repository.writeManifest(
-                Self.manifest(
+            return try await repository.withExclusiveLock {
+                try await runWithLockedState(
                     plan: plan,
-                    runPlan: runPlan,
-                    runID: runID,
-                    targetRecords: targetRecords,
-                    updatedAt: startedAt
-                )
-            )
-
-            let previousTargetRecords = Self.targetsByID(existingManifest?.targets ?? [])
-            let previousCommitFailedAttempts = Self.commitFailedAttemptedArtifactsByTargetID(latestRun)
-            var generatedTargetIDs: [String] = []
-
-            for target in targetsToRun {
-                let targetResult = try await executeTarget(
-                    target,
-                    runID: runID,
-                    runDirectories: runDirectories,
-                    plan: plan,
-                    helperURLs: helperURLs,
-                    executionMode: executionMode,
-                    rawDumpingOptions: options.rawDumpingOptions,
+                    options: options,
+                    selectedTargets: selectedTargets,
+                    repository: repository,
                     artifactStore: artifactStore,
-                    previousTarget: previousTargetRecords[target.candidate.identifier],
-                    previousCommitFailedAttempts: previousCommitFailedAttempts[target.candidate.identifier] ?? [],
-                    cleanupBeforeRun: Self.shouldCleanupBeforeRun(
-                        targetID: target.candidate.identifier,
-                        resumeBehavior: options.resumeBehavior,
-                        previousTarget: previousTargetRecords[target.candidate.identifier]
-                    )
-                )
-
-                runRecord = Self.runRecordByAppending(
-                    targetResult.runTarget,
-                    to: runRecord,
-                    status: .running,
-                    endedAt: nil
-                )
-                targetRecords = Self.upserting(targetResult.manifestTarget, in: targetRecords)
-                try repository.writeRun(runRecord)
-                try repository.writeManifest(
-                    Self.manifest(
-                        plan: plan,
-                        runPlan: runPlan,
-                        runID: runID,
-                        targetRecords: targetRecords,
-                        updatedAt: dateProvider()
-                    )
-                )
-
-                if targetResult.runTarget.status == .completed {
-                    generatedTargetIDs.append(target.candidate.identifier)
-                }
-            }
-
-            let skippedTargetRecords = Self.skippedRunTargets(
-                selectedTargets: selectedTargets,
-                targetIDsToRun: targetIDsToRun
-            )
-            for skipped in skippedTargetRecords {
-                runRecord = Self.runRecordByAppending(
-                    skipped,
-                    to: runRecord,
-                    status: .running,
-                    endedAt: nil
+                    helperURLs: helperURLs,
+                    executionMode: executionMode
                 )
             }
-
-            let finalStatus = Self.finalRunStatus(for: runRecord.targetResults)
-            let endedAt = dateProvider()
-            runRecord = RunRecord(
-                runID: runRecord.runID,
-                schemaVersion: runRecord.schemaVersion,
-                toolVersion: runRecord.toolVersion,
-                plan: runRecord.plan,
-                startedAt: runRecord.startedAt,
-                endedAt: endedAt,
-                status: finalStatus,
-                targetResults: runRecord.targetResults,
-                attemptedArtifacts: runRecord.targetResults.flatMap(\.attemptedArtifacts),
-                logs: runRecord.logs
-            )
-            try repository.writeRun(runRecord)
-            try repository.writeManifest(
-                Self.manifest(
-                    plan: plan,
-                    runPlan: runPlan,
-                    runID: runID,
-                    targetRecords: targetRecords,
-                    updatedAt: endedAt
-                )
-            )
-            try repository.pruneRunHistory(from: repository.listRunSummaries())
-
-            let failedTargetIDs = runRecord.targetResults
-                .filter { !$0.status.isSuccessfulOrSkipped }
-                .map(\.targetID)
-            if !failedTargetIDs.isEmpty {
-                throw GenerationError.runFailed(
-                    runID: runID,
-                    failedTargetIDs: failedTargetIDs
-                )
-            }
-
-            return Result(
-                plan: plan,
-                generatedTargets: generatedTargetIDs.map(Target.generated(identifier:)),
-                runID: runID,
-                manifestURL: repository.manifestURL,
-                runRecordURL: try repository.runRecordURL(for: runID)
-            )
         }
     }
 }
@@ -232,6 +77,183 @@ private extension PrivateHeaderGeneration.GenerationExecutor {
     struct TargetExecutionResult {
         let runTarget: PrivateHeaderGeneration.RunTargetRecord
         let manifestTarget: PrivateHeaderGeneration.TargetRecord
+    }
+
+    func runWithLockedState(
+        plan: PrivateHeaderGeneration.Plan,
+        options: PrivateHeaderGeneration.Options,
+        selectedTargets: [PrivateHeaderGeneration.TargetDiscovery.DiscoveredTarget],
+        repository: PrivateHeaderGeneration.RunRepository,
+        artifactStore: PrivateHeaderGeneration.ArtifactStore,
+        helperURLs: PrivateHeaderGeneration.RawDumping.HelperURLs,
+        executionMode: PrivateHeaderGeneration.RawDumping.ExecutionMode
+    ) async throws -> PrivateHeaderGeneration.Result {
+        let existingManifest = try repository.readManifest()
+        let latestRun = try existingManifest.flatMap { try repository.readLatestRun(from: $0) }
+        let runPlan = Self.runPlanRecord(
+            plan: plan,
+            selectedTargets: selectedTargets,
+            executionMode: executionMode,
+            helperEnvironment: options.rawDumpingOptions.recordedHelperEnvironment(
+                for: executionMode
+            )
+        )
+
+        let resumeSummary = try Self.resumeSummary(
+            for: options.resumeBehavior,
+            runPlan: runPlan,
+            manifest: existingManifest,
+            latestRun: latestRun,
+            artifactStore: artifactStore
+        )
+        let targetIDsToRun = Self.targetIDsToRun(
+            resumeBehavior: options.resumeBehavior,
+            selectedTargets: selectedTargets,
+            resumeSummary: resumeSummary
+        )
+        let targetsToRun = selectedTargets.filter { targetIDsToRun.contains($0.candidate.identifier) }
+
+        try repository.prepareStateDirectory()
+        let runID = runIDGenerator()
+        let runDirectories = try repository.prepareRunDirectories(for: runID)
+        try FileManager.default.createDirectory(
+            at: plan.artifactDirectory,
+            withIntermediateDirectories: true
+        )
+
+        var targetRecords = existingManifest?.targets ?? []
+        if case .fresh = options.resumeBehavior {
+            targetRecords = targetRecords.filter { record in
+                !selectedTargets.contains { $0.candidate.identifier == record.id }
+            }
+        }
+
+        let startedAt = dateProvider()
+        var runRecord = PrivateHeaderGeneration.RunRecord(
+            runID: runID,
+            schemaVersion: 1,
+            toolVersion: options.toolVersion,
+            plan: runPlan,
+            startedAt: startedAt,
+            endedAt: nil,
+            status: .running,
+            targetResults: [],
+            attemptedArtifacts: [],
+            logs: []
+        )
+        try repository.writeRun(runRecord)
+        try repository.writeManifest(
+            Self.manifest(
+                plan: plan,
+                runPlan: runPlan,
+                runID: runID,
+                targetRecords: targetRecords,
+                updatedAt: startedAt
+            )
+        )
+
+        let previousTargetRecords = Self.targetsByID(existingManifest?.targets ?? [])
+        let previousCommitFailedAttempts = Self.commitFailedAttemptedArtifactsByTargetID(latestRun)
+        var generatedTargetIDs: [String] = []
+
+        for target in targetsToRun {
+            let targetResult = try await executeTarget(
+                target,
+                runID: runID,
+                runDirectories: runDirectories,
+                plan: plan,
+                helperURLs: helperURLs,
+                executionMode: executionMode,
+                rawDumpingOptions: options.rawDumpingOptions,
+                artifactStore: artifactStore,
+                previousTarget: previousTargetRecords[target.candidate.identifier],
+                previousCommitFailedAttempts: previousCommitFailedAttempts[target.candidate.identifier] ?? [],
+                cleanupBeforeRun: Self.shouldCleanupBeforeRun(
+                    targetID: target.candidate.identifier,
+                    resumeBehavior: options.resumeBehavior,
+                    previousTarget: previousTargetRecords[target.candidate.identifier]
+                )
+            )
+
+            runRecord = Self.runRecordByAppending(
+                targetResult.runTarget,
+                to: runRecord,
+                status: .running,
+                endedAt: nil
+            )
+            targetRecords = Self.upserting(targetResult.manifestTarget, in: targetRecords)
+            try repository.writeRun(runRecord)
+            try repository.writeManifest(
+                Self.manifest(
+                    plan: plan,
+                    runPlan: runPlan,
+                    runID: runID,
+                    targetRecords: targetRecords,
+                    updatedAt: dateProvider()
+                )
+            )
+
+            if targetResult.runTarget.status == .completed {
+                generatedTargetIDs.append(target.candidate.identifier)
+            }
+        }
+
+        let skippedTargetRecords = Self.skippedRunTargets(
+            selectedTargets: selectedTargets,
+            targetIDsToRun: targetIDsToRun
+        )
+        for skipped in skippedTargetRecords {
+            runRecord = Self.runRecordByAppending(
+                skipped,
+                to: runRecord,
+                status: .running,
+                endedAt: nil
+            )
+        }
+
+        let finalStatus = Self.finalRunStatus(for: runRecord.targetResults)
+        let endedAt = dateProvider()
+        runRecord = PrivateHeaderGeneration.RunRecord(
+            runID: runRecord.runID,
+            schemaVersion: runRecord.schemaVersion,
+            toolVersion: runRecord.toolVersion,
+            plan: runRecord.plan,
+            startedAt: runRecord.startedAt,
+            endedAt: endedAt,
+            status: finalStatus,
+            targetResults: runRecord.targetResults,
+            attemptedArtifacts: runRecord.targetResults.flatMap(\.attemptedArtifacts),
+            logs: runRecord.logs
+        )
+        try repository.writeRun(runRecord)
+        try repository.writeManifest(
+            Self.manifest(
+                plan: plan,
+                runPlan: runPlan,
+                runID: runID,
+                targetRecords: targetRecords,
+                updatedAt: endedAt
+            )
+        )
+        try repository.pruneRunHistory(from: repository.listRunSummaries())
+
+        let failedTargetIDs = runRecord.targetResults
+            .filter { !$0.status.isSuccessfulOrSkipped }
+            .map(\.targetID)
+        if !failedTargetIDs.isEmpty {
+            throw PrivateHeaderGeneration.GenerationError.runFailed(
+                runID: runID,
+                failedTargetIDs: failedTargetIDs
+            )
+        }
+
+        return PrivateHeaderGeneration.Result(
+            plan: plan,
+            generatedTargets: generatedTargetIDs.map(PrivateHeaderGeneration.Target.generated(identifier:)),
+            runID: runID,
+            manifestURL: repository.manifestURL,
+            runRecordURL: try repository.runRecordURL(for: runID)
+        )
     }
 
     func executeTarget(

--- a/Sources/PrivateHeaderKitCore/PrivateHeaderGenerationRunRepository.swift
+++ b/Sources/PrivateHeaderKitCore/PrivateHeaderGenerationRunRepository.swift
@@ -1,4 +1,9 @@
 import Foundation
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#endif
 
 public extension PrivateHeaderGeneration {
     struct RunRepository: Sendable {
@@ -18,6 +23,10 @@ public extension PrivateHeaderGeneration {
 
         public var runsDirectory: URL {
             stateDirectory.appendingPathComponent("runs", isDirectory: true)
+        }
+
+        internal var lockURL: URL {
+            stateDirectory.appendingPathComponent("generation.lock", isDirectory: false)
         }
 
         public func runDirectory(for runID: String) throws -> URL {
@@ -42,6 +51,19 @@ public extension PrivateHeaderGeneration {
                 at: stateDirectory,
                 withIntermediateDirectories: true
             )
+        }
+
+        internal func withExclusiveLock<Result>(
+            wait: Bool = true,
+            _ operation: () async throws -> Result
+        ) async throws -> Result {
+            try prepareStateDirectory()
+            return try await StateFileLock.withExclusiveLock(
+                at: lockURL,
+                wait: wait
+            ) {
+                try await operation()
+            }
         }
 
         @discardableResult
@@ -173,11 +195,20 @@ public extension PrivateHeaderGeneration {
 
     enum RunRepositoryError: Error, Equatable, CustomStringConvertible, Sendable {
         case invalidRunID(String)
+        case lockOpenFailed(path: String, errno: Int32)
+        case lockAcquisitionFailed(path: String, errno: Int32)
+        case lockUnavailable(path: String)
 
         public var description: String {
             switch self {
             case .invalidRunID(let runID):
                 "run ID is not safe as a path component: \(runID)"
+            case .lockOpenFailed(let path, let errno):
+                "failed to open generation state lock at \(path): errno \(errno)"
+            case .lockAcquisitionFailed(let path, let errno):
+                "failed to acquire generation state lock at \(path): errno \(errno)"
+            case .lockUnavailable(let path):
+                "generation state lock is already held at \(path)"
             }
         }
     }
@@ -231,5 +262,43 @@ private extension PrivateHeaderGeneration.RunRepository {
         else {
             throw PrivateHeaderGeneration.RunRepositoryError.invalidRunID(runID)
         }
+    }
+}
+
+private enum StateFileLock {
+    static func withExclusiveLock<Result>(
+        at lockURL: URL,
+        wait: Bool,
+        _ operation: () async throws -> Result
+    ) async throws -> Result {
+        let descriptor = open(lockURL.path, O_CREAT | O_RDWR | O_CLOEXEC, mode_t(0o600))
+        guard descriptor >= 0 else {
+            throw PrivateHeaderGeneration.RunRepositoryError.lockOpenFailed(
+                path: lockURL.path,
+                errno: errno
+            )
+        }
+        defer {
+            _ = close(descriptor)
+        }
+
+        let lockOperation = wait ? LOCK_EX : LOCK_EX | LOCK_NB
+        guard flock(descriptor, lockOperation) == 0 else {
+            let lockErrno = errno
+            if lockErrno == EWOULDBLOCK || lockErrno == EAGAIN {
+                throw PrivateHeaderGeneration.RunRepositoryError.lockUnavailable(
+                    path: lockURL.path
+                )
+            }
+            throw PrivateHeaderGeneration.RunRepositoryError.lockAcquisitionFailed(
+                path: lockURL.path,
+                errno: lockErrno
+            )
+        }
+        defer {
+            _ = flock(descriptor, LOCK_UN)
+        }
+
+        return try await operation()
     }
 }

--- a/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationExecutorTests.swift
+++ b/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationExecutorTests.swift
@@ -53,6 +53,32 @@ struct PrivateHeaderGenerationExecutorTests {
         #expect(run.targetResults.first?.attemptedArtifacts.map(\.rawValue) == ["Frameworks/Foo/Headers/Generated.h"])
     }
 
+    @Test func executorHoldsStateLockWhileGeneratingTargets() async throws {
+        let fixture = try ExecutorFixture()
+        defer { fixture.remove() }
+        try fixture.createFramework("Foo.framework")
+
+        let plan = try fixture.makePlan(targetRequest: .query("Foo"))
+        let repository = PrivateHeaderGeneration.RunRepository(plan: plan)
+        let probe = StateLockProbe(repository: repository)
+        let runner = RecordingRawDumpRunner()
+        let executor = PrivateHeaderGeneration.GenerationExecutor(
+            rawDumpRunner: { invocation in
+                await probe.recordNestedLockAttempt()
+                return try await runner.run(invocation)
+            },
+            runIDGenerator: { "run-001" },
+            dateProvider: fixedDates()
+        )
+
+        _ = try await executor.run(.init(plan: plan))
+
+        #expect(probe.unavailablePath == repository.lockURL.path)
+        #expect(probe.unexpectedlyAcquired == false)
+        #expect(probe.unexpectedError == nil)
+        #expect(fileExists(repository.lockURL))
+    }
+
     @Test func completedTargetWithManagedArtifactsIsSkippedOnResume() async throws {
         let fixture = try ExecutorFixture()
         defer { fixture.remove() }
@@ -388,6 +414,34 @@ struct PrivateHeaderGenerationExecutorTests {
         #expect(target.attemptedArtifacts.map(\.rawValue) == [
             "Frameworks/Foo/Headers/Generated.h",
         ])
+    }
+}
+
+private final class StateLockProbe: @unchecked Sendable {
+    let repository: PrivateHeaderGeneration.RunRepository
+    var unavailablePath: String?
+    var unexpectedlyAcquired = false
+    var unexpectedError: String?
+
+    init(repository: PrivateHeaderGeneration.RunRepository) {
+        self.repository = repository
+    }
+
+    func recordNestedLockAttempt() async {
+        do {
+            try await repository.withExclusiveLock(wait: false) {
+                unexpectedlyAcquired = true
+            }
+        } catch let error as PrivateHeaderGeneration.RunRepositoryError {
+            switch error {
+            case .lockUnavailable(let path):
+                unavailablePath = path
+            default:
+                unexpectedError = String(describing: error)
+            }
+        } catch {
+            unexpectedError = String(describing: error)
+        }
     }
 }
 

--- a/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationRunRepositoryTests.swift
+++ b/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationRunRepositoryTests.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Testing
 
-import PrivateHeaderKitCore
+@testable import PrivateHeaderKitCore
 
 @Suite
 struct PrivateHeaderGenerationRunRepositoryTests {
@@ -65,6 +65,39 @@ struct PrivateHeaderGenerationRunRepositoryTests {
 
         #expect(try repository.readManifest() == nil)
         #expect(try repository.readLatestRun() == nil)
+    }
+
+    @Test func exclusiveLockCreatesLockFileUnderStateDirectoryAndRejectsNestedNonBlockingAcquire() async throws {
+        let root = try makeTemporaryDirectory()
+        defer {
+            try? FileManager.default.removeItem(at: root)
+        }
+        let stateBaseDirectory = root.appendingPathComponent(".state", isDirectory: true)
+        let stateDirectory = stateBaseDirectory
+            .appendingPathComponent("iOS27.0(24A5355q)", isDirectory: true)
+        let repository = PrivateHeaderGeneration.RunRepository(stateDirectory: stateDirectory)
+        let expectedLockURL = stateDirectory.appendingPathComponent("generation.lock", isDirectory: false)
+
+        #expect(!fileExists(expectedLockURL))
+
+        try await repository.withExclusiveLock {
+            #expect(fileExists(expectedLockURL))
+            #expect(expectedLockURL.path.hasPrefix(stateBaseDirectory.path + "/"))
+            do {
+                _ = try await repository.withExclusiveLock(wait: false) {
+                    Issue.record("nested lock acquisition unexpectedly succeeded")
+                }
+            } catch let error as PrivateHeaderGeneration.RunRepositoryError {
+                switch error {
+                case .lockUnavailable(let path):
+                    #expect(path == expectedLockURL.path)
+                default:
+                    Issue.record("unexpected lock error: \(error)")
+                }
+            } catch {
+                Issue.record("unexpected error: \(error)")
+            }
+        }
     }
 
     @Test func readLatestRunUsesManifestLatestRunIDWhenPresent() throws {
@@ -285,4 +318,8 @@ private func directoryExists(_ url: URL) -> Bool {
     var isDirectory: ObjCBool = false
     let exists = FileManager.default.fileExists(atPath: url.path, isDirectory: &isDirectory)
     return exists && isDirectory.boolValue
+}
+
+private func fileExists(_ url: URL) -> Bool {
+    FileManager.default.fileExists(atPath: url.path)
 }


### PR DESCRIPTION
## Purpose

Prevent concurrent `generate` invocations for the same output/source from racing on shared generation state and dropping target records through last-writer-wins manifest updates.

## Changes

- Added an internal `RunRepository.withExclusiveLock` boundary backed by a POSIX `flock` lock file under the per-source `.state` directory.
- Wrapped generation state reads, run/manifest writes, artifact generation, and run-history pruning inside the repository lock.
- Added focused Core tests for lock file placement, deterministic nested non-blocking lock failure, and executor lock coverage during target generation.

## Testing

- `swift test --filter PrivateHeaderKitCoreTests`
- `swift test`
- `git diff --check`
- `codex-review` against `codex/rewrite-review-base`: findings 0