### PR TITLE
Adapt raw dump to upstream Swift index events

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "e1890902106b78b1a23dd873a38dd5d33c6d1465e29bce4f7b9fb5b3ad4a2b83",
+  "originHash" : "dc17d247dfaca6dd6fa23816b8fd4d265d7d15259cccf44de8ecdc144ebe3eec",
   "pins" : [
     {
       "identity" : "associatedobject",
@@ -20,21 +20,12 @@
       }
     },
     {
-      "identity" : "dyldprivate",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/lynnswap/DyldPrivate.git",
-      "state" : {
-        "revision" : "3b4d596b702d7c8f589d0babe42c7387e5d24dbc",
-        "version" : "0.1.0"
-      }
-    },
-    {
       "identity" : "frameworktoolbox",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/lynnswap/FrameworkToolbox.git",
+      "location" : "https://github.com/Mx-Iris/FrameworkToolbox",
       "state" : {
-        "revision" : "b0f1043d407fa10b8af42e0dc9c11ff2363b3632",
-        "version" : "0.3.3"
+        "revision" : "b82281eb8a6ffcb312941c3d06584182837f4ca9",
+        "version" : "0.7.1"
       }
     },
     {
@@ -58,7 +49,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/lynnswap/MachOSwiftSection.git",
       "state" : {
-        "revision" : "5b0ffcfde22caa6aeed971c9014db6d3075f5da7"
+        "revision" : "35698144adde6d39e071046135cd4a32330c582d"
       }
     },
     {
@@ -143,6 +134,15 @@
       }
     },
     {
+      "identity" : "swift-confidential",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/MxIris-Library-Forks/swift-confidential.git",
+      "state" : {
+        "revision" : "0e3e84cc18ffb4b39c4e51d9deacc3007e5fc67b",
+        "version" : "0.5.100"
+      }
+    },
+    {
       "identity" : "swift-crypto",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-crypto.git",
@@ -152,12 +152,30 @@
       }
     },
     {
+      "identity" : "swift-demangling",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/MxIris-Reverse-Engineering/swift-demangling",
+      "state" : {
+        "revision" : "d32f3154b6a551728e06fe4d5ad3e8f9e83010f5",
+        "version" : "0.4.2"
+      }
+    },
+    {
       "identity" : "swift-dependencies",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-dependencies",
       "state" : {
         "revision" : "c79f72b3e67a1eb64f66f76704c22ed6a5c1ed84",
         "version" : "1.11.0"
+      }
+    },
+    {
+      "identity" : "swift-dyld-private",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/MxIris-Reverse-Engineering/swift-dyld-private",
+      "state" : {
+        "revision" : "e9b255ed123e0ff5bb998d11639b993196159214",
+        "version" : "1.2.1"
       }
     },
     {
@@ -188,21 +206,12 @@
       }
     },
     {
-      "identity" : "swift-log",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-log.git",
-      "state" : {
-        "revision" : "2778fd4e5a12a8aaa30a3ee8285f4ce54c5f3181",
-        "version" : "1.9.1"
-      }
-    },
-    {
       "identity" : "swift-memberwise-init-macro",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/MxIris-Library-Forks/swift-memberwise-init-macro",
+      "location" : "https://github.com/gohanlon/swift-memberwise-init-macro",
       "state" : {
-        "revision" : "6121b169fb5a83d7262a69b640468606f98c6c6e",
-        "version" : "0.5.3-fork.1"
+        "revision" : "d0fb82bb6638051524214fb54524bfcd876735a1",
+        "version" : "0.6.0"
       }
     },
     {
@@ -221,6 +230,15 @@
       "state" : {
         "revision" : "93806cfecae1f198c894ed5585b93aff0e2d1f5a",
         "version" : "0.5.0"
+      }
+    },
+    {
+      "identity" : "swift-semantic-string",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/MxIris-Reverse-Engineering/swift-semantic-string",
+      "state" : {
+        "revision" : "1c3438861ea6dbba0856ab02071d683914468e82",
+        "version" : "0.1.1"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "dc17d247dfaca6dd6fa23816b8fd4d265d7d15259cccf44de8ecdc144ebe3eec",
+  "originHash" : "9a0905a5e091e289ce5acc56e377b969c84e779d41ecff31c5fc4555b7b3f1a7",
   "pins" : [
     {
       "identity" : "associatedobject",
@@ -31,17 +31,19 @@
     {
       "identity" : "machokit",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/lynnswap/MachOKit.git",
+      "location" : "https://github.com/MxIris-Reverse-Engineering/MachOKit.git",
       "state" : {
-        "revision" : "006b7c88a62d086b5483f0277afade29ef8c687c"
+        "revision" : "d83be31cca95efe72e39f914d35f1c4da799777e",
+        "version" : "0.50.100"
       }
     },
     {
       "identity" : "machoobjcsection",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/lynnswap/MachOObjCSection.git",
+      "location" : "https://github.com/MxIris-Reverse-Engineering/MachOObjCSection.git",
       "state" : {
-        "revision" : "46b96a919b7c305283659053476c8a3ebb274fce"
+        "revision" : "63e4b8a61d54fe90bb30e87c0c93f6a8b9c181f9",
+        "version" : "0.7.103"
       }
     },
     {
@@ -217,10 +219,10 @@
     {
       "identity" : "swift-objc-dump",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/p-x9/swift-objc-dump.git",
+      "location" : "https://github.com/MxIris-Reverse-Engineering/swift-objc-dump.git",
       "state" : {
-        "revision" : "089b0dd03825c47c86abd80ea98c290309379911",
-        "version" : "0.8.0"
+        "revision" : "641d257d60385b231a608ab8c4ecdf31348c779e",
+        "version" : "0.8.101"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -27,7 +27,7 @@ let package = Package(
         ),
         .package(
             url: "https://github.com/lynnswap/MachOSwiftSection.git",
-            revision: "5b0ffcfde22caa6aeed971c9014db6d3075f5da7"
+            revision: "35698144adde6d39e071046135cd4a32330c582d"
         ),
     ],
     targets: [
@@ -47,6 +47,7 @@ let package = Package(
                 .product(name: "MachOKit", package: "MachOKit"),
                 .product(name: "MachOObjCSection", package: "MachOObjCSection"),
                 .product(name: "ObjCDump", package: "swift-objc-dump"),
+                .product(name: "SwiftDeclaration", package: "MachOSwiftSection"),
                 .product(name: "SwiftInterface", package: "MachOSwiftSection"),
             ],
             path: "Sources/PrivateHeaderKitRawDumpCore"

--- a/Package.swift
+++ b/Package.swift
@@ -14,16 +14,16 @@ let package = Package(
     ],
     dependencies: [
         .package(
-            url: "https://github.com/lynnswap/MachOKit.git",
-            revision: "006b7c88a62d086b5483f0277afade29ef8c687c"
+            url: "https://github.com/MxIris-Reverse-Engineering/MachOKit.git",
+            from: "0.46.100"
         ),
         .package(
-            url: "https://github.com/lynnswap/MachOObjCSection.git",
-            revision: "46b96a919b7c305283659053476c8a3ebb274fce"
+            url: "https://github.com/MxIris-Reverse-Engineering/MachOObjCSection.git",
+            from: "0.6.100"
         ),
         .package(
-            url: "https://github.com/p-x9/swift-objc-dump.git",
-            from: "0.8.0"
+            url: "https://github.com/MxIris-Reverse-Engineering/swift-objc-dump.git",
+            from: "0.8.100"
         ),
         .package(
             url: "https://github.com/lynnswap/MachOSwiftSection.git",

--- a/Sources/PrivateHeaderKitRawDumpCore/PrivateHeaderKitRawDumpMain.swift
+++ b/Sources/PrivateHeaderKitRawDumpCore/PrivateHeaderKitRawDumpMain.swift
@@ -3,6 +3,7 @@ import Dispatch
 import MachOKit
 import MachOObjCSection
 import ObjCDump
+import SwiftDeclaration
 @_spi(Support) import SwiftInterface
 #if canImport(Darwin)
 import Darwin
@@ -31,11 +32,11 @@ protocol SwiftInterfaceBuildingFactory {
 
 struct DefaultSwiftInterfaceBuilderFactory: SwiftInterfaceBuildingFactory {
     let configuration: SwiftInterfaceBuilderConfiguration
-    let eventHandlers: [SwiftInterfaceEvents.Handler]
+    let eventHandlers: [SwiftIndexEvents.Handler]
 
     init(
         configuration: SwiftInterfaceBuilderConfiguration = .init(),
-        eventHandlers: [SwiftInterfaceEvents.Handler] = []
+        eventHandlers: [SwiftIndexEvents.Handler] = []
     ) {
         self.configuration = configuration
         self.eventHandlers = eventHandlers
@@ -56,7 +57,7 @@ struct SwiftInterfaceBuilderAdapter: SwiftInterfaceBuilding {
     init(
         machO: MachOFile,
         configuration: SwiftInterfaceBuilderConfiguration = .init(),
-        eventHandlers: [SwiftInterfaceEvents.Handler] = []
+        eventHandlers: [SwiftIndexEvents.Handler] = []
     ) throws {
         self.builder = try SwiftInterfaceBuilder(configuration: configuration, eventHandlers: eventHandlers, in: machO)
     }
@@ -724,25 +725,25 @@ private func profileLogDuration(
     fputs("privateheaderkit __raw-dump: profile \(name) \(secondsText) \(imagePath)\n", stderr)
 }
 
-private final class SwiftInterfaceTimingHandler: SwiftInterfaceEvents.Handler {
+private final class SwiftInterfaceTimingHandler: SwiftIndexEvents.Handler {
     private struct OpKey: Hashable {
-        let phase: SwiftInterfaceEvents.Phase
-        let operation: SwiftInterfaceEvents.PhaseOperation
+        let phase: SwiftIndexEvents.Phase
+        let operation: SwiftIndexEvents.PhaseOperation
     }
 
     private let label: String
     private let startNanos: UInt64
     private let lock = NSLock()
-    private var phaseStart: [SwiftInterfaceEvents.Phase: UInt64] = [:]
+    private var phaseStart: [SwiftIndexEvents.Phase: UInt64] = [:]
     private var opStart: [OpKey: UInt64] = [:]
-    private var extractionSectionStart: [SwiftInterfaceEvents.Section: UInt64] = [:]
+    private var extractionSectionStart: [SwiftIndexEvents.Section: UInt64] = [:]
 
     init(label: String) {
         self.label = label
         self.startNanos = DispatchTime.now().uptimeNanoseconds
     }
 
-    func handle(event: SwiftInterfaceEvents.Payload) {
+    func handle(event: SwiftIndexEvents.Payload) {
         switch event {
         case .phaseTransition(let phase, let state):
             handlePhaseTransition(phase: phase, state: state)
@@ -762,26 +763,12 @@ private final class SwiftInterfaceTimingHandler: SwiftInterfaceEvents.Handler {
             handlePhaseTransition(phase: .moduleCollection, state: .started)
         case .moduleCollectionCompleted(result: _):
             handlePhaseTransition(phase: .moduleCollection, state: .completed)
-        case .dependencyLoadingStarted(input: _):
-            handlePhaseTransition(phase: .dependencyLoading, state: .started)
-        case .dependencyLoadingCompleted(result: _):
-            handlePhaseTransition(phase: .dependencyLoading, state: .completed)
-        case .dependencyLoadingFailed(failure: let failure):
-            handlePhaseTransition(phase: .dependencyLoading, state: .failed(failure.error))
-        case .typeDatabaseIndexingStarted(input: _):
-            handlePhaseTransition(phase: .typeDatabaseIndexing, state: .started)
-        case .typeDatabaseIndexingCompleted:
-            handlePhaseTransition(phase: .typeDatabaseIndexing, state: .completed)
-        case .typeDatabaseIndexingFailed(error: let error):
-            handlePhaseTransition(phase: .typeDatabaseIndexing, state: .failed(error))
-        case .diagnostic(message: let message):
-            handleDiagnostic(message: message)
         default:
             break
         }
     }
 
-    private func handlePhaseTransition(phase: SwiftInterfaceEvents.Phase, state: SwiftInterfaceEvents.State) {
+    private func handlePhaseTransition(phase: SwiftIndexEvents.Phase, state: SwiftIndexEvents.State) {
         let now = DispatchTime.now().uptimeNanoseconds
         lock.lock()
         defer { lock.unlock() }
@@ -799,7 +786,7 @@ private final class SwiftInterfaceTimingHandler: SwiftInterfaceEvents.Handler {
         }
     }
 
-    private func handleOpStarted(phase: SwiftInterfaceEvents.Phase, operation: SwiftInterfaceEvents.PhaseOperation) {
+    private func handleOpStarted(phase: SwiftIndexEvents.Phase, operation: SwiftIndexEvents.PhaseOperation) {
         let now = DispatchTime.now().uptimeNanoseconds
         let key = OpKey(phase: phase, operation: operation)
         lock.lock()
@@ -808,7 +795,7 @@ private final class SwiftInterfaceTimingHandler: SwiftInterfaceEvents.Handler {
         lock.unlock()
     }
 
-    private func handleOpCompleted(phase: SwiftInterfaceEvents.Phase, operation: SwiftInterfaceEvents.PhaseOperation) {
+    private func handleOpCompleted(phase: SwiftIndexEvents.Phase, operation: SwiftIndexEvents.PhaseOperation) {
         let now = DispatchTime.now().uptimeNanoseconds
         let key = OpKey(phase: phase, operation: operation)
         lock.lock()
@@ -817,7 +804,7 @@ private final class SwiftInterfaceTimingHandler: SwiftInterfaceEvents.Handler {
         lock.unlock()
     }
 
-    private func handleOpFailed(phase: SwiftInterfaceEvents.Phase, operation: SwiftInterfaceEvents.PhaseOperation, error: any Error) {
+    private func handleOpFailed(phase: SwiftIndexEvents.Phase, operation: SwiftIndexEvents.PhaseOperation, error: any Error) {
         let now = DispatchTime.now().uptimeNanoseconds
         let key = OpKey(phase: phase, operation: operation)
         lock.lock()
@@ -826,7 +813,7 @@ private final class SwiftInterfaceTimingHandler: SwiftInterfaceEvents.Handler {
         lock.unlock()
     }
 
-    private func handleExtractionStarted(section: SwiftInterfaceEvents.Section) {
+    private func handleExtractionStarted(section: SwiftIndexEvents.Section) {
         let now = DispatchTime.now().uptimeNanoseconds
         lock.lock()
         extractionSectionStart[section] = now
@@ -834,7 +821,7 @@ private final class SwiftInterfaceTimingHandler: SwiftInterfaceEvents.Handler {
         lock.unlock()
     }
 
-    private func handleExtractionCompleted(result: SwiftInterfaceEvents.ExtractionResult) {
+    private func handleExtractionCompleted(result: SwiftIndexEvents.ExtractionResult) {
         let now = DispatchTime.now().uptimeNanoseconds
         lock.lock()
         let start = extractionSectionStart.removeValue(forKey: result.section) ?? now
@@ -845,7 +832,7 @@ private final class SwiftInterfaceTimingHandler: SwiftInterfaceEvents.Handler {
         lock.unlock()
     }
 
-    private func handleExtractionFailed(section: SwiftInterfaceEvents.Section, error: any Error) {
+    private func handleExtractionFailed(section: SwiftIndexEvents.Section, error: any Error) {
         let now = DispatchTime.now().uptimeNanoseconds
         lock.lock()
         let start = extractionSectionStart.removeValue(forKey: section) ?? now
@@ -853,17 +840,6 @@ private final class SwiftInterfaceTimingHandler: SwiftInterfaceEvents.Handler {
             now: now,
             message: "extraction.\(sectionName(section)) failed (\(formatDurationSeconds(now &- start))): \(String(describing: error))"
         )
-        lock.unlock()
-    }
-
-    private func handleDiagnostic(message: SwiftInterfaceEvents.DiagnosticMessage) {
-        let now = DispatchTime.now().uptimeNanoseconds
-        lock.lock()
-        var text = "diagnostic.\(diagnosticLevelName(message.level)) \(message.message)"
-        if let error = message.error {
-            text += " error=\(String(describing: error))"
-        }
-        log(now: now, message: text)
         lock.unlock()
     }
 
@@ -876,44 +852,32 @@ private final class SwiftInterfaceTimingHandler: SwiftInterfaceEvents.Handler {
         String(format: "%.3fs", Double(nanos) / 1_000_000_000.0)
     }
 
-    private func phaseName(_ phase: SwiftInterfaceEvents.Phase) -> String {
+    private func phaseName(_ phase: SwiftIndexEvents.Phase) -> String {
         switch phase {
-        case .initialization: return "initialization"
         case .preparation: return "preparation"
         case .extraction: return "extraction"
         case .indexing: return "indexing"
         case .moduleCollection: return "moduleCollection"
-        case .dependencyLoading: return "dependencyLoading"
-        case .typeDatabaseIndexing: return "typeDatabaseIndexing"
         case .build: return "build"
         }
     }
 
-    private func operationName(_ op: SwiftInterfaceEvents.PhaseOperation) -> String {
+    private func operationName(_ op: SwiftIndexEvents.PhaseOperation) -> String {
         switch op {
         case .typeIndexing: return "typeIndexing"
         case .protocolIndexing: return "protocolIndexing"
         case .conformanceIndexing: return "conformanceIndexing"
         case .extensionIndexing: return "extensionIndexing"
-        case .dependencyIndexing: return "dependencyIndexing"
         }
     }
 
-    private func sectionName(_ section: SwiftInterfaceEvents.Section) -> String {
+    private func sectionName(_ section: SwiftIndexEvents.Section) -> String {
         switch section {
         case .swiftTypes: return "swiftTypes"
         case .swiftProtocols: return "swiftProtocols"
         case .protocolConformances: return "protocolConformances"
         case .associatedTypes: return "associatedTypes"
-        }
-    }
-
-    private func diagnosticLevelName(_ level: SwiftInterfaceEvents.DiagnosticLevel) -> String {
-        switch level {
-        case .warning: return "warning"
-        case .error: return "error"
-        case .debug: return "debug"
-        case .trace: return "trace"
+        case .symbolIndex: return "symbolIndex"
         }
     }
 }

--- a/Sources/PrivateHeaderKitRawDumpCore/PrivateHeaderKitRawDumpMain.swift
+++ b/Sources/PrivateHeaderKitRawDumpCore/PrivateHeaderKitRawDumpMain.swift
@@ -734,7 +734,7 @@ private final class SwiftInterfaceTimingHandler: SwiftIndexEvents.Handler {
     private let label: String
     private let startNanos: UInt64
     private let lock = NSLock()
-    private var phaseStart: [SwiftIndexEvents.Phase: UInt64] = [:]
+    private var phaseStart: [SwiftIndexEvents.Phase: [UInt64]] = [:]
     private var opStart: [OpKey: UInt64] = [:]
     private var extractionSectionStart: [SwiftIndexEvents.Section: UInt64] = [:]
 
@@ -775,15 +775,27 @@ private final class SwiftInterfaceTimingHandler: SwiftIndexEvents.Handler {
 
         switch state {
         case .started:
-            phaseStart[phase] = now
+            phaseStart[phase, default: []].append(now)
             log(now: now, message: "\(phaseName(phase)) started")
         case .completed:
-            let start = phaseStart.removeValue(forKey: phase) ?? now
+            let start = popPhaseStart(for: phase) ?? now
             log(now: now, message: "\(phaseName(phase)) completed (\(formatDurationSeconds(now &- start)))")
         case .failed(let error):
-            let start = phaseStart.removeValue(forKey: phase) ?? now
+            let start = popPhaseStart(for: phase) ?? now
             log(now: now, message: "\(phaseName(phase)) failed (\(formatDurationSeconds(now &- start))): \(String(describing: error))")
         }
+    }
+
+    private func popPhaseStart(for phase: SwiftIndexEvents.Phase) -> UInt64? {
+        guard var starts = phaseStart[phase], let start = starts.popLast() else {
+            return nil
+        }
+        if starts.isEmpty {
+            phaseStart.removeValue(forKey: phase)
+        } else {
+            phaseStart[phase] = starts
+        }
+        return start
     }
 
     private func handleOpStarted(phase: SwiftIndexEvents.Phase, operation: SwiftIndexEvents.PhaseOperation) {

--- a/Sources/PrivateHeaderKitRawDumpCore/PrivateHeaderKitRawDumpMain.swift
+++ b/Sources/PrivateHeaderKitRawDumpCore/PrivateHeaderKitRawDumpMain.swift
@@ -1085,7 +1085,7 @@ private func runtimePropertyInfo(
 ) -> ObjCPropertyInfo {
     ObjCPropertyInfo(
         name: snapshot.name,
-        attributes: snapshot.attributesString,
+        attributesString: snapshot.attributesString,
         isClassProperty: snapshot.isClassProperty
     )
 }
@@ -1096,7 +1096,8 @@ private func runtimeMethodInfo(
     ObjCMethodInfo(
         name: snapshot.name,
         typeEncoding: snapshot.typeEncoding,
-        isClassMethod: snapshot.isClassMethod
+        isClassMethod: snapshot.isClassMethod,
+        imp: 0
     )
 }
 


### PR DESCRIPTION
## Purpose
Adapt PrivateHeaderKit to the upstream-style MachOSwiftSection event API so it no longer depends on fork-only SwiftInterfaceEvents.

## Changes
- Pin MachOSwiftSection to revision 35698144adde6d39e071046135cd4a32330c582d.
- Use SwiftDeclaration/SwiftIndexEvents for raw dump Swift interface event logging.
- Remove fork-only dependency loading, type database, and diagnostic event cases; add symbolIndex section naming.
- Align direct MachO dependency sources with the upstream MachOSwiftSection dependency graph and adjust ObjCDump initializer calls.

## Testing
- swift build --target PrivateHeaderKitRawDumpCore
- swift test --filter PrivateHeaderKitRawDumpTests
- ARCH=$(uname -m) && SDK=$(xcrun --sdk iphonesimulator --show-sdk-path) && swift build -c release --sdk "$SDK" --triple "$ARCH-apple-ios-simulator" --product privateheaderkit-sim-helper --skip-update --force-resolved-versions
- git diff --check
- codex-review against codex/rewrite-review-base: clean after fixes