### PR TITLE
Track MachOSwiftSection 0.14 releases

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/MxIris-Reverse-Engineering/MachOKit.git",
       "state" : {
-        "revision" : "d83be31cca95efe72e39f914d35f1c4da799777e",
-        "version" : "0.50.100"
+        "revision" : "4374bafbe4c628c05e068382a12467e7971b29ac",
+        "version" : "0.51.101"
       }
     },
     {
@@ -60,7 +60,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/MxIris-Reverse-Engineering/MachOSwiftSection.git",
       "state" : {
-        "revision" : "f17bc65b57f372b461fe45687298671c3400909e"
+        "revision" : "3396cfd7332d40edb6aa3b0600758916701a8be4",
+        "version" : "0.14.1"
       }
     },
     {
@@ -145,15 +146,6 @@
       }
     },
     {
-      "identity" : "swift-confidential",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/MxIris-Library-Forks/swift-confidential.git",
-      "state" : {
-        "revision" : "0e3e84cc18ffb4b39c4e51d9deacc3007e5fc67b",
-        "version" : "0.5.100"
-      }
-    },
-    {
       "identity" : "swift-crypto",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-crypto.git",
@@ -167,8 +159,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/MxIris-Reverse-Engineering/swift-demangling",
       "state" : {
-        "revision" : "d32f3154b6a551728e06fe4d5ad3e8f9e83010f5",
-        "version" : "0.4.2"
+        "revision" : "04c959b1b5f2cc8c9baca522cd0fedabb45f73a0",
+        "version" : "0.4.5"
       }
     },
     {
@@ -178,15 +170,6 @@
       "state" : {
         "revision" : "c79f72b3e67a1eb64f66f76704c22ed6a5c1ed84",
         "version" : "1.11.0"
-      }
-    },
-    {
-      "identity" : "swift-dyld-private",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/MxIris-Reverse-Engineering/swift-dyld-private",
-      "state" : {
-        "revision" : "e9b255ed123e0ff5bb998d11639b993196159214",
-        "version" : "1.2.1"
       }
     },
     {
@@ -257,8 +240,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/MxIris-Reverse-Engineering/swift-semantic-string",
       "state" : {
-        "revision" : "1c3438861ea6dbba0856ab02071d683914468e82",
-        "version" : "0.1.1"
+        "revision" : "daea78f0c94305d69b3c59af337ea69eda53603b",
+        "version" : "0.2.0"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "63f06bbfd6b8136d30b3a515f78d5d44d7f7be64cdddc0da215c6ad0bd14e73b",
+  "originHash" : "e04ca557832199d523bd03e87935e0003882418a76004eef239d101c69339bde",
   "pins" : [
     {
       "identity" : "associatedobject",

--- a/Package.swift
+++ b/Package.swift
@@ -44,7 +44,7 @@ let package = Package(
         ),
         .package(
             url: "https://github.com/MxIris-Reverse-Engineering/MachOSwiftSection.git",
-            revision: "f17bc65b57f372b461fe45687298671c3400909e"
+            "0.14.1" ..< "0.15.0"
         ),
     ],
     targets: [
@@ -71,6 +71,7 @@ let package = Package(
                 .product(name: "ObjCDump", package: "swift-objc-dump"),
                 .product(name: "MachOSwiftSection", package: "MachOSwiftSection"),
                 .product(name: "SwiftDeclaration", package: "MachOSwiftSection"),
+                .product(name: "SwiftDeclarationRendering", package: "MachOSwiftSection"),
                 .product(name: "SwiftInterface", package: "MachOSwiftSection"),
             ],
             path: "Sources/PrivateHeaderKitRawDumpCore"

--- a/Package.swift
+++ b/Package.swift
@@ -32,11 +32,11 @@ let package = Package(
         ),
         .package(
             url: "https://github.com/MxIris-Reverse-Engineering/MachOKit.git",
-            from: "0.46.100"
+            from: "0.51.101"
         ),
         .package(
             url: "https://github.com/MxIris-Reverse-Engineering/MachOObjCSection.git",
-            from: "0.6.100"
+            from: "0.7.103"
         ),
         .package(
             url: "https://github.com/MxIris-Reverse-Engineering/swift-objc-dump.git",

--- a/Sources/PrivateHeaderKitRawDumpCore/PrivateHeaderKitRawDumpMain.swift
+++ b/Sources/PrivateHeaderKitRawDumpCore/PrivateHeaderKitRawDumpMain.swift
@@ -63,7 +63,7 @@ struct DefaultSwiftInterfaceBuilderFactory: SwiftInterfaceBuildingFactory {
     }
 }
 
-struct SwiftInterfaceBuilderAdapter<MachO: MachOSwiftSectionRepresentableWithCache>: SwiftInterfaceBuilding {
+struct SwiftInterfaceBuilderAdapter<MachO: FieldLayoutRenderable>: SwiftInterfaceBuilding {
     private let builder: SwiftInterfaceBuilder<MachO>
 
     init(

--- a/Sources/PrivateHeaderKitRawDumpCore/PrivateHeaderKitRawDumpMain.swift
+++ b/Sources/PrivateHeaderKitRawDumpCore/PrivateHeaderKitRawDumpMain.swift
@@ -6,7 +6,8 @@ import MachOSwiftSection
 import ObjCDump
 import PrivateHeaderKitHelperProtocol
 import SwiftDeclaration
-@_spi(Support) import SwiftInterface
+import SwiftDeclarationRendering
+import SwiftInterface
 #if canImport(Darwin)
 import Darwin
 #elseif canImport(Glibc)


### PR DESCRIPTION
## Purpose

Consume the maintained upstream MachOSwiftSection release line directly and avoid recurring fork synchronization work.

## Changes

- Replace the fixed MachOSwiftSection revision with the `0.14.1 ..< 0.15.0` upstream release range.
- Align the direct MachOKit and MachOObjCSection minimums with the resolved upstream graph.
- Adopt `SwiftDeclarationRendering` and the public `SwiftInterface` module exposed by MachOSwiftSection 0.14.
- Refresh the resolved dependency graph and remove obsolete transitive packages.
- Refresh `Package.resolved`'s manifest identity from the current `Package.swift` while retaining the reviewed dependency pins.
- Satisfy the upstream field-layout rendering constraint for both file-backed and loaded-cache Mach-O inputs.

## Maintenance decision

- Keep the Mx swift-objc-dump 0.8 release line; no p-x9 0.9 migration or local compatibility fork is required.

## Testing

- `swift package resolve --force-resolved-versions` leaves the reviewed lockfile unchanged.
- Final-stack `swift test --force-resolved-versions`.
- Branch-wide Codex Review against the updated documentation branch: no actionable findings.
- `git diff --check`.
