### PR TITLE
Publish incremental dump results with quiet progress output

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -7,6 +7,11 @@ iOS / macOS の private framework ヘッダを生成します。
 - iOS: Simulator ランタイムと dyld shared cache から生成
 - macOS: ホストの `/System/Library/{Frameworks,PrivateFrameworks}` から生成
 
+## 動作要件
+
+PrivateHeaderKit の CLI、installer、internal helper は Darwin / macOS host のみを
+サポートします。Linux などの non-Darwin host はサポート対象外です。
+
 ## コマンド構成
 
 PrivateHeaderKit がユーザー向けに公開するコマンドは 1 つです。

--- a/README.ja.md
+++ b/README.ja.md
@@ -113,6 +113,9 @@ state があれば `Continue` / `Restart` の明示選択を求め、legacy stat
 保存または backup の扱いを表示してから移行します。automation / CI では generation
 option を直接渡します。
 
+生成済み header は `~/PrivateHeaderKit/generated-headers/<source-storage-id>/` に出力
+されます。実行開始時にも、この実際の出力先を terminal に表示します。
+
 ```bash
 privateheaderkit --platform iOS --version 27.0 --build 24A5355q --out "$HOME/PrivateHeaderKit" --target "SwiftUI,UIKit"
 privateheaderkit --platform iOS --version 27.0 --build 24A5355q --system-root /path/to/RuntimeRoot --device "iPhone 17" --out "$HOME/PrivateHeaderKit" --target "SwiftUI,UIKit" --fresh
@@ -137,19 +140,34 @@ runtime を解決し、device を選択・boot して internal simulator helper 
   work がない互換 state は再利用できますが、未完了 state がある場合は、呼び出し側
   が `--resume` または `--fresh` を明示するまで拒否します。
 
-`--fresh` は処理開始前に現在 publish 済みの header tree を削除しません。publish は
-毎回、新しい immutable generation として構築します。完了した target は自身が所有
-する file だけを置き換え、失敗または中断した target には最後に publish 成功した
-file を残します。旧 `<version>` positional style は public surface に含みません。
+`--fresh` は処理開始前に現在 publish 済みの header tree を削除しません。完了した
+target は、次の target を開始する前に自身が所有する file を
+`generated-headers/<source-storage-id>/` へ反映します。後続 target や run 全体の
+finalize が失敗しても、先に完了した target の file は残り、`--resume` では再実行
+せず続きから処理します。失敗または中断した target には、最後に publish 成功した
+file を残します。run 終了時の immutable generation は recovery 用の内部 snapshot
+であり、生成中に header を見えなくする publication gate ではありません。旧
+`<version>` positional style は public surface に含みません。
+
+TTY では処理中の target を `.`, `..`, `...` の一時的な1行として更新します。成功行
+は次の target で置き換え、terminal に成功 target の一覧を残しません。失敗した
+target と短い診断だけを残します。raw helper の通常出力は terminal へ転送せず、失敗
+時の bounded diagnostic tail は target の `failureSummary` として SQLite state に保存
+します。
 
 ## Output Layout Contract
 
-output base には、stable な source storage ID path、immutable generation、source
-ごとの SQLite state database を配置します。
+output base には、人が直接参照する incremental header tree、recovery 用の immutable
+generation、source ごとの SQLite state database を配置します。
 
 ```text
 <output-base>/
-  <source-storage-id> -> .privateheaderkit/<source-storage-id>/current
+  generated-headers/
+    <source-storage-id>/
+      Frameworks/...
+      PrivateFrameworks/...
+      SystemLibrary/...
+      usr/lib/...
   .privateheaderkit/
     <source-storage-id>/
       current -> generations/<generation-id>
@@ -165,12 +183,13 @@ output base には、stable な source storage ID path、immutable generation、
 ```
 
 `--out` は `<output-base>` を指定します。consumer は
-`<output-base>/<source-storage-id>/` を使い、publication metadata と immutable
-generation directory は `.privateheaderkit` 以下に置きます。`legacy-backups` は
-rewrite 前の output directory を移行した場合にだけ作成します。generation state、
-target attempt、publication intent、run log は `generation.sqlite` に保存します。
-storage ID は PrivateHeaderKit が所有する versioned identifier であり、consumer は
-表示用 source label から組み立てません。
+`<output-base>/generated-headers/<source-storage-id>/` を使います。完了 target の
+artifact と SQLite の published-target record は target 単位で確定し、内部 snapshot
+は `.privateheaderkit` 以下で run 終了時に整合させます。`legacy-backups` は rewrite 前
+の output directory を移行した場合にだけ作成します。generation state、target
+attempt、publication intent、run log は `generation.sqlite` に保存します。storage ID
+は PrivateHeaderKit が所有する versioned identifier であり、consumer は表示用 source
+label から組み立てません。
 
 ## Legacy Output の移行
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,11 @@ Generate private framework headers for iOS and macOS.
 - iOS: dump from simulator runtimes and dyld shared caches.
 - macOS: dump from host `/System/Library/{Frameworks,PrivateFrameworks}`.
 
+## Requirements
+
+The PrivateHeaderKit CLI, installer, and internal helpers support Darwin/macOS
+hosts only. Non-Darwin hosts such as Linux are unsupported.
+
 ## Command Model
 
 PrivateHeaderKit exposes one user-facing command:

--- a/README.md
+++ b/README.md
@@ -119,6 +119,10 @@ present, the same confirmation lists both paths and their preservation or
 backup effects before migration. For automation and CI, pass generation
 options directly:
 
+Generated headers are written to
+`~/PrivateHeaderKit/generated-headers/<source-storage-id>/`. The command also
+prints this concrete destination when a run starts.
+
 ```bash
 privateheaderkit --platform iOS --version 27.0 --build 24A5355q --out "$HOME/PrivateHeaderKit" --target "SwiftUI,UIKit"
 privateheaderkit --platform iOS --version 27.0 --build 24A5355q --system-root /path/to/RuntimeRoot --device "iPhone 17" --out "$HOME/PrivateHeaderKit" --target "SwiftUI,UIKit" --fresh
@@ -145,19 +149,34 @@ optional automation flags.
   until the caller explicitly chooses `--resume` or `--fresh`.
 
 `--fresh` does not delete the currently published header tree before work
-starts. Every publication is built as a new immutable generation. A target that
-finishes replaces only the files it owns; failed or interrupted targets retain
-their last successfully published files. The old `<version>` positional style
-is not part of the public surface.
+starts. A completed target updates the files it owns under
+`generated-headers/<source-storage-id>/` before the next target starts. A later
+target or finalization failure does not remove those files, and `--resume`
+continues without rerunning targets that were already published. Failed or
+interrupted targets retain their last successfully published files. The
+immutable generation finalized at the end of a run is an internal recovery
+snapshot, not a gate that hides headers while generation is in progress. The
+old `<version>` positional style is not part of the public surface.
+
+On a TTY, the active target is one transient line animated as `.`, `..`, and
+`...`. Successful lines are replaced by the next target instead of accumulating
+in the terminal; only failed targets and concise diagnostics remain. Normal raw
+helper output is not forwarded to the terminal. A bounded diagnostic tail for
+a failed target is retained as its SQLite `failureSummary`.
 
 ## Output Layout Contract
 
-The output base contains a stable source storage ID path, immutable generations,
-and one SQLite state database per source:
+The output base contains the incrementally visible header tree, internal
+immutable recovery generations, and one SQLite state database per source:
 
 ```text
 <output-base>/
-  <source-storage-id> -> .privateheaderkit/<source-storage-id>/current
+  generated-headers/
+    <source-storage-id>/
+      Frameworks/...
+      PrivateFrameworks/...
+      SystemLibrary/...
+      usr/lib/...
   .privateheaderkit/
     <source-storage-id>/
       current -> generations/<generation-id>
@@ -173,13 +192,14 @@ and one SQLite state database per source:
 ```
 
 `--out` selects `<output-base>`. Consumers use
-`<output-base>/<source-storage-id>/`, while publication metadata and immutable
-generation directories remain under `.privateheaderkit`. The
-`legacy-backups` directory is created only when a pre-rewrite output directory
-is migrated. Generation state, target attempts, publication intent, and run
-logs are stored in `generation.sqlite`. The storage ID is versioned and owned
-by PrivateHeaderKit; consumers must not construct it from the displayed source
-label.
+`<output-base>/generated-headers/<source-storage-id>/`. Completed target
+artifacts and their SQLite published-target records become durable per target;
+the internal snapshot under `.privateheaderkit` is reconciled at the end of a
+run. The `legacy-backups` directory is created only when a pre-rewrite output
+directory is migrated. Generation state, target attempts, publication intent,
+and run logs are stored in `generation.sqlite`. The storage ID is versioned and
+owned by PrivateHeaderKit; consumers must not construct it from the displayed
+source label.
 
 ## Legacy Output Migration
 

--- a/Sources/PrivateHeaderKitCLI/PrivateHeaderKitCommand.swift
+++ b/Sources/PrivateHeaderKitCLI/PrivateHeaderKitCommand.swift
@@ -347,7 +347,14 @@ func runPrivateHeaderKitPreparedGeneration(
     do {
         let result = try await preparedGeneration.run(
             resumeBehavior,
-            privateHeaderKitProgressReporter(outputLogger: outputLogger)
+            privateHeaderKitProgressReporter(
+                artifactDirectory: request.output.artifactBaseDirectory.appendingPathComponent(
+                    request.source.storageIdentifier,
+                    isDirectory: true
+                ),
+                outputLogger: outputLogger,
+                failureLogger: errorLogger
+            )
         )
         resultScreenClearer?()
         renderPrivateHeaderKitRunSummary(

--- a/Sources/PrivateHeaderKitCLI/PrivateHeaderKitGenerationClient.swift
+++ b/Sources/PrivateHeaderKitCLI/PrivateHeaderKitGenerationClient.swift
@@ -100,11 +100,11 @@ private func preparePrivateHeaderGeneration(
     )
 }
 
-private func runPrivateHeaderKitRawDump(
+func runPrivateHeaderKitRawDump(
     _ invocation: PrivateHeaderGeneration.RawDumping.Invocation,
     processRunner: any CommandRunning
 ) async throws -> PrivateHeaderGeneration.RawDumping.Result {
-    let processResult = try await processRunner.runStreaming(
+    let processResult = try await processRunner.runBuffered(
         invocation.command,
         env: invocation.environment,
         cwd: nil

--- a/Sources/PrivateHeaderKitCLI/PrivateHeaderKitRendering.swift
+++ b/Sources/PrivateHeaderKitCLI/PrivateHeaderKitRendering.swift
@@ -1,26 +1,318 @@
+import Dispatch
 import Foundation
 import PrivateHeaderKitCore
 
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#endif
+
 func privateHeaderKitProgressReporter(
-    outputLogger: @escaping PrivateHeaderKitOutputLogger
+    artifactDirectory: URL,
+    outputLogger: @escaping PrivateHeaderKitOutputLogger,
+    failureLogger: @escaping PrivateHeaderKitOutputLogger
 ) -> PrivateHeaderGeneration.GenerationExecutor.ProgressReporter {
-    { event in
+    let renderer = PrivateHeaderKitProgressOutputLogger(
+        outputLogger: outputLogger,
+        failureLogger: failureLogger,
+        artifactDirectory: artifactDirectory,
+        inlineProgressEnabled: stdoutSupportsInlineProgress()
+    )
+    return { event in
+        renderer.report(event)
+    }
+}
+
+final class PrivateHeaderKitProgressOutputLogger: @unchecked Sendable {
+    private struct ActiveTarget {
+        let index: Int
+        let total: Int
+        let displayName: String
+    }
+
+    private let outputLogger: PrivateHeaderKitOutputLogger
+    private let failureLogger: PrivateHeaderKitOutputLogger
+    private let artifactDirectory: URL
+    private let inlineProgressEnabled: Bool
+    private let inlineWriter: @Sendable (String) -> Void
+    private let startsTimer: Bool
+    private let inlineColumnCount: Int
+    private let indicators = [".", "..", "..."]
+    private let lock = NSLock()
+    private var timer: DispatchSourceTimer?
+    private var activeTarget: ActiveTarget?
+    private var indicatorIndex = 0
+    private var renderedLength = 0
+    private var cursorHidden = false
+
+    init(
+        outputLogger: @escaping PrivateHeaderKitOutputLogger,
+        failureLogger: @escaping PrivateHeaderKitOutputLogger,
+        artifactDirectory: URL,
+        inlineProgressEnabled: Bool,
+        inlineWriter: @escaping @Sendable (String) -> Void = writePrivateHeaderKitInlineOutput,
+        startsTimer: Bool = true,
+        inlineColumnCount: Int = privateHeaderKitTerminalColumnCount()
+    ) {
+        self.outputLogger = outputLogger
+        self.failureLogger = failureLogger
+        self.artifactDirectory = artifactDirectory
+        self.inlineProgressEnabled = inlineProgressEnabled
+        self.inlineWriter = inlineWriter
+        self.startsTimer = startsTimer
+        self.inlineColumnCount = max(1, inlineColumnCount)
+    }
+
+    deinit {
+        stopProgressRendering(clearLine: true)
+    }
+
+    func report(_ event: PrivateHeaderGeneration.ProgressEvent) {
         switch event {
         case .runStarted(let runID, let totalTargetCount):
-            outputLogger("Generation started: \(shortenedRunID(runID.rawValue))")
-            outputLogger("Targets: \(totalTargetCount)")
-        case .targetStarted(let index, let total, let displayName):
-            outputLogger("[\(index)/\(total)] \(displayName)")
-        case .targetFinished(_, _, _, let status):
-            outputLogger("  \(status.rawValue)")
-        case .warning(let warning):
             outputLogger(
-                "warning [\(warning.kind)] \(warning.relativePath): \(warning.message)"
+                "Generation \(shortenedRunID(runID.rawValue)): \(totalTargetCount) targets → "
+                    + artifactDirectory.path
             )
-        case .runFinished(let summary):
-            outputLogger("Generation finished: \(summary.status.rawValue)")
+        case .targetStarted(let index, let total, let displayName):
+            startTarget(index: index, total: total, displayName: displayName)
+        case .targetFinished(
+            let index,
+            let total,
+            let displayName,
+            let status,
+            let failureSummary
+        ):
+            finishTarget(
+                index: index,
+                total: total,
+                displayName: displayName,
+                status: status,
+                failureSummary: failureSummary
+            )
+        case .warning(let warning):
+            writePersistentLine(
+                "warning [\(warning.kind)] \(warning.relativePath): "
+                    + concisePrivateHeaderKitDiagnostic(warning.message),
+                logger: failureLogger
+            )
+        case .runFinished:
+            stopProgressRendering(clearLine: true)
         }
     }
+
+    func advanceIndicatorForTesting() {
+        advanceIndicator()
+    }
+
+    private func startTarget(index: Int, total: Int, displayName: String) {
+        guard inlineProgressEnabled else { return }
+
+        lock.lock()
+        stopTimerLocked()
+        activeTarget = ActiveTarget(index: index, total: total, displayName: displayName)
+        indicatorIndex = 0
+        hideCursorLocked()
+        renderIndicatorLocked()
+        if startsTimer {
+            startTimerLocked()
+        }
+        lock.unlock()
+    }
+
+    private func finishTarget(
+        index: Int,
+        total: Int,
+        displayName: String,
+        status: PrivateHeaderGeneration.RunTargetStatus,
+        failureSummary: String?
+    ) {
+        let target = ActiveTarget(index: index, total: total, displayName: displayName)
+        let shouldPersist = status != .completed && status != .skipped
+
+        if inlineProgressEnabled {
+            lock.lock()
+            stopTimerLocked()
+            activeTarget = nil
+            writeInlineLineLocked(
+                inlineTargetLine(target, suffix: status.rawValue),
+                terminator: shouldPersist ? "\n" : ""
+            )
+            lock.unlock()
+        } else if shouldPersist {
+            failureLogger("\(targetPrefix(target)) \(status.rawValue)")
+        }
+
+        if shouldPersist, let failureSummary {
+            failureLogger("  " + concisePrivateHeaderKitDiagnostic(failureSummary))
+        }
+    }
+
+    private func writePersistentLine(
+        _ line: String,
+        logger: PrivateHeaderKitOutputLogger
+    ) {
+        if inlineProgressEnabled {
+            lock.lock()
+            stopTimerLocked()
+            if renderedLength > 0 {
+                writeInlineLineLocked("", terminator: "\n")
+            }
+            activeTarget = nil
+            lock.unlock()
+        }
+        logger(line)
+    }
+
+    private func stopProgressRendering(clearLine: Bool) {
+        guard inlineProgressEnabled else { return }
+        lock.lock()
+        stopTimerLocked()
+        activeTarget = nil
+        if clearLine, renderedLength > 0 {
+            clearInlineLineLocked()
+        }
+        showCursorLocked()
+        lock.unlock()
+    }
+
+    private func startTimerLocked() {
+        let timer = DispatchSource.makeTimerSource(queue: .global(qos: .utility))
+        timer.schedule(deadline: .now() + .milliseconds(500), repeating: .milliseconds(500))
+        timer.setEventHandler { [weak self] in
+            self?.advanceIndicator()
+        }
+        self.timer = timer
+        timer.resume()
+    }
+
+    private func stopTimerLocked() {
+        timer?.cancel()
+        timer = nil
+    }
+
+    private func advanceIndicator() {
+        lock.lock()
+        defer { lock.unlock() }
+        guard activeTarget != nil else { return }
+        indicatorIndex = (indicatorIndex + 1) % indicators.count
+        renderIndicatorLocked()
+    }
+
+    private func renderIndicatorLocked() {
+        guard let activeTarget else { return }
+        writeInlineLineLocked(
+            inlineTargetLine(activeTarget, suffix: indicators[indicatorIndex]),
+            terminator: ""
+        )
+    }
+
+    private func targetPrefix(_ target: ActiveTarget) -> String {
+        "[\(target.index)/\(target.total)] \(singleLinePrivateHeaderKitText(target.displayName))"
+    }
+
+    private func inlineTargetLine(_ target: ActiveTarget, suffix: String) -> String {
+        let prefix = "[\(target.index)/\(target.total)] "
+        let suffix = " \(suffix)"
+        let availableNameWidth = max(
+            1,
+            inlineColumnCount - privateHeaderKitTerminalWidth(prefix)
+                - privateHeaderKitTerminalWidth(suffix)
+        )
+        return prefix
+            + privateHeaderKitTerminalSuffix(
+                singleLinePrivateHeaderKitText(target.displayName),
+                fitting: availableNameWidth
+            )
+            + suffix
+    }
+
+    private func writeInlineLineLocked(_ line: String, terminator: String) {
+        let lineWidth = privateHeaderKitTerminalWidth(line)
+        let padding = max(0, renderedLength - lineWidth)
+        inlineWriter("\r\(line)\(String(repeating: " ", count: padding))\(terminator)")
+        renderedLength = terminator.isEmpty ? lineWidth : 0
+    }
+
+    private func clearInlineLineLocked() {
+        inlineWriter("\r\(String(repeating: " ", count: renderedLength))\r")
+        renderedLength = 0
+    }
+
+    private func hideCursorLocked() {
+        guard !cursorHidden else { return }
+        inlineWriter("\u{001B}[?25l")
+        cursorHidden = true
+    }
+
+    private func showCursorLocked() {
+        guard cursorHidden else { return }
+        inlineWriter("\u{001B}[?25h")
+        cursorHidden = false
+    }
+}
+
+private func stdoutSupportsInlineProgress() -> Bool {
+    guard isatty(STDOUT_FILENO) != 0 else { return false }
+    return ProcessInfo.processInfo.environment["TERM"] != "dumb"
+}
+
+private func privateHeaderKitTerminalColumnCount() -> Int {
+    var size = winsize()
+    guard ioctl(STDOUT_FILENO, TIOCGWINSZ, &size) == 0, size.ws_col > 0 else {
+        return 80
+    }
+    return Int(size.ws_col)
+}
+
+private func singleLinePrivateHeaderKitText(_ text: String) -> String {
+    text
+        .replacingOccurrences(of: "\\", with: "\\\\")
+        .replacingOccurrences(of: "\r", with: "\\r")
+        .replacingOccurrences(of: "\n", with: "\\n")
+        .replacingOccurrences(of: "\t", with: "\\t")
+}
+
+private func privateHeaderKitTerminalWidth(_ text: String) -> Int {
+    text.unicodeScalars.reduce(into: 0) { width, scalar in
+        width += scalar.isASCII ? 1 : 2
+    }
+}
+
+private func privateHeaderKitTerminalSuffix(_ text: String, fitting maximumWidth: Int) -> String {
+    guard privateHeaderKitTerminalWidth(text) > maximumWidth else { return text }
+    guard maximumWidth > 1 else { return "…" }
+
+    var suffix: [Character] = []
+    var width = privateHeaderKitTerminalWidth("…")
+    for character in text.reversed() {
+        let characterWidth = privateHeaderKitTerminalWidth(String(character))
+        guard width + characterWidth <= maximumWidth else { break }
+        suffix.append(character)
+        width += characterWidth
+    }
+    return "…" + String(suffix.reversed())
+}
+
+private func writePrivateHeaderKitInlineOutput(_ output: String) {
+    FileHandle.standardOutput.write(Data(output.utf8))
+}
+
+func concisePrivateHeaderKitDiagnostic(_ message: String) -> String {
+    let lines =
+        message
+        .split(whereSeparator: \.isNewline)
+        .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+        .filter { !$0.isEmpty }
+    let preferred =
+        lines.last(where: { $0.localizedCaseInsensitiveContains("error:") })
+        ?? lines.last
+        ?? message.trimmingCharacters(in: .whitespacesAndNewlines)
+    let sanitized = singleLinePrivateHeaderKitText(preferred)
+    let maximumLength = 500
+    guard sanitized.count > maximumLength else { return sanitized }
+    return String(sanitized.prefix(maximumLength - 1)) + "…"
 }
 
 func renderPrivateHeaderKitGenerationError(
@@ -98,15 +390,26 @@ func renderPrivateHeaderKitRunSummary(
         outputLogger(formatResultMetric("Interrupted", summary.targetCounts.interrupted))
     }
     if summary.targetCounts.pending + summary.targetCounts.running > 0 {
-        outputLogger(formatResultMetric("Unfinished", summary.targetCounts.pending + summary.targetCounts.running))
+        outputLogger(
+            formatResultMetric(
+                "Unfinished", summary.targetCounts.pending + summary.targetCounts.running))
     }
 
     if let infrastructureMessage {
         outputLogger("")
         outputLogger("Infrastructure failure")
-        outputLogger("  \(infrastructureMessage)")
+        outputLogger("  \(concisePrivateHeaderKitDiagnostic(infrastructureMessage))")
     }
-    if !failedTargetIDs.isEmpty {
+    if !summary.targetFailures.isEmpty {
+        outputLogger("")
+        outputLogger("Failed targets")
+        for failure in summary.targetFailures.prefix(20) {
+            outputLogger("  \(failure.displayName) (\(failure.status.rawValue))")
+            if let message = failure.message {
+                outputLogger("    \(concisePrivateHeaderKitDiagnostic(message))")
+            }
+        }
+    } else if !failedTargetIDs.isEmpty {
         outputLogger("")
         outputLogger("Failed targets")
         for targetID in failedTargetIDs.prefix(20) {
@@ -117,7 +420,10 @@ func renderPrivateHeaderKitRunSummary(
         outputLogger("")
         outputLogger("Warnings")
         for warning in summary.warnings.prefix(20) {
-            outputLogger("  [\(warning.kind)] \(warning.relativePath): \(warning.message)")
+            outputLogger(
+                "  [\(warning.kind)] \(warning.relativePath): "
+                    + concisePrivateHeaderKitDiagnostic(warning.message)
+            )
         }
     }
 
@@ -133,7 +439,8 @@ private func formatResultMetric(_ label: String, _ value: Int) -> String {
 }
 
 private func formatResultField(_ label: String, _ value: String) -> String {
-    let padded = label.count < 10
+    let padded =
+        label.count < 10
         ? label.padding(toLength: 10, withPad: " ", startingAt: 0)
         : label
     return "  \(padded) \(value)"
@@ -143,7 +450,8 @@ private func formattedTargetQuery(_ query: String) -> String {
     guard query != "all" else {
         return "All targets"
     }
-    return query
+    return
+        query
         .split(separator: ",")
         .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
         .joined(separator: ", ")

--- a/Sources/PrivateHeaderKitCore/ManagedFileSystem.swift
+++ b/Sources/PrivateHeaderKitCore/ManagedFileSystem.swift
@@ -1,10 +1,5 @@
+import Darwin
 import Foundation
-
-#if canImport(Darwin)
-  import Darwin
-#elseif canImport(Glibc)
-  import Glibc
-#endif
 
 package enum ManagedFileSystem {
   package enum ItemKind: String, Equatable, Sendable {
@@ -50,6 +45,11 @@ package enum ManagedFileSystem {
       guard kind == .directory else {
         throw Failure.unexpectedKind(path: url.path, expected: "directory", actual: kind)
       }
+      try syncDirectory(url)
+      let parent = url.deletingLastPathComponent()
+      if parent.path != url.path {
+        try syncDirectory(parent)
+      }
       return
     }
     let parent = url.deletingLastPathComponent()
@@ -59,9 +59,15 @@ package enum ManagedFileSystem {
     try ensureRealDirectory(parent)
     guard mkdir(url.path, mode_t(0o755)) == 0 else {
       let code = errno
-      if code == EEXIST, try itemKind(at: url) == .directory { return }
+      if code == EEXIST, try itemKind(at: url) == .directory {
+        try syncDirectory(url)
+        try syncDirectory(parent)
+        return
+      }
       throw Failure.posix(operation: "mkdir", path: url.path, errno: code)
     }
+    try syncDirectory(url)
+    try syncDirectory(parent)
   }
 
   package static func atomicRename(from source: URL, to destination: URL) throws {
@@ -71,6 +77,38 @@ package enum ManagedFileSystem {
         path: "\(source.path) -> \(destination.path)",
         errno: errno
       )
+    }
+  }
+
+  package static func atomicRenameExclusively(from source: URL, to destination: URL) throws {
+    guard renamex_np(source.path, destination.path, UInt32(RENAME_EXCL)) == 0 else {
+      throw Failure.posix(
+        operation: "renamex_np(RENAME_EXCL)",
+        path: "\(source.path) -> \(destination.path)",
+        errno: errno
+      )
+    }
+  }
+
+  package static func syncDirectory(_ url: URL) throws {
+    let descriptor = open(url.path, O_RDONLY)
+    guard descriptor >= 0 else {
+      throw Failure.posix(operation: "open", path: url.path, errno: errno)
+    }
+    defer { _ = close(descriptor) }
+    guard fsync(descriptor) == 0 else {
+      throw Failure.posix(operation: "fsync", path: url.path, errno: errno)
+    }
+  }
+
+  package static func syncFile(_ url: URL) throws {
+    let descriptor = open(url.path, O_RDONLY)
+    guard descriptor >= 0 else {
+      throw Failure.posix(operation: "open", path: url.path, errno: errno)
+    }
+    defer { _ = close(descriptor) }
+    guard fsync(descriptor) == 0 else {
+      throw Failure.posix(operation: "fsync", path: url.path, errno: errno)
     }
   }
 

--- a/Sources/PrivateHeaderKitCore/ManagedFileSystem.swift
+++ b/Sources/PrivateHeaderKitCore/ManagedFileSystem.swift
@@ -64,6 +64,16 @@ package enum ManagedFileSystem {
     }
   }
 
+  package static func atomicRename(from source: URL, to destination: URL) throws {
+    guard rename(source.path, destination.path) == 0 else {
+      throw Failure.posix(
+        operation: "rename",
+        path: "\(source.path) -> \(destination.path)",
+        errno: errno
+      )
+    }
+  }
+
   @discardableResult
   package static func requireRegularFileOrMissing(_ url: URL) throws -> Bool {
     guard let kind = try itemKind(at: url) else { return false }

--- a/Sources/PrivateHeaderKitCore/PrivateHeaderGeneration.swift
+++ b/Sources/PrivateHeaderKitCore/PrivateHeaderGeneration.swift
@@ -1,9 +1,9 @@
 import Foundation
 
 #if canImport(Darwin)
-import Darwin
+  import Darwin
 #elseif canImport(Glibc)
-import Glibc
+  import Glibc
 #endif
 
 package enum PrivateHeaderGeneration {
@@ -27,7 +27,8 @@ extension PrivateHeaderGeneration {
       guard !version.isEmpty else {
         throw ValidationError.emptyComponent(field: "version")
       }
-      let build = build
+      let build =
+        build
         .map(\.precomposedStringWithCanonicalMapping)
         .flatMap { $0.isEmpty ? nil : $0 }
       let storageIdentifier = Self.makeStorageIdentifier(
@@ -149,7 +150,13 @@ extension PrivateHeaderGeneration {
   package enum ProgressEvent: Equatable, Sendable {
     case runStarted(runID: RunID, totalTargetCount: Int)
     case targetStarted(index: Int, total: Int, displayName: String)
-    case targetFinished(index: Int, total: Int, displayName: String, status: RunTargetStatus)
+    case targetFinished(
+      index: Int,
+      total: Int,
+      displayName: String,
+      status: RunTargetStatus,
+      failureSummary: String?
+    )
     case warning(GenerationWarning)
     case runFinished(RunSummary)
   }
@@ -173,6 +180,7 @@ extension PrivateHeaderGeneration {
     package let artifactDirectory: URL
     package let stateDatabaseURL: URL
     package let warnings: [GenerationWarning]
+    package let targetFailures: [TargetFailure]
 
     package init(
       runID: RunID,
@@ -180,7 +188,8 @@ extension PrivateHeaderGeneration {
       targetCounts: TargetCounts,
       artifactDirectory: URL,
       stateDatabaseURL: URL,
-      warnings: [GenerationWarning] = []
+      warnings: [GenerationWarning] = [],
+      targetFailures: [TargetFailure] = []
     ) {
       self.runID = runID
       self.status = status
@@ -188,6 +197,26 @@ extension PrivateHeaderGeneration {
       self.artifactDirectory = artifactDirectory
       self.stateDatabaseURL = stateDatabaseURL
       self.warnings = warnings
+      self.targetFailures = targetFailures
+    }
+  }
+
+  package struct TargetFailure: Hashable, Sendable {
+    package let targetID: String
+    package let displayName: String
+    package let status: RunTargetStatus
+    package let message: String?
+
+    package init(
+      targetID: String,
+      displayName: String,
+      status: RunTargetStatus,
+      message: String?
+    ) {
+      self.targetID = targetID
+      self.displayName = displayName
+      self.status = status
+      self.message = message
     }
   }
 
@@ -274,7 +303,9 @@ extension PrivateHeaderGeneration {
       self.baseDirectory = baseDirectory
     }
 
-    package var artifactBaseDirectory: URL { baseDirectory }
+    package var artifactBaseDirectory: URL {
+      baseDirectory.appendingPathComponent("generated-headers", isDirectory: true)
+    }
     package var stateBaseDirectory: URL {
       baseDirectory.appendingPathComponent(".state", isDirectory: true)
     }

--- a/Sources/PrivateHeaderKitCore/PrivateHeaderGenerationArtifactPublisher.swift
+++ b/Sources/PrivateHeaderKitCore/PrivateHeaderGenerationArtifactPublisher.swift
@@ -54,7 +54,7 @@ package struct ArtifactPublisher: Sendable {
       case .artifactCollision(let firstPath, let firstOwner, let secondPath, let secondOwner):
         "artifact paths collide: \(firstOwner):\(firstPath) and \(secondOwner):\(secondPath)"
       case .inventoryMismatch(let expected, let actual):
-        "generation inventory mismatch; expected \(expected), actual \(actual)"
+        Self.inventoryMismatchDescription(expected: expected, actual: actual)
       case .markerMismatch(let message):
         "generation marker mismatch: \(message)"
       case .posix(let operation, let path, let error):
@@ -62,6 +62,32 @@ package struct ArtifactPublisher: Sendable {
       case .atomicSwapUnsupported(let path):
         "filesystem does not support atomic legacy directory swap at \(path)"
       }
+    }
+
+    private static func inventoryMismatchDescription(
+      expected: [String],
+      actual: [String]
+    ) -> String {
+      let missing = Array(Set(expected).subtracting(actual)).sorted()
+      let unexpected = Array(Set(actual).subtracting(expected)).sorted()
+      var details: [String] = []
+      if !missing.isEmpty {
+        details.append("missing \(summarizedPaths(missing))")
+      }
+      if !unexpected.isEmpty {
+        details.append("unexpected \(summarizedPaths(unexpected))")
+      }
+      if details.isEmpty {
+        details.append("expected \(expected.count) files, found \(actual.count)")
+      }
+      return "generation inventory mismatch: " + details.joined(separator: "; ")
+    }
+
+    private static func summarizedPaths(_ paths: [String]) -> String {
+      let limit = 5
+      let visible = paths.prefix(limit).joined(separator: ", ")
+      let remaining = paths.count - min(paths.count, limit)
+      return remaining == 0 ? visible : "\(visible), and \(remaining) more"
     }
   }
 
@@ -136,9 +162,8 @@ package struct ArtifactPublisher: Sendable {
         )
       }
 
-      var ownedPathByCanonicalPath: [
-        PrivateHeaderGeneration.ArtifactPath: PrivateHeaderGeneration.ArtifactPath
-      ] = [:]
+      var ownedPathByCanonicalPath:
+        [PrivateHeaderGeneration.ArtifactPath: PrivateHeaderGeneration.ArtifactPath] = [:]
       for ownedPath in ownedPaths.sorted(by: ArtifactPublisher.artifactPathPrecedes) {
         ownedPathByCanonicalPath[ownedPath] = ownedPath
         let components = ownedPath.rawValue.split(separator: "/").map(String.init)
@@ -258,9 +283,10 @@ package struct ArtifactPublisher: Sendable {
         return
       }
       let matchesRecordedPrefix = existing.recordedByOwnership && existing.path == path
-      let matchesObservedDirectory = existing.observedDirectoryPath.map {
-        $0.rawValue.utf8.elementsEqual(path.rawValue.utf8)
-      } ?? false
+      let matchesObservedDirectory =
+        existing.observedDirectoryPath.map {
+          $0.rawValue.utf8.elementsEqual(path.rawValue.utf8)
+        } ?? false
       guard existing.kind == .directory,
         matchesObservedDirectory || (existing.observedDirectoryPath == nil && matchesRecordedPrefix)
       else {
@@ -441,11 +467,122 @@ package struct ArtifactPublisher: Sendable {
     files: [PrivateHeaderGeneration.ArtifactPath: URL],
     to draft: Draft
   ) throws -> Draft {
-    let plan = try targetMutationPlan(targetID: targetID, files: files, draft: draft)
-    for path in plan.pathsToRemove {
+    try applyCompletedTargets([targetID: files], to: draft)
+  }
+
+  package func validateTargetReplacement(
+    targetID: String,
+    artifacts: [PrivateHeaderGeneration.ArtifactPath],
+    existingArtifactsByTarget: [String: [PrivateHeaderGeneration.ArtifactPath]],
+    opaquePaths: [PrivateHeaderGeneration.ArtifactPath]
+  ) throws {
+    var prospectiveArtifactsByTarget = existingArtifactsByTarget
+    prospectiveArtifactsByTarget[targetID] = artifacts
+    let incomingKeys = Set(artifacts.map(Self.lexicalPathKey))
+    let remainingOpaquePaths = opaquePaths.filter {
+      !incomingKeys.contains(Self.lexicalPathKey($0))
+    }
+    try Self.validatePortableOwnership(
+      artifactsByTarget: prospectiveArtifactsByTarget,
+      opaquePaths: remainingOpaquePaths
+    )
+  }
+
+  package func applyCompletedTargets(
+    _ filesByTarget: [String: [PrivateHeaderGeneration.ArtifactPath: URL]],
+    to draft: Draft
+  ) throws -> Draft {
+    guard !filesByTarget.isEmpty else { return draft }
+    guard try itemKind(at: draft.directory) == .directory else {
+      throw PublisherError.unexpectedItem(
+        path: draft.directory.path,
+        description: "expected draft directory"
+      )
+    }
+
+    var artifactsByTarget = draft.artifactsByTarget
+    var incomingFiles:
+      [(targetID: String, path: PrivateHeaderGeneration.ArtifactPath, source: URL)] = []
+    var incomingPathKeys: Set<[UInt8]> = []
+    var pathsToRemove: [PrivateHeaderGeneration.ArtifactPath] = []
+
+    for targetID in filesByTarget.keys.sorted() {
+      guard let files = filesByTarget[targetID], !files.isEmpty else {
+        throw PublisherError.missingArtifact("target \(targetID) produced no files")
+      }
+      let sortedFiles = files.sorted { $0.key.rawValue < $1.key.rawValue }
+      artifactsByTarget[targetID] = sortedFiles.map(\.key)
+      pathsToRemove += draft.artifactsByTarget[targetID] ?? []
+      for (path, source) in sortedFiles {
+        incomingPathKeys.insert(Self.lexicalPathKey(path))
+        incomingFiles.append((targetID, path, source))
+      }
+    }
+
+    let claimedOpaquePaths = draft.opaquePaths.filter {
+      incomingPathKeys.contains(Self.lexicalPathKey($0))
+    }
+    pathsToRemove += claimedOpaquePaths
+    var seenRemovalKeys: Set<[UInt8]> = []
+    pathsToRemove =
+      pathsToRemove
+      .filter { seenRemovalKeys.insert(Self.lexicalPathKey($0)).inserted }
+      .sorted { Self.lexicalStringPrecedes($0.rawValue, $1.rawValue) }
+    let opaquePaths = draft.opaquePaths.filter {
+      !incomingPathKeys.contains(Self.lexicalPathKey($0))
+    }.sorted {
+      Self.lexicalStringPrecedes($0.rawValue, $1.rawValue)
+    }
+
+    try Self.validatePortableOwnership(
+      artifactsByTarget: draft.artifactsByTarget,
+      opaquePaths: draft.opaquePaths
+    )
+    try Self.validatePortableOwnership(
+      artifactsByTarget: artifactsByTarget,
+      opaquePaths: opaquePaths
+    )
+    for path in pathsToRemove {
+      try preflightRemoval(path, from: draft.directory)
+    }
+
+    let existingItems = try inventoryItems(
+      at: draft.directory,
+      allowHidden: true,
+      allowedExtensions: nil
+    )
+    let namespace = try ProspectiveNamespace(
+      ownedPaths: draft.artifactsByTarget.values.flatMap { $0 } + draft.opaquePaths,
+      existingDirectories: existingItems.compactMap {
+        $0.kind == .directory ? $0.path : nil
+      },
+      existingRegularPaths: existingItems.compactMap {
+        $0.kind == .regular ? $0.path : nil
+      },
+      pathsToRemove: pathsToRemove
+    )
+
+    var copies: [TargetMutationPlan.Copy] = []
+    copies.reserveCapacity(incomingFiles.count)
+    for incoming in incomingFiles.sorted(by: {
+      if $0.path != $1.path { return $0.path.rawValue < $1.path.rawValue }
+      return $0.targetID < $1.targetID
+    }) {
+      guard try itemKind(at: incoming.source) == .regular else {
+        throw PublisherError.unexpectedItem(
+          path: incoming.source.path,
+          description: "expected regular file"
+        )
+      }
+      let destination = try artifactURL(incoming.path, in: draft.directory)
+      try namespace.preflightDestination(incoming.path, destination: destination)
+      copies.append(.init(source: incoming.source, destination: destination))
+    }
+
+    for path in pathsToRemove {
       try removeOwnedArtifact(path, from: draft.directory)
     }
-    for copy in plan.copies {
+    for copy in copies {
       guard try itemKind(at: copy.destination) == nil else {
         throw PublisherError.unexpectedItem(
           path: copy.destination.path,
@@ -461,8 +598,8 @@ package struct ArtifactPublisher: Sendable {
     return Draft(
       generationID: draft.generationID,
       directory: draft.directory,
-      artifactsByTarget: plan.artifactsByTarget,
-      opaquePaths: plan.opaquePaths
+      artifactsByTarget: artifactsByTarget,
+      opaquePaths: opaquePaths
     )
   }
 
@@ -489,6 +626,7 @@ package struct ArtifactPublisher: Sendable {
     _ draft: Draft,
     planFingerprint: String
   ) throws -> PreparedGeneration {
+    try removeFinderMetadata(in: draft.directory)
     try Self.validatePortableOwnership(
       artifactsByTarget: draft.artifactsByTarget,
       opaquePaths: draft.opaquePaths
@@ -1111,6 +1249,45 @@ extension ArtifactPublisher {
     }
   }
 
+  fileprivate func removeFinderMetadata(in root: URL) throws {
+    var enumerationFailure: (URL, any Error)?
+    guard
+      let enumerator = FileManager.default.enumerator(
+        at: root,
+        includingPropertiesForKeys: nil,
+        options: [],
+        errorHandler: { url, error in
+          enumerationFailure = (url, error)
+          return false
+        }
+      )
+    else {
+      throw PublisherError.unexpectedItem(
+        path: root.path,
+        description: "could not enumerate directory"
+      )
+    }
+    var metadataURLs: [URL] = []
+    for case let url as URL in enumerator where url.lastPathComponent == ".DS_Store" {
+      guard try itemKind(at: url) == .regular else {
+        throw PublisherError.unexpectedItem(
+          path: url.path,
+          description: "Finder metadata path is not a regular file"
+        )
+      }
+      metadataURLs.append(url)
+    }
+    if let (url, error) = enumerationFailure {
+      throw PublisherError.unexpectedItem(
+        path: url.path,
+        description: "directory enumeration failed: \(error)"
+      )
+    }
+    for url in metadataURLs {
+      try FileManager.default.removeItem(at: url)
+    }
+  }
+
   fileprivate func inventoryItems(
     at root: URL,
     allowHidden: Bool,
@@ -1138,11 +1315,14 @@ extension ArtifactPublisher {
     var items: [InventoriedItem] = []
     for case let url as URL in enumerator {
       let relative = String(url.standardizedFileURL.path.dropFirst(rootPath.count + 1))
-      if !allowHidden, relative.split(separator: "/").contains(where: { $0.hasPrefix(".") }) {
-        throw PublisherError.unexpectedItem(path: url.path, description: "hidden staging payload")
-      }
       guard let kind = try itemKind(at: url) else {
         throw PublisherError.missingArtifact(url.path)
+      }
+      if url.lastPathComponent == ".DS_Store", kind == .regular {
+        continue
+      }
+      if !allowHidden, relative.split(separator: "/").contains(where: { $0.hasPrefix(".") }) {
+        throw PublisherError.unexpectedItem(path: url.path, description: "hidden staging payload")
       }
       switch kind {
       case .directory:

--- a/Sources/PrivateHeaderKitCore/PrivateHeaderGenerationArtifactPublisher.swift
+++ b/Sources/PrivateHeaderKitCore/PrivateHeaderGenerationArtifactPublisher.swift
@@ -105,6 +105,11 @@ package struct ArtifactPublisher: Sendable {
     let persistedContentDigests: [PrivateHeaderGeneration.ArtifactPath: String]?
   }
 
+  fileprivate struct InspectedGeneration {
+    let decodedMarker: DecodedGenerationMarker
+    let files: [(path: PrivateHeaderGeneration.ArtifactPath, url: URL)]
+  }
+
   fileprivate struct OwnedArtifact {
     let path: PrivateHeaderGeneration.ArtifactPath
     let owner: String
@@ -399,8 +404,13 @@ package struct ArtifactPublisher: Sendable {
   package func inspect() throws -> PrivateHeaderGeneration.PublicationSnapshot {
     try validateBaseURL()
     let stableState = try stablePathState()
-    let markers = try generationMarkers()
     let currentGenerationID = try readCurrentGenerationID()
+    let markers = try generationMarkers(authenticatingContentsOf: currentGenerationID)
+    guard stableState == (try stablePathState()),
+      currentGenerationID == (try readCurrentGenerationID())
+    else {
+      throw PublisherError.markerMismatch("publication pointers changed during inspection")
+    }
     if let currentGenerationID, markers[currentGenerationID] == nil {
       throw PublisherError.markerMismatch(
         "current points to generation without a valid marker: \(currentGenerationID.rawValue)"
@@ -851,7 +861,7 @@ package struct ArtifactPublisher: Sendable {
     }
     let url = generationURL(generationID)
     if try itemKind(at: url) != nil {
-      _ = try validateGeneration(at: url, expectedID: generationID)
+      _ = try inspectGeneration(at: url, expectedID: generationID)
       try FileManager.default.removeItem(at: url)
       try syncDirectory(generationsURL)
     }
@@ -1220,7 +1230,10 @@ extension ArtifactPublisher {
     return try PrivateHeaderGeneration.GenerationID(components[1])
   }
 
-  fileprivate func generationMarkers() throws -> [PrivateHeaderGeneration.GenerationID:
+  fileprivate func generationMarkers(
+    authenticatingContentsOf authenticatedGenerationID:
+      PrivateHeaderGeneration.GenerationID? = nil
+  ) throws -> [PrivateHeaderGeneration.GenerationID:
     PrivateHeaderGeneration.GenerationMarkerSnapshot]
   {
     guard try itemKind(at: generationsURL) != nil else { return [:] }
@@ -1237,7 +1250,12 @@ extension ArtifactPublisher {
           path: entry.path, description: "generation entry is not a directory")
       }
       let id = try PrivateHeaderGeneration.GenerationID(entry.lastPathComponent)
-      markers[id] = try validateGeneration(at: entry, expectedID: id)
+      let inspected = try inspectGeneration(at: entry, expectedID: id)
+      if id == authenticatedGenerationID {
+        markers[id] = try authenticateGenerationContents(inspected, expectedID: id)
+      } else {
+        markers[id] = inspected.decodedMarker.snapshot
+      }
     }
     return markers
   }
@@ -1246,9 +1264,18 @@ extension ArtifactPublisher {
     at directory: URL,
     expectedID: PrivateHeaderGeneration.GenerationID
   ) throws -> PrivateHeaderGeneration.GenerationMarkerSnapshot {
+    try authenticateGenerationContents(
+      inspectGeneration(at: directory, expectedID: expectedID),
+      expectedID: expectedID
+    )
+  }
+
+  fileprivate func inspectGeneration(
+    at directory: URL,
+    expectedID: PrivateHeaderGeneration.GenerationID
+  ) throws -> InspectedGeneration {
     let decodedMarker = try decodeGenerationMarker(at: directory, expectedID: expectedID)
     let marker = decodedMarker.snapshot
-    let markerContentDigests = decodedMarker.persistedContentDigests
     let files = try inventoryRegularFiles(at: directory, allowHidden: true, allowedExtensions: nil)
       .filter { $0.path.rawValue != Self.markerName }
     let actual = Set(files.map(\.path))
@@ -1259,12 +1286,20 @@ extension ArtifactPublisher {
         actual: actual.map(\.rawValue).sorted()
       )
     }
+    return InspectedGeneration(decodedMarker: decodedMarker, files: files)
+  }
+
+  fileprivate func authenticateGenerationContents(
+    _ inspected: InspectedGeneration,
+    expectedID: PrivateHeaderGeneration.GenerationID
+  ) throws -> PrivateHeaderGeneration.GenerationMarkerSnapshot {
+    let marker = inspected.decodedMarker.snapshot
     let actualContentDigests = try Dictionary(
-      uniqueKeysWithValues: files.map { item in
+      uniqueKeysWithValues: inspected.files.map { item in
         (item.path, try Self.sha256(of: item.url))
       }
     )
-    if let markerContentDigests {
+    if let markerContentDigests = inspected.decodedMarker.persistedContentDigests {
       for (artifact, expectedDigest) in markerContentDigests {
         guard actualContentDigests[artifact] == expectedDigest else {
           throw PublisherError.markerMismatch(

--- a/Sources/PrivateHeaderKitCore/PrivateHeaderGenerationArtifactPublisher.swift
+++ b/Sources/PrivateHeaderKitCore/PrivateHeaderGenerationArtifactPublisher.swift
@@ -492,7 +492,24 @@ package struct ArtifactPublisher: Sendable {
     _ filesByTarget: [String: [PrivateHeaderGeneration.ArtifactPath: URL]],
     to draft: Draft
   ) throws -> Draft {
-    guard !filesByTarget.isEmpty else { return draft }
+    try applyCompletedTargets(filesByTarget, to: draft, removesAbsentTargets: false)
+  }
+
+  package func replaceCompletedTargets(
+    _ filesByTarget: [String: [PrivateHeaderGeneration.ArtifactPath: URL]],
+    in draft: Draft
+  ) throws -> Draft {
+    try applyCompletedTargets(filesByTarget, to: draft, removesAbsentTargets: true)
+  }
+
+  private func applyCompletedTargets(
+    _ filesByTarget: [String: [PrivateHeaderGeneration.ArtifactPath: URL]],
+    to draft: Draft,
+    removesAbsentTargets: Bool
+  ) throws -> Draft {
+    if filesByTarget.isEmpty, !removesAbsentTargets {
+      return draft
+    }
     guard try itemKind(at: draft.directory) == .directory else {
       throw PublisherError.unexpectedItem(
         path: draft.directory.path,
@@ -500,11 +517,12 @@ package struct ArtifactPublisher: Sendable {
       )
     }
 
-    var artifactsByTarget = draft.artifactsByTarget
+    var artifactsByTarget = removesAbsentTargets ? [:] : draft.artifactsByTarget
     var incomingFiles:
       [(targetID: String, path: PrivateHeaderGeneration.ArtifactPath, source: URL)] = []
     var incomingPathKeys: Set<[UInt8]> = []
-    var pathsToRemove: [PrivateHeaderGeneration.ArtifactPath] = []
+    var pathsToRemove: [PrivateHeaderGeneration.ArtifactPath] =
+      removesAbsentTargets ? draft.artifactsByTarget.values.flatMap { $0 } : []
 
     for targetID in filesByTarget.keys.sorted() {
       guard let files = filesByTarget[targetID], !files.isEmpty else {

--- a/Sources/PrivateHeaderKitCore/PrivateHeaderGenerationArtifactPublisher.swift
+++ b/Sources/PrivateHeaderKitCore/PrivateHeaderGenerationArtifactPublisher.swift
@@ -97,6 +97,12 @@ package struct ArtifactPublisher: Sendable {
     let artifactChecksum: String
     let artifactsByTarget: [String: [String]]
     let opaquePaths: [String]
+    let contentDigests: [String: String]?
+  }
+
+  fileprivate struct DecodedGenerationMarker {
+    let snapshot: PrivateHeaderGeneration.GenerationMarkerSnapshot
+    let persistedContentDigests: [PrivateHeaderGeneration.ArtifactPath: String]?
   }
 
   fileprivate struct OwnedArtifact {
@@ -462,6 +468,25 @@ package struct ArtifactPublisher: Sendable {
     )
   }
 
+  package func opaquePathsForTargetValidation(
+    in snapshot: PrivateHeaderGeneration.PublicationSnapshot,
+    allowLegacyMigration: Bool,
+    claimedBy artifacts: [PrivateHeaderGeneration.ArtifactPath]
+  ) throws -> [PrivateHeaderGeneration.ArtifactPath] {
+    let opaquePaths: [PrivateHeaderGeneration.ArtifactPath]
+    if let marker = snapshot.currentMarker {
+      opaquePaths = marker.opaquePaths
+    } else if snapshot.stablePathState == .legacyDirectory {
+      guard allowLegacyMigration else {
+        throw PublisherError.legacyMigrationRequiresFresh(stableURL.path)
+      }
+      opaquePaths = try inventoryLegacyFiles(at: stableURL)
+    } else {
+      opaquePaths = []
+    }
+    return Self.unclaimedOpaquePaths(opaquePaths, claimedBy: artifacts)
+  }
+
   package func applyCompletedTarget(
     targetID: String,
     files: [PrivateHeaderGeneration.ArtifactPath: URL],
@@ -475,37 +500,57 @@ package struct ArtifactPublisher: Sendable {
     artifacts: [PrivateHeaderGeneration.ArtifactPath],
     existingArtifactsByTarget: [String: [PrivateHeaderGeneration.ArtifactPath]],
     opaquePaths: [PrivateHeaderGeneration.ArtifactPath]
-  ) throws {
+  ) throws -> [PrivateHeaderGeneration.ArtifactPath] {
     var prospectiveArtifactsByTarget = existingArtifactsByTarget
     prospectiveArtifactsByTarget[targetID] = artifacts
-    let incomingKeys = Set(artifacts.map(Self.lexicalPathKey))
-    let remainingOpaquePaths = opaquePaths.filter {
-      !incomingKeys.contains(Self.lexicalPathKey($0))
-    }
+    let remainingOpaquePaths = Self.unclaimedOpaquePaths(opaquePaths, claimedBy: artifacts)
     try Self.validatePortableOwnership(
       artifactsByTarget: prospectiveArtifactsByTarget,
       opaquePaths: remainingOpaquePaths
     )
+    return remainingOpaquePaths
+  }
+
+  package static func unclaimedOpaquePaths(
+    _ opaquePaths: [PrivateHeaderGeneration.ArtifactPath],
+    claimedBy artifacts: [PrivateHeaderGeneration.ArtifactPath]
+  ) -> [PrivateHeaderGeneration.ArtifactPath] {
+    let claimedPathKeys = Set(artifacts.map(Self.lexicalPathKey))
+    return opaquePaths.filter {
+      !claimedPathKeys.contains(Self.lexicalPathKey($0))
+    }
   }
 
   package func applyCompletedTargets(
     _ filesByTarget: [String: [PrivateHeaderGeneration.ArtifactPath: URL]],
     to draft: Draft
   ) throws -> Draft {
-    try applyCompletedTargets(filesByTarget, to: draft, removesAbsentTargets: false)
+    try applyCompletedTargets(
+      filesByTarget,
+      to: draft,
+      removesAbsentTargets: false,
+      retiringOpaquePaths: []
+    )
   }
 
   package func replaceCompletedTargets(
     _ filesByTarget: [String: [PrivateHeaderGeneration.ArtifactPath: URL]],
+    retiringOpaquePaths: [PrivateHeaderGeneration.ArtifactPath] = [],
     in draft: Draft
   ) throws -> Draft {
-    try applyCompletedTargets(filesByTarget, to: draft, removesAbsentTargets: true)
+    try applyCompletedTargets(
+      filesByTarget,
+      to: draft,
+      removesAbsentTargets: true,
+      retiringOpaquePaths: retiringOpaquePaths
+    )
   }
 
   private func applyCompletedTargets(
     _ filesByTarget: [String: [PrivateHeaderGeneration.ArtifactPath: URL]],
     to draft: Draft,
-    removesAbsentTargets: Bool
+    removesAbsentTargets: Bool,
+    retiringOpaquePaths: [PrivateHeaderGeneration.ArtifactPath]
   ) throws -> Draft {
     if filesByTarget.isEmpty, !removesAbsentTargets {
       return draft
@@ -537,8 +582,10 @@ package struct ArtifactPublisher: Sendable {
       }
     }
 
+    let retiredOpaquePathKeys = Set(retiringOpaquePaths.map(Self.lexicalPathKey))
     let claimedOpaquePaths = draft.opaquePaths.filter {
-      incomingPathKeys.contains(Self.lexicalPathKey($0))
+      let key = Self.lexicalPathKey($0)
+      return incomingPathKeys.contains(key) || retiredOpaquePathKeys.contains(key)
     }
     pathsToRemove += claimedOpaquePaths
     var seenRemovalKeys: Set<[UInt8]> = []
@@ -547,7 +594,8 @@ package struct ArtifactPublisher: Sendable {
       .filter { seenRemovalKeys.insert(Self.lexicalPathKey($0)).inserted }
       .sorted { Self.lexicalStringPrecedes($0.rawValue, $1.rawValue) }
     let opaquePaths = draft.opaquePaths.filter {
-      !incomingPathKeys.contains(Self.lexicalPathKey($0))
+      let key = Self.lexicalPathKey($0)
+      return !incomingPathKeys.contains(key) && !retiredOpaquePathKeys.contains(key)
     }.sorted {
       Self.lexicalStringPrecedes($0.rawValue, $1.rawValue)
     }
@@ -642,18 +690,23 @@ package struct ArtifactPublisher: Sendable {
 
   package func prepareGeneration(
     _ draft: Draft,
-    planFingerprint: String
+    planFingerprint: String,
+    expectedArtifactDigestsByTarget:
+      [String: [PrivateHeaderGeneration.ArtifactPath: String]] = [:]
   ) throws -> PreparedGeneration {
     try removeFinderMetadata(in: draft.directory)
     try Self.validatePortableOwnership(
       artifactsByTarget: draft.artifactsByTarget,
       opaquePaths: draft.opaquePaths
     )
-    let actual = try inventoryRegularFiles(
+    let inventory = try inventoryItems(
       at: draft.directory,
       allowHidden: true,
       allowedExtensions: nil
     )
+    let actual = inventory.compactMap { item in
+      item.kind == .regular ? (path: item.path, url: item.url) : nil
+    }
     let actualPaths = Set(actual.map(\.path))
     let ownedPaths = Set(draft.artifactsByTarget.values.flatMap { $0 })
     let expectedPaths = ownedPaths.union(draft.opaquePaths)
@@ -664,10 +717,33 @@ package struct ArtifactPublisher: Sendable {
       )
     }
 
+    let contentDigests = try Dictionary(
+      uniqueKeysWithValues: actual.map { item in
+        (item.path, try Self.sha256(of: item.url))
+      }
+    )
+    for (targetID, expectedDigests) in expectedArtifactDigestsByTarget {
+      guard let targetArtifacts = draft.artifactsByTarget[targetID],
+        Set(targetArtifacts) == Set(expectedDigests.keys)
+      else {
+        throw PublisherError.markerMismatch(
+          "expected content digests do not match target \(targetID) inventory"
+        )
+      }
+      for (artifact, expectedDigest) in expectedDigests {
+        guard Self.isValidSHA256(expectedDigest), contentDigests[artifact] == expectedDigest else {
+          throw PublisherError.markerMismatch(
+            "artifact contents do not match published target \(targetID): \(artifact.rawValue)"
+          )
+        }
+      }
+    }
+    try synchronizeGenerationContents(inventory, root: draft.directory)
     let checksum = Self.artifactChecksum(
       planFingerprint: planFingerprint,
       artifactsByTarget: draft.artifactsByTarget,
-      opaquePaths: draft.opaquePaths
+      opaquePaths: draft.opaquePaths,
+      contentDigests: contentDigests
     )
     let marker = PrivateHeaderGeneration.GenerationMarkerSnapshot(
       generationID: draft.generationID,
@@ -676,10 +752,19 @@ package struct ArtifactPublisher: Sendable {
       artifactsByTarget: draft.artifactsByTarget.mapValues {
         $0.sorted { $0.rawValue < $1.rawValue }
       },
-      opaquePaths: draft.opaquePaths.sorted { $0.rawValue < $1.rawValue }
+      opaquePaths: draft.opaquePaths.sorted { $0.rawValue < $1.rawValue },
+      contentDigests: contentDigests
     )
     try writeMarker(marker, to: draft.directory)
-    _ = try validateGeneration(at: draft.directory, expectedID: draft.generationID)
+    let decodedMarker = try decodeGenerationMarker(
+      at: draft.directory,
+      expectedID: draft.generationID
+    )
+    guard decodedMarker.snapshot == marker,
+      decodedMarker.persistedContentDigests == marker.contentDigests
+    else {
+      throw PublisherError.markerMismatch("generation marker changed after writing")
+    }
     return PreparedGeneration(
       generationID: draft.generationID,
       draftDirectory: draft.directory,
@@ -692,15 +777,15 @@ package struct ArtifactPublisher: Sendable {
     guard try itemKind(at: generation.finalDirectory) == nil else {
       throw PublisherError.generationAlreadyExists(generation.generationID.rawValue)
     }
-    try atomicRename(from: generation.draftDirectory, to: generation.finalDirectory)
-    try syncDirectory(generationsURL)
     let validated = try validateGeneration(
-      at: generation.finalDirectory,
+      at: generation.draftDirectory,
       expectedID: generation.generationID
     )
     guard validated == generation.marker else {
-      throw PublisherError.markerMismatch("generation changed after final move")
+      throw PublisherError.markerMismatch("generation changed after preparation")
     }
+    try atomicRename(from: generation.draftDirectory, to: generation.finalDirectory)
+    try syncDirectory(generationsURL)
   }
 
   package func switchCurrent(to generationID: PrivateHeaderGeneration.GenerationID) throws {
@@ -972,7 +1057,12 @@ extension ArtifactPublisher {
     artifactsByTarget: [String: [PrivateHeaderGeneration.ArtifactPath]],
     opaquePaths: [PrivateHeaderGeneration.ArtifactPath]
   ) throws {
-    var entries: [OwnedArtifact] = []
+    var entries = [
+      OwnedArtifact(
+        path: PrivateHeaderGeneration.ArtifactPath(rawValue: markerName),
+        owner: "reserved generation marker"
+      )
+    ]
     for targetID in artifactsByTarget.keys.sorted() {
       entries += artifactsByTarget[targetID, default: []].map {
         OwnedArtifact(path: $0, owner: targetID)
@@ -1156,6 +1246,47 @@ extension ArtifactPublisher {
     at directory: URL,
     expectedID: PrivateHeaderGeneration.GenerationID
   ) throws -> PrivateHeaderGeneration.GenerationMarkerSnapshot {
+    let decodedMarker = try decodeGenerationMarker(at: directory, expectedID: expectedID)
+    let marker = decodedMarker.snapshot
+    let markerContentDigests = decodedMarker.persistedContentDigests
+    let files = try inventoryRegularFiles(at: directory, allowHidden: true, allowedExtensions: nil)
+      .filter { $0.path.rawValue != Self.markerName }
+    let actual = Set(files.map(\.path))
+    let expected = Set(marker.artifactsByTarget.values.flatMap { $0 }).union(marker.opaquePaths)
+    guard actual == expected else {
+      throw PublisherError.inventoryMismatch(
+        expected: expected.map(\.rawValue).sorted(),
+        actual: actual.map(\.rawValue).sorted()
+      )
+    }
+    let actualContentDigests = try Dictionary(
+      uniqueKeysWithValues: files.map { item in
+        (item.path, try Self.sha256(of: item.url))
+      }
+    )
+    if let markerContentDigests {
+      for (artifact, expectedDigest) in markerContentDigests {
+        guard actualContentDigests[artifact] == expectedDigest else {
+          throw PublisherError.markerMismatch(
+            "artifact content digest does not match marker: \(artifact.rawValue)"
+          )
+        }
+      }
+    }
+    return PrivateHeaderGeneration.GenerationMarkerSnapshot(
+      generationID: expectedID,
+      planFingerprint: marker.planFingerprint,
+      artifactChecksum: marker.artifactChecksum,
+      artifactsByTarget: marker.artifactsByTarget,
+      opaquePaths: marker.opaquePaths,
+      contentDigests: actualContentDigests
+    )
+  }
+
+  fileprivate func decodeGenerationMarker(
+    at directory: URL,
+    expectedID: PrivateHeaderGeneration.GenerationID
+  ) throws -> DecodedGenerationMarker {
     let markerURL = directory.appendingPathComponent(Self.markerName, isDirectory: false)
     guard try itemKind(at: markerURL) == .regular else {
       throw PublisherError.markerMismatch("missing marker for \(expectedID.rawValue)")
@@ -1166,6 +1297,24 @@ extension ArtifactPublisher {
       artifactsByTarget[targetID] = try paths.map { try PrivateHeaderGeneration.ArtifactPath($0) }
     }
     let opaquePaths = try marker.opaquePaths.map { try PrivateHeaderGeneration.ArtifactPath($0) }
+    let markerContentDigests: [PrivateHeaderGeneration.ArtifactPath: String]?
+    if let rawContentDigests = marker.contentDigests {
+      var decoded: [PrivateHeaderGeneration.ArtifactPath: String] = [:]
+      decoded.reserveCapacity(rawContentDigests.count)
+      for (rawPath, digest) in rawContentDigests {
+        let path = try PrivateHeaderGeneration.ArtifactPath(rawPath)
+        guard decoded[path] == nil, Self.isValidSHA256(digest) else {
+          throw PublisherError.markerMismatch("generation marker has invalid content digests")
+        }
+        decoded[path] = digest
+      }
+      guard decoded.count == rawContentDigests.count else {
+        throw PublisherError.markerMismatch("generation marker has duplicate content digest paths")
+      }
+      markerContentDigests = decoded
+    } else {
+      markerContentDigests = nil
+    }
     try Self.validatePortableOwnership(
       artifactsByTarget: artifactsByTarget,
       opaquePaths: opaquePaths
@@ -1173,30 +1322,33 @@ extension ArtifactPublisher {
     guard marker.generationID == expectedID.rawValue else {
       throw PublisherError.markerMismatch("directory and marker generation IDs differ")
     }
+    let expected = Set(artifactsByTarget.values.flatMap { $0 }).union(opaquePaths)
+    if let markerContentDigests {
+      guard Set(markerContentDigests.keys) == expected else {
+        throw PublisherError.markerMismatch(
+          "generation marker content digests do not match its inventory"
+        )
+      }
+    }
     let checksum = Self.artifactChecksum(
       planFingerprint: marker.planFingerprint,
       artifactsByTarget: artifactsByTarget,
-      opaquePaths: opaquePaths
+      opaquePaths: opaquePaths,
+      contentDigests: markerContentDigests
     )
     guard checksum == marker.artifactChecksum else {
       throw PublisherError.markerMismatch("artifact checksum does not match marker inventory")
     }
-    let files = try inventoryRegularFiles(at: directory, allowHidden: true, allowedExtensions: nil)
-      .filter { $0.path.rawValue != Self.markerName }
-    let actual = Set(files.map(\.path))
-    let expected = Set(artifactsByTarget.values.flatMap { $0 }).union(opaquePaths)
-    guard actual == expected else {
-      throw PublisherError.inventoryMismatch(
-        expected: expected.map(\.rawValue).sorted(),
-        actual: actual.map(\.rawValue).sorted()
-      )
-    }
-    return PrivateHeaderGeneration.GenerationMarkerSnapshot(
-      generationID: expectedID,
-      planFingerprint: marker.planFingerprint,
-      artifactChecksum: marker.artifactChecksum,
-      artifactsByTarget: artifactsByTarget,
-      opaquePaths: opaquePaths
+    return DecodedGenerationMarker(
+      snapshot: PrivateHeaderGeneration.GenerationMarkerSnapshot(
+        generationID: expectedID,
+        planFingerprint: marker.planFingerprint,
+        artifactChecksum: marker.artifactChecksum,
+        artifactsByTarget: artifactsByTarget,
+        opaquePaths: opaquePaths,
+        contentDigests: markerContentDigests ?? [:]
+      ),
+      persistedContentDigests: markerContentDigests
     )
   }
 
@@ -1209,7 +1361,10 @@ extension ArtifactPublisher {
       planFingerprint: snapshot.planFingerprint,
       artifactChecksum: snapshot.artifactChecksum,
       artifactsByTarget: snapshot.artifactsByTarget.mapValues { $0.map(\.rawValue).sorted() },
-      opaquePaths: snapshot.opaquePaths.map(\.rawValue).sorted()
+      opaquePaths: snapshot.opaquePaths.map(\.rawValue).sorted(),
+      contentDigests: Dictionary(
+        uniqueKeysWithValues: snapshot.contentDigests.map { ($0.key.rawValue, $0.value) }
+      )
     )
     let encoder = JSONEncoder()
     encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
@@ -1222,7 +1377,8 @@ extension ArtifactPublisher {
   fileprivate static func artifactChecksum(
     planFingerprint: String,
     artifactsByTarget: [String: [PrivateHeaderGeneration.ArtifactPath]],
-    opaquePaths: [PrivateHeaderGeneration.ArtifactPath]
+    opaquePaths: [PrivateHeaderGeneration.ArtifactPath],
+    contentDigests: [PrivateHeaderGeneration.ArtifactPath: String]? = nil
   ) -> String {
     var lines = ["plan=\(planFingerprint)"]
     for targetID in artifactsByTarget.keys.sorted() {
@@ -1233,8 +1389,53 @@ extension ArtifactPublisher {
     for path in opaquePaths.map(\.rawValue).sorted() {
       lines.append("opaque=\(path)")
     }
+    if let contentDigests {
+      for (path, digest) in contentDigests.sorted(by: {
+        $0.key.rawValue < $1.key.rawValue
+      }) {
+        lines.append("content=\(path.rawValue):\(digest)")
+      }
+    }
     let digest = SHA256.hash(data: Data(lines.joined(separator: "\n").utf8))
     return digest.map { String(format: "%02x", $0) }.joined()
+  }
+
+  fileprivate func synchronizeGenerationContents(
+    _ inventory: [InventoriedItem],
+    root: URL
+  ) throws {
+    for file in inventory.filter({ $0.kind == .regular }).sorted(by: {
+      $0.url.path < $1.url.path
+    }) {
+      try syncFile(file.url)
+    }
+    var directories = Set(
+      inventory.filter { $0.kind == .directory }.map { $0.url.standardizedFileURL }
+    )
+    directories.insert(root.standardizedFileURL)
+    for directory in directories.sorted(by: {
+      let leftDepth = $0.pathComponents.count
+      let rightDepth = $1.pathComponents.count
+      return leftDepth == rightDepth ? $0.path < $1.path : leftDepth > rightDepth
+    }) {
+      try syncDirectory(directory)
+    }
+  }
+
+  fileprivate static func sha256(of url: URL) throws -> String {
+    let handle = try FileHandle(forReadingFrom: url)
+    defer { handle.closeFile() }
+    var hasher = SHA256()
+    while let chunk = try handle.read(upToCount: 1_048_576), !chunk.isEmpty {
+      hasher.update(data: chunk)
+    }
+    return hasher.finalize().map { String(format: "%02x", $0) }.joined()
+  }
+
+  fileprivate static func isValidSHA256(_ digest: String) -> Bool {
+    digest.utf8.count == 64 && digest.utf8.allSatisfy {
+      (48...57).contains($0) || (97...102).contains($0)
+    }
   }
 
   fileprivate func inventoryLegacyFiles(at root: URL) throws -> [PrivateHeaderGeneration
@@ -1244,12 +1445,6 @@ extension ArtifactPublisher {
       .map(\.path)
       .sorted { $0.rawValue < $1.rawValue }
     try Self.validatePortableOwnership(artifactsByTarget: [:], opaquePaths: paths)
-    guard !paths.contains(where: { $0.rawValue == Self.markerName }) else {
-      throw PublisherError.unexpectedItem(
-        path: root.appendingPathComponent(Self.markerName).path,
-        description: "legacy tree contains reserved generation marker path"
-      )
-    }
     return paths
   }
 

--- a/Sources/PrivateHeaderKitCore/PrivateHeaderGenerationArtifactStore.swift
+++ b/Sources/PrivateHeaderKitCore/PrivateHeaderGenerationArtifactStore.swift
@@ -1,3 +1,4 @@
+import CryptoKit
 import Foundation
 
 extension PrivateHeaderGeneration {
@@ -19,6 +20,7 @@ extension PrivateHeaderGeneration {
 
     enum ArtifactStoreError: Error, Equatable, CustomStringConvertible, Sendable {
         case nonFileArtifactRoot(String)
+        case artifactRootTypeMismatch(path: String, actual: String)
         case nonFileStagingDirectory(String)
         case artifactPathEscapesRoot(
             artifactPath: ArtifactPath, artifactRoot: String, resolvedPath: String)
@@ -40,7 +42,12 @@ extension PrivateHeaderGeneration {
         case destinationVolumeCaseSensitivityChanged(root: String, expected: Bool, actual: Bool)
         case stagingDirectoryChanged(String)
         case artifactRootChanged(expected: String, actual: String)
+        case artifactContentChanged(artifactPath: ArtifactPath, path: String)
+        case artifactInventoryFailed(path: String, description: String)
+        case invalidArtifactDigestSet(String)
+        case replacementVolumeMismatch(liveRoot: String, transactionRoot: String)
         case invalidReplacementManifest(String)
+        case cleanupSynchronizationFailed(primary: String, synchronization: String)
         case replacementPreparationCleanupFailed(primary: String, cleanup: String)
         case replacementRollbackFailed(primary: String, rollback: String)
 
@@ -48,6 +55,8 @@ extension PrivateHeaderGeneration {
             switch self {
             case .nonFileArtifactRoot(let artifactRoot):
                 "artifact root must be a file URL: \(artifactRoot)"
+            case .artifactRootTypeMismatch(let path, let actual):
+                "artifact root must be a directory or missing: \(path), found \(actual)"
             case .nonFileStagingDirectory(let stagingDirectory):
                 "staging directory must be a file URL: \(stagingDirectory)"
             case .artifactPathEscapesRoot(let artifactPath, let artifactRoot, let resolvedPath):
@@ -84,8 +93,18 @@ extension PrivateHeaderGeneration {
                 "staging directory changed after commit preflight: \(path)"
             case .artifactRootChanged(let expected, let actual):
                 "artifact root changed after commit preflight: expected \(expected), found \(actual)"
+            case .artifactContentChanged(let artifactPath, let path):
+                "artifact contents changed after replacement preparation: \(artifactPath.rawValue) at \(path)"
+            case .artifactInventoryFailed(let path, let description):
+                "artifact inventory failed at \(path): \(description)"
+            case .invalidArtifactDigestSet(let description):
+                "invalid artifact digest set: \(description)"
+            case .replacementVolumeMismatch(let liveRoot, let transactionRoot):
+                "artifact replacement requires one filesystem volume: \(liveRoot) and \(transactionRoot)"
             case .invalidReplacementManifest(let message):
                 "invalid artifact replacement manifest: \(message)"
+            case .cleanupSynchronizationFailed(let primary, let synchronization):
+                "artifact cleanup failed: \(primary); synchronizing prior deletions also failed: \(synchronization)"
             case .replacementPreparationCleanupFailed(let primary, let cleanup):
                 "artifact replacement preparation failed: \(primary); cleanup also failed: \(cleanup)"
             case .replacementRollbackFailed(let primary, let rollback):
@@ -95,6 +114,8 @@ extension PrivateHeaderGeneration {
     }
 
     struct ArtifactStore: Sendable {
+        private static let replacementManifestVersion = 1
+
         internal struct CommitPlan: Sendable {
             fileprivate let root: ArtifactRootURLs
             fileprivate let stagingDirectory: URL
@@ -111,12 +132,38 @@ extension PrivateHeaderGeneration {
             fileprivate let directory: URL
             fileprivate let incomingRoot: URL
             fileprivate let backupRoot: URL
+            fileprivate let restoreRoot: URL
             internal let runID: PrivateHeaderGeneration.RunID
             internal let targetID: String
             fileprivate let artifactRoot: ArtifactPath
             internal let incomingArtifacts: [ArtifactPath]
             fileprivate let mutationArtifacts: [ArtifactPath]
+            fileprivate let mutationPathKinds: [ArtifactPath: MutationPathKind]
             fileprivate let backedUpArtifacts: [ArtifactPath]
+            fileprivate let incomingDigests: [ArtifactPath: String]
+            fileprivate let backedUpDigests: [ArtifactPath: String]
+            fileprivate let artifactRootIdentity: FileSystemIdentity
+
+            internal var artifactDigests: [ArtifactPath: String] { incomingDigests }
+        }
+
+        fileprivate enum MutationPathKind: String, Codable, Equatable, Sendable {
+            case missing
+            case regularFile
+            case directory
+            case occupiedByRegularFile
+        }
+
+        private struct PreparedMutation {
+            let backedUpArtifacts: [ArtifactPath]
+            let pathKinds: [ArtifactPath: MutationPathKind]
+        }
+
+        fileprivate struct FileSystemIdentity: Codable, Equatable, Sendable {
+            let device: UInt64
+            let inode: UInt64
+
+            var description: String { "\(device):\(inode)" }
         }
 
         private struct ReplacementManifest: Codable {
@@ -126,7 +173,40 @@ extension PrivateHeaderGeneration {
             let artifactRoot: String
             let incomingArtifacts: [String]
             let mutationArtifacts: [String]
+            let mutationPathKinds: [String: MutationPathKind]
             let backedUpArtifacts: [String]
+            let incomingDigests: [String: String]
+            let backedUpDigests: [String: String]
+            let artifactRootIdentity: FileSystemIdentity
+        }
+
+        private struct ReplacementManifestVersion: Decodable {
+            let version: Int
+        }
+
+        private struct RestorationPlan {
+            let sourceRoot: ArtifactRootURLs
+            let destinationRoot: ArtifactRootURLs
+            let entries: [RestorationEntry]
+        }
+
+        private struct RestorationEntry {
+            let artifact: ArtifactPath
+            let source: URL
+            let destination: URL
+            let digest: String
+        }
+
+        private struct IncomingRollbackPlan {
+            let root: ArtifactRootURLs
+            let stagedRoot: ArtifactRootURLs
+            let installedArtifacts: [ArtifactPath]
+        }
+
+        private struct RollbackPlan {
+            let incoming: IncomingRollbackPlan
+            let replacementDirectories: [ArtifactPath]
+            let restoration: RestorationPlan?
         }
 
         public let artifactRoot: URL
@@ -139,7 +219,10 @@ extension PrivateHeaderGeneration {
             _ artifact: ArtifactPath,
             fileManager: FileManager = .default
         ) throws -> Bool {
-            let root = try Self.artifactRootURLs(for: artifactRoot)
+            let root = try Self.artifactRootURLs(
+                for: artifactRoot,
+                fileManager: fileManager
+            )
             switch try Self.inspectArtifactPath(
                 artifact,
                 root: root,
@@ -149,6 +232,210 @@ extension PrivateHeaderGeneration {
                 return true
             case .missingParent, .occupiedParent, .symbolicLinkParent, .leaf:
                 return false
+            }
+        }
+
+        internal func inventoryRegularArtifacts(
+            fileManager: FileManager = .default
+        ) throws -> [ArtifactPath] {
+            let root = try Self.artifactRootURLs(
+                for: artifactRoot,
+                fileManager: fileManager
+            )
+            guard
+                try Self.artifactItemKind(
+                    at: root.unresolved,
+                    fileManager: fileManager
+                ) == .directory
+            else {
+                throw ArtifactStoreError.artifactRootTypeMismatch(
+                    path: root.unresolved.path,
+                    actual: "missing"
+                )
+            }
+            var enumerationFailure: (URL, any Error)?
+            guard
+                let enumerator = fileManager.enumerator(
+                    at: root.unresolved,
+                    includingPropertiesForKeys: nil,
+                    options: [],
+                    errorHandler: { url, error in
+                        enumerationFailure = (url, error)
+                        return false
+                    }
+                )
+            else {
+                throw ArtifactStoreError.artifactInventoryFailed(
+                    path: root.unresolved.path,
+                    description: "could not enumerate directory"
+                )
+            }
+
+            let rootPath = root.unresolved.path
+            var artifacts: [ArtifactPath] = []
+            for case let url as URL in enumerator {
+                let standardized = url.standardizedFileURL
+                guard standardized.path.hasPrefix(rootPath + "/") else {
+                    throw ArtifactStoreError.artifactInventoryFailed(
+                        path: standardized.path,
+                        description: "enumerated item escapes artifact root"
+                    )
+                }
+                let relativePath = String(standardized.path.dropFirst(rootPath.count + 1))
+                let artifact = try ArtifactPath(relativePath)
+                guard
+                    let kind = try Self.artifactItemKind(
+                        at: standardized,
+                        fileManager: fileManager
+                    )
+                else {
+                    throw ArtifactStoreError.artifactInventoryFailed(
+                        path: standardized.path,
+                        description: "item disappeared during enumeration"
+                    )
+                }
+                switch kind {
+                case .directory:
+                    continue
+                case .regularFile:
+                    if standardized.lastPathComponent == ".DS_Store" { continue }
+                    artifacts.append(artifact)
+                case .symbolicLink:
+                    throw ArtifactStoreError.symbolicLinkInArtifactPath(
+                        artifactPath: artifact,
+                        symbolicLinkPath: standardized.path
+                    )
+                case .other:
+                    throw ArtifactStoreError.artifactInventoryFailed(
+                        path: standardized.path,
+                        description: "unsupported filesystem item"
+                    )
+                }
+            }
+            if let (url, error) = enumerationFailure {
+                throw ArtifactStoreError.artifactInventoryFailed(
+                    path: url.path,
+                    description: "directory enumeration failed: \(error)"
+                )
+            }
+            return artifacts.sorted { $0.rawValue < $1.rawValue }
+        }
+
+        internal func artifactsExcludingEquivalentPaths(
+            _ candidates: [ArtifactPath],
+            retainedArtifacts: [ArtifactPath],
+            fileManager: FileManager = .default
+        ) throws -> [ArtifactPath] {
+            let root = try Self.artifactRootURLs(
+                for: artifactRoot,
+                fileManager: fileManager
+            )
+            let volumeSupportsCaseSensitiveNames =
+                try Self.destinationVolumeSupportsCaseSensitiveNames(
+                    for: root,
+                    fileManager: fileManager
+                )
+            let retainedKeys = Set(retainedArtifacts.map {
+                Self.artifactPathIdentityKey(
+                    for: $0,
+                    volumeSupportsCaseSensitiveNames: volumeSupportsCaseSensitiveNames
+                )
+            })
+            return Self.cleanupCandidates(
+                manifestArtifacts: candidates.filter {
+                    !retainedKeys.contains(
+                        Self.artifactPathIdentityKey(
+                            for: $0,
+                            volumeSupportsCaseSensitiveNames: volumeSupportsCaseSensitiveNames
+                        )
+                    )
+                }
+            )
+        }
+
+        internal func artifactsMatchDigests(
+            _ artifacts: [ArtifactPath],
+            digests: [ArtifactPath: String],
+            fileManager: FileManager = .default
+        ) throws -> Bool {
+            guard !digests.isEmpty else { return false }
+            guard Set(digests.keys) == Set(artifacts), digests.values.allSatisfy(Self.isValidSHA256)
+            else {
+                throw ArtifactStoreError.invalidArtifactDigestSet(
+                    "digest paths or values do not match the target artifact set"
+                )
+            }
+            let root = try Self.artifactRootURLs(
+                for: artifactRoot,
+                fileManager: fileManager
+            )
+            for artifact in artifacts {
+                guard
+                    case .leaf(let url, .some(.regularFile)) = try Self.inspectArtifactPath(
+                        artifact,
+                        root: root,
+                        fileManager: fileManager
+                    ),
+                    let expectedDigest = digests[artifact]
+                else {
+                    return false
+                }
+                guard try Self.sha256(of: url) == expectedDigest else { return false }
+            }
+            return true
+        }
+
+        internal func validateExistingArtifacts(
+            _ artifacts: [ArtifactPath],
+            digests: [ArtifactPath: String],
+            fileManager: FileManager = .default
+        ) throws {
+            guard Set(digests.keys) == Set(artifacts), digests.values.allSatisfy(Self.isValidSHA256)
+            else {
+                throw ArtifactStoreError.invalidArtifactDigestSet(
+                    "digest paths or values do not match the artifact set"
+                )
+            }
+            let root = try Self.artifactRootURLs(
+                for: artifactRoot,
+                fileManager: fileManager
+            )
+            for artifact in artifacts {
+                let inspection = try Self.inspectArtifactPath(
+                    artifact,
+                    root: root,
+                    fileManager: fileManager
+                )
+                switch inspection {
+                case .missingParent, .leaf(_, nil):
+                    continue
+                case .leaf(let url, .some(.regularFile)):
+                    guard let expectedDigest = digests[artifact],
+                        try Self.sha256(of: url) == expectedDigest
+                    else {
+                        throw ArtifactStoreError.artifactContentChanged(
+                            artifactPath: artifact,
+                            path: url.path
+                        )
+                    }
+                case .symbolicLinkParent(let url):
+                    throw ArtifactStoreError.symbolicLinkInArtifactPath(
+                        artifactPath: artifact,
+                        symbolicLinkPath: url.path
+                    )
+                case .occupiedParent(let url, let kind):
+                    throw ArtifactStoreError.cleanupParentTypeMismatch(
+                        artifactPath: artifact,
+                        parentPath: url.path,
+                        actual: Self.artifactItemKindDescription(kind)
+                    )
+                case .leaf(_, .some(let kind)):
+                    throw ArtifactStoreError.commitDestinationTypeMismatch(
+                        artifactPath: artifact,
+                        expected: "regular file or missing",
+                        actual: Self.artifactItemKindDescription(kind)
+                    )
+                }
             }
         }
 
@@ -164,6 +451,138 @@ extension PrivateHeaderGeneration {
             )
         }
 
+        internal func restoreArtifact(
+            _ artifact: ArtifactPath,
+            from source: URL,
+            stagingDirectory: URL,
+            synchronizeExistingArtifact: Bool,
+            fileManager: FileManager = .default
+        ) throws {
+            guard
+                try Self.artifactItemKind(at: source, fileManager: fileManager) == .regularFile
+            else {
+                throw ArtifactStoreError.stagedArtifactIsNotRegularFile(source.path)
+            }
+            let root = try Self.artifactRootURLs(
+                for: artifactRoot,
+                fileManager: fileManager
+            )
+            let destination = Self.artifactURL(artifact, under: root.unresolved)
+            if let existing = try Self.restorableArtifactURL(
+                artifact,
+                root: root,
+                fileManager: fileManager
+            ) {
+                if fileManager.contentsEqual(atPath: source.path, andPath: existing.path) {
+                    if synchronizeExistingArtifact {
+                        try ManagedFileSystem.syncFile(existing)
+                        try ManagedFileSystem.syncDirectory(
+                            existing.deletingLastPathComponent().standardizedFileURL
+                        )
+                    }
+                    return
+                }
+            }
+
+            let destinationDirectory = destination.deletingLastPathComponent().standardizedFileURL
+            try ManagedFileSystem.ensureRealDirectory(destinationDirectory)
+            let refreshedRoot = try Self.artifactRootURLs(
+                for: artifactRoot,
+                fileManager: fileManager
+            )
+            guard refreshedRoot == root else {
+                throw ArtifactStoreError.artifactRootChanged(
+                    expected: root.resolved.path,
+                    actual: refreshedRoot.resolved.path
+                )
+            }
+            if let existing = try Self.restorableArtifactURL(
+                artifact,
+                root: refreshedRoot,
+                fileManager: fileManager
+            ) {
+                if fileManager.contentsEqual(atPath: source.path, andPath: existing.path) {
+                    if synchronizeExistingArtifact {
+                        try ManagedFileSystem.syncFile(existing)
+                        try ManagedFileSystem.syncDirectory(
+                            existing.deletingLastPathComponent().standardizedFileURL
+                        )
+                    }
+                    return
+                }
+            }
+
+            guard try ManagedFileSystem.itemKind(at: stagingDirectory) == .directory else {
+                throw ArtifactStoreError.stagedArtifactIsNotDirectory(stagingDirectory.path)
+            }
+            let temporary = stagingDirectory.appendingPathComponent(
+                "artifact-\(UUID().uuidString.lowercased())",
+                isDirectory: false
+            )
+            do {
+                try fileManager.copyItem(at: source, to: temporary)
+                try ManagedFileSystem.syncFile(temporary)
+                try ManagedFileSystem.atomicRename(from: temporary, to: destination)
+                try ManagedFileSystem.syncFile(destination)
+                try ManagedFileSystem.syncDirectory(destinationDirectory)
+                try ManagedFileSystem.syncDirectory(stagingDirectory)
+            } catch {
+                try? fileManager.removeItem(at: temporary)
+                throw error
+            }
+            guard fileManager.contentsEqual(atPath: source.path, andPath: destination.path) else {
+                throw ArtifactStoreError.artifactContentChanged(
+                    artifactPath: artifact,
+                    path: destination.path
+                )
+            }
+        }
+
+        private static func restorableArtifactURL(
+            _ artifact: ArtifactPath,
+            root: ArtifactRootURLs,
+            fileManager: FileManager
+        ) throws -> URL? {
+            switch try inspectArtifactPath(
+                artifact,
+                root: root,
+                fileManager: fileManager
+            ) {
+            case .missingParent, .leaf(_, nil):
+                return nil
+            case .leaf(let existing, .some(.regularFile)):
+                return existing
+            case .occupiedParent(let path, let kind):
+                throw ArtifactStoreError.cleanupParentTypeMismatch(
+                    artifactPath: artifact,
+                    parentPath: path.path,
+                    actual: artifactItemKindDescription(kind)
+                )
+            case .symbolicLinkParent(let path):
+                throw ArtifactStoreError.symbolicLinkInArtifactPath(
+                    artifactPath: artifact,
+                    symbolicLinkPath: path.path
+                )
+            case .leaf(let path, .some(.symbolicLink)):
+                throw ArtifactStoreError.symbolicLinkInArtifactPath(
+                    artifactPath: artifact,
+                    symbolicLinkPath: path.path
+                )
+            case .leaf(_, .some(.directory)):
+                throw ArtifactStoreError.commitDestinationTypeMismatch(
+                    artifactPath: artifact,
+                    expected: "regular file or missing",
+                    actual: "directory"
+                )
+            case .leaf(_, .some(.other)):
+                throw ArtifactStoreError.commitDestinationTypeMismatch(
+                    artifactPath: artifact,
+                    expected: "regular file or missing",
+                    actual: "special file"
+                )
+            }
+        }
+
         internal func prepareCommit(
             stagingDirectory: URL,
             stagedSourceDirectory: URL,
@@ -171,7 +590,28 @@ extension PrivateHeaderGeneration {
             artifacts: [ArtifactPath],
             fileManager: FileManager = .default
         ) throws -> CommitPlan {
-            let root = try Self.artifactRootURLs(for: self.artifactRoot)
+            let plan = try makeCommitPlan(
+                stagingDirectory: stagingDirectory,
+                stagedSourceDirectory: stagedSourceDirectory,
+                artifactRoot: artifactRoot,
+                artifacts: artifacts,
+                fileManager: fileManager
+            )
+            try preflightCommit(plan, fileManager: fileManager)
+            return plan
+        }
+
+        private func makeCommitPlan(
+            stagingDirectory: URL,
+            stagedSourceDirectory: URL,
+            artifactRoot: ArtifactPath,
+            artifacts: [ArtifactPath],
+            fileManager: FileManager
+        ) throws -> CommitPlan {
+            let root = try Self.artifactRootURLs(
+                for: self.artifactRoot,
+                fileManager: fileManager
+            )
             let destinationVolumeSupportsCaseSensitiveNames =
                 try Self
                 .destinationVolumeSupportsCaseSensitiveNames(
@@ -205,7 +645,6 @@ extension PrivateHeaderGeneration {
                 destinationVolumeSupportsCaseSensitiveNames:
                     destinationVolumeSupportsCaseSensitiveNames
             )
-            try preflightCommit(plan, fileManager: fileManager)
             return plan
         }
 
@@ -224,28 +663,44 @@ extension PrivateHeaderGeneration {
         }
 
         internal func prepareReplacement(
-            _ plan: CommitPlan,
+            stagingDirectory: URL,
+            stagedSourceDirectory: URL,
+            artifactRoot: ArtifactPath,
+            artifacts: [ArtifactPath],
             removing artifactsToRemove: [ArtifactPath],
             runID: PrivateHeaderGeneration.RunID,
             targetID: String,
             at transactionDirectory: URL,
-            fileManager: FileManager = .default
+            fileManager: FileManager = .default,
+            exclusiveRename: (URL, URL) throws -> Void =
+                ManagedFileSystem.atomicRenameExclusively
         ) throws -> Replacement {
-            try preflightCommit(plan, fileManager: fileManager)
+            let plan = try makeCommitPlan(
+                stagingDirectory: stagingDirectory,
+                stagedSourceDirectory: stagedSourceDirectory,
+                artifactRoot: artifactRoot,
+                artifacts: artifacts,
+                fileManager: fileManager
+            )
+            try preflightCommitInputs(plan, fileManager: fileManager)
+            let artifactRootIdentity = try Self.directoryIdentity(
+                at: plan.root.unresolved,
+                fileManager: fileManager
+            )
             let incomingArtifacts = plan.artifacts.sorted { $0.rawValue < $1.rawValue }
             let mutationArtifacts = Self.cleanupCandidates(
                 manifestArtifacts: artifactsToRemove,
                 attemptedArtifacts: incomingArtifacts
             )
-            _ = try Self.cleanupArtifactInspections(
-                for: mutationArtifacts,
-                root: plan.root,
-                fileManager: fileManager
-            )
 
             let directory = transactionDirectory.standardizedFileURL
             let incomingRoot = directory.appendingPathComponent("incoming", isDirectory: true)
             let backupRoot = directory.appendingPathComponent("backup", isDirectory: true)
+            let restoreRoot = directory.appendingPathComponent("restore", isDirectory: true)
+            let durableAncestor = try Self.nearestExistingRealDirectory(
+                startingAt: directory.deletingLastPathComponent(),
+                fileManager: fileManager
+            )
             do {
                 guard try Self.artifactItemKind(at: directory, fileManager: fileManager) == nil else {
                     throw ArtifactStoreError.invalidReplacementManifest(
@@ -263,6 +718,21 @@ extension PrivateHeaderGeneration {
                     at: backupRoot,
                     withIntermediateDirectories: true
                 )
+                try fileManager.createDirectory(
+                    at: restoreRoot,
+                    withIntermediateDirectories: true
+                )
+                try Self.validateReplacementVolumes(
+                    liveRoot: plan.root.unresolved,
+                    liveRootIdentity: artifactRootIdentity,
+                    transactionRoots: [incomingRoot, restoreRoot],
+                    fileManager: fileManager
+                )
+                try Self.validateExclusiveRenameSupport(
+                    in: directory,
+                    fileManager: fileManager,
+                    exclusiveRename: exclusiveRename
+                )
 
                 let incomingStore = ArtifactStore(artifactRoot: incomingRoot)
                 let incomingPlan = try incomingStore.prepareCommit(
@@ -273,25 +743,59 @@ extension PrivateHeaderGeneration {
                     fileManager: fileManager
                 )
                 try incomingStore.copy(incomingPlan, fileManager: fileManager)
-
-                let backedUpArtifacts = try backupExistingArtifacts(
-                    mutationArtifacts,
-                    from: plan.root,
-                    to: backupRoot,
+                let incomingDigests = try Self.artifactDigests(
+                    for: incomingArtifacts,
+                    under: incomingRoot,
                     fileManager: fileManager
                 )
+
+                let preparedMutation = try prepareMutation(
+                    mutationArtifacts,
+                    preferring: artifactsToRemove,
+                    from: plan.root,
+                    to: backupRoot,
+                    volumeSupportsCaseSensitiveNames:
+                        plan.destinationVolumeSupportsCaseSensitiveNames,
+                    fileManager: fileManager
+                )
+                let backedUpArtifacts = preparedMutation.backedUpArtifacts
+                let backedUpDigests = try Self.artifactDigests(
+                    for: backedUpArtifacts,
+                    under: backupRoot,
+                    fileManager: fileManager
+                )
+                try Self.copyArtifacts(
+                    backedUpArtifacts,
+                    from: backupRoot,
+                    to: restoreRoot,
+                    expectedDigests: backedUpDigests,
+                    fileManager: fileManager
+                )
+                try Self.syncTree(at: incomingRoot, fileManager: fileManager)
+                try Self.syncTree(at: backupRoot, fileManager: fileManager)
+                try Self.syncTree(at: restoreRoot, fileManager: fileManager)
                 let replacement = Replacement(
                     directory: directory,
                     incomingRoot: incomingRoot,
                     backupRoot: backupRoot,
+                    restoreRoot: restoreRoot,
                     runID: runID,
                     targetID: targetID,
                     artifactRoot: plan.artifactRoot,
                     incomingArtifacts: incomingArtifacts,
                     mutationArtifacts: mutationArtifacts,
-                    backedUpArtifacts: backedUpArtifacts
+                    mutationPathKinds: preparedMutation.pathKinds,
+                    backedUpArtifacts: backedUpArtifacts,
+                    incomingDigests: incomingDigests,
+                    backedUpDigests: backedUpDigests,
+                    artifactRootIdentity: artifactRootIdentity
                 )
                 try writeManifest(for: replacement, fileManager: fileManager)
+                try Self.syncDirectoryChain(
+                    from: directory,
+                    through: durableAncestor,
+                    fileManager: fileManager
+                )
                 return replacement
             } catch {
                 let primary = error
@@ -313,7 +817,13 @@ extension PrivateHeaderGeneration {
             _ replacement: Replacement,
             fileManager: FileManager = .default
         ) throws {
+            try preflightReplacementApply(replacement, fileManager: fileManager)
+            try markReplacementApplyStarted(replacement, fileManager: fileManager)
             do {
+                _ = try cleanupManagedArtifacts(
+                    replacement.backedUpArtifacts,
+                    fileManager: fileManager
+                )
                 let incomingSourceDirectory = Self.artifactURL(
                     replacement.artifactRoot,
                     under: replacement.incomingRoot
@@ -326,11 +836,12 @@ extension PrivateHeaderGeneration {
                     fileManager: fileManager
                 )
                 try applyPreparedIncoming(incomingPlan, fileManager: fileManager)
-                let incomingArtifactSet = Set(replacement.incomingArtifacts)
-                let obsoleteArtifacts = replacement.mutationArtifacts.filter {
-                    !incomingArtifactSet.contains($0)
-                }
-                _ = try cleanupManagedArtifacts(obsoleteArtifacts, fileManager: fileManager)
+                try synchronizeReplacementMutations(
+                    replacement,
+                    sourceRoot: replacement.incomingRoot,
+                    sourceArtifacts: replacement.incomingArtifacts,
+                    fileManager: fileManager
+                )
             } catch {
                 let primary = error
                 do {
@@ -349,28 +860,879 @@ extension PrivateHeaderGeneration {
             _ replacement: Replacement,
             fileManager: FileManager = .default
         ) throws {
+            guard try replacementApplyHasStarted(replacement, fileManager: fileManager) else {
+                return
+            }
+            try validateReplacementArtifactRoot(replacement, fileManager: fileManager)
+            try validateReplacementVolumes(replacement, fileManager: fileManager)
+            let plan = try prepareRollbackPlan(replacement, fileManager: fileManager)
+            try cleanupInstalledIncomingArtifacts(
+                plan.incoming,
+                expectedDigests: replacement.incomingDigests,
+                fileManager: fileManager
+            )
+            try cleanupReplacementDirectories(
+                plan.replacementDirectories,
+                root: plan.incoming.root,
+                fileManager: fileManager
+            )
             _ = try cleanupManagedArtifacts(
-                replacement.mutationArtifacts,
+                plan.restoration?.entries.map(\.artifact) ?? [],
                 fileManager: fileManager
             )
-            guard !replacement.backedUpArtifacts.isEmpty else { return }
-            let backupSourceDirectory = Self.artifactURL(
-                replacement.artifactRoot,
-                under: replacement.backupRoot
-            )
-            let restorePlan = try prepareCommit(
-                stagingDirectory: replacement.backupRoot,
-                stagedSourceDirectory: backupSourceDirectory,
-                artifactRoot: replacement.artifactRoot,
-                artifacts: replacement.backedUpArtifacts,
+            if let restoration = plan.restoration {
+                try restoreBackedUpArtifacts(
+                    restoration,
+                    fileManager: fileManager
+                )
+            }
+            try synchronizeReplacementMutations(
+                replacement,
+                sourceRoot: plan.restoration?.sourceRoot.unresolved,
+                sourceArtifacts: replacement.backedUpArtifacts,
                 fileManager: fileManager
             )
-            try copy(restorePlan, fileManager: fileManager)
+        }
+
+        private func preflightReplacementApply(
+            _ replacement: Replacement,
+            fileManager: FileManager
+        ) throws {
+            try validateReplacementArtifactRoot(replacement, fileManager: fileManager)
+            try validateReplacementVolumes(replacement, fileManager: fileManager)
+            try validateTransactionArtifacts(replacement, fileManager: fileManager)
+            guard try !replacementApplyHasStarted(replacement, fileManager: fileManager) else {
+                throw ArtifactStoreError.invalidReplacementManifest(
+                    "replacement apply already started at \(replacement.directory.path)"
+                )
+            }
+
+            let root = try Self.artifactRootURLs(
+                for: artifactRoot,
+                fileManager: fileManager
+            )
+            let volumeSupportsCaseSensitiveNames =
+                try Self.destinationVolumeSupportsCaseSensitiveNames(
+                    for: root,
+                    fileManager: fileManager
+                )
+            let currentMutationPathKinds = try Self.mutationPathKinds(
+                for: replacement.mutationArtifacts,
+                root: root,
+                fileManager: fileManager
+            )
+            for artifact in replacement.mutationArtifacts {
+                guard
+                    currentMutationPathKinds[artifact]
+                        == replacement.mutationPathKinds[artifact]
+                else {
+                    throw ArtifactStoreError.artifactContentChanged(
+                        artifactPath: artifact,
+                        path: Self.artifactURL(artifact, under: artifactRoot).path
+                    )
+                }
+            }
+            for artifact in replacement.backedUpArtifacts {
+                guard
+                    case .leaf(let url, .some(.regularFile)) = try Self.inspectArtifactPath(
+                        artifact,
+                        root: root,
+                        fileManager: fileManager
+                    ),
+                    try Self.sha256(of: url) == replacement.backedUpDigests[artifact]
+                else {
+                    throw ArtifactStoreError.artifactContentChanged(
+                        artifactPath: artifact,
+                        path: Self.artifactURL(artifact, under: artifactRoot).path
+                    )
+                }
+            }
+
+            for artifact in replacement.incomingArtifacts {
+                switch try Self.inspectArtifactPath(
+                    artifact,
+                    root: root,
+                    fileManager: fileManager
+                ) {
+                case .missingParent, .leaf(_, nil):
+                    continue
+                case .leaf(let url, .some(.regularFile)):
+                    guard
+                        let backedUpArtifact = replacement.backedUpArtifacts.first(where: {
+                            Self.artifactPathsAreEquivalent(
+                                $0,
+                                artifact,
+                                volumeSupportsCaseSensitiveNames:
+                                    volumeSupportsCaseSensitiveNames
+                            )
+                        }),
+                        try Self.sha256(of: url)
+                            == replacement.backedUpDigests[backedUpArtifact]
+                    else {
+                        throw ArtifactStoreError.artifactContentChanged(
+                            artifactPath: artifact,
+                            path: url.path
+                        )
+                    }
+                case .occupiedParent(_, .regularFile):
+                    guard replacement.backedUpArtifacts.contains(where: {
+                        Self.pathIsAncestor(
+                            $0,
+                            of: artifact,
+                            volumeSupportsCaseSensitiveNames:
+                                volumeSupportsCaseSensitiveNames
+                        )
+                    }) else {
+                        throw ArtifactStoreError.artifactContentChanged(
+                            artifactPath: artifact,
+                            path: Self.artifactURL(artifact, under: artifactRoot).path
+                        )
+                    }
+                case .leaf(_, .some(.directory)):
+                    guard replacement.backedUpArtifacts.contains(where: {
+                        Self.pathIsAncestor(
+                            artifact,
+                            of: $0,
+                            volumeSupportsCaseSensitiveNames:
+                                volumeSupportsCaseSensitiveNames
+                        )
+                    }) else {
+                        throw ArtifactStoreError.artifactContentChanged(
+                            artifactPath: artifact,
+                            path: Self.artifactURL(artifact, under: artifactRoot).path
+                        )
+                    }
+                case .occupiedParent(let url, let kind):
+                    throw ArtifactStoreError.cleanupParentTypeMismatch(
+                        artifactPath: artifact,
+                        parentPath: url.path,
+                        actual: Self.artifactItemKindDescription(kind)
+                    )
+                case .symbolicLinkParent(let url), .leaf(let url, .some(.symbolicLink)):
+                    throw ArtifactStoreError.symbolicLinkInArtifactPath(
+                        artifactPath: artifact,
+                        symbolicLinkPath: url.path
+                    )
+                case .leaf(let url, .some(.other)):
+                    throw ArtifactStoreError.commitDestinationTypeMismatch(
+                        artifactPath: artifact,
+                        expected: "regular file, directory, or missing",
+                        actual: "special file at \(url.path)"
+                    )
+                }
+            }
+        }
+
+        private func prepareRollbackPlan(
+            _ replacement: Replacement,
+            fileManager: FileManager
+        ) throws -> RollbackPlan {
+            let restoration = try prepareBackedUpArtifactRestoration(
+                replacement,
+                fileManager: fileManager
+            )
+            let incoming = try prepareIncomingRollback(
+                replacement,
+                fileManager: fileManager
+            )
+            let replacementDirectories = try validateBackedUpLiveArtifactsForRollback(
+                replacement,
+                installedIncomingArtifacts: incoming.installedArtifacts,
+                fileManager: fileManager
+            )
+            return RollbackPlan(
+                incoming: incoming,
+                replacementDirectories: replacementDirectories,
+                restoration: restoration
+            )
+        }
+
+        private func prepareIncomingRollback(
+            _ replacement: Replacement,
+            fileManager: FileManager
+        ) throws -> IncomingRollbackPlan {
+            let root = try Self.artifactRootURLs(
+                for: artifactRoot,
+                fileManager: fileManager
+            )
+            let stagedRoot = try Self.artifactRootURLs(
+                for: replacement.incomingRoot,
+                fileManager: fileManager
+            )
+            try Self.validateStagedRoot(stagedRoot, fileManager: fileManager)
+            let volumeSupportsCaseSensitiveNames =
+                try Self.destinationVolumeSupportsCaseSensitiveNames(
+                    for: root,
+                    fileManager: fileManager
+                )
+            var installedArtifacts: [ArtifactPath] = []
+
+            for artifact in Self.cleanupOperationOrder(replacement.incomingArtifacts) {
+                let expectedDigest = try Self.requiredDigest(
+                    for: artifact,
+                    in: replacement.incomingDigests
+                )
+                switch try Self.inspectArtifactPath(
+                    artifact,
+                    root: stagedRoot,
+                    fileManager: fileManager
+                ) {
+                case .leaf(let source, .some(.regularFile)):
+                    guard try Self.sha256(of: source) == expectedDigest else {
+                        throw ArtifactStoreError.artifactContentChanged(
+                            artifactPath: artifact,
+                            path: source.path
+                        )
+                    }
+                case .missingParent, .leaf(_, nil):
+                    switch try Self.inspectArtifactPath(
+                        artifact,
+                        root: root,
+                        fileManager: fileManager
+                    ) {
+                    case .missingParent, .leaf(_, nil):
+                        break
+                    case .leaf(let destination, .some(.regularFile)):
+                        let actualDigest = try Self.sha256(of: destination)
+                        let matchesBackedUpArtifact = replacement.backedUpDigests.contains(where: {
+                            Self.artifactPathsAreEquivalent(
+                                $0.key,
+                                artifact,
+                                volumeSupportsCaseSensitiveNames:
+                                    volumeSupportsCaseSensitiveNames
+                            ) && $0.value == actualDigest
+                        })
+                        if matchesBackedUpArtifact {
+                            break
+                        }
+                        if actualDigest == expectedDigest {
+                            installedArtifacts.append(artifact)
+                        } else {
+                            throw ArtifactStoreError.artifactContentChanged(
+                                artifactPath: artifact,
+                                path: destination.path
+                            )
+                        }
+                    case .leaf(_, .some(.directory)):
+                        guard replacement.backedUpArtifacts.contains(where: {
+                            Self.pathIsAncestor(
+                                artifact,
+                                of: $0,
+                                volumeSupportsCaseSensitiveNames:
+                                    volumeSupportsCaseSensitiveNames
+                            )
+                        }) else {
+                            throw ArtifactStoreError.artifactContentChanged(
+                                artifactPath: artifact,
+                                path: Self.artifactURL(artifact, under: artifactRoot).path
+                            )
+                        }
+                    case .occupiedParent(_, .regularFile):
+                        guard replacement.backedUpArtifacts.contains(where: {
+                            Self.pathIsAncestor(
+                                $0,
+                                of: artifact,
+                                volumeSupportsCaseSensitiveNames:
+                                    volumeSupportsCaseSensitiveNames
+                            )
+                        }) else {
+                            throw ArtifactStoreError.artifactContentChanged(
+                                artifactPath: artifact,
+                                path: Self.artifactURL(artifact, under: artifactRoot).path
+                            )
+                        }
+                    case .occupiedParent(let url, let kind):
+                        throw ArtifactStoreError.cleanupParentTypeMismatch(
+                            artifactPath: artifact,
+                            parentPath: url.path,
+                            actual: Self.artifactItemKindDescription(kind)
+                        )
+                    case .symbolicLinkParent(let url),
+                        .leaf(let url, .some(.symbolicLink)):
+                        throw ArtifactStoreError.symbolicLinkInArtifactPath(
+                            artifactPath: artifact,
+                            symbolicLinkPath: url.path
+                        )
+                    case .leaf(let url, .some(.other)):
+                        throw ArtifactStoreError.commitDestinationTypeMismatch(
+                            artifactPath: artifact,
+                            expected: "regular file, directory, or missing",
+                            actual: "special file at \(url.path)"
+                        )
+                    }
+                case .symbolicLinkParent(let url), .leaf(let url, .some(.symbolicLink)):
+                    throw ArtifactStoreError.symbolicLinkInStagingDirectory(url.path)
+                case .occupiedParent(let url, _), .leaf(let url, .some(.directory)),
+                    .leaf(let url, .some(.other)):
+                    throw ArtifactStoreError.stagedArtifactIsNotRegularFile(url.path)
+                }
+            }
+            return IncomingRollbackPlan(
+                root: root,
+                stagedRoot: stagedRoot,
+                installedArtifacts: installedArtifacts
+            )
+        }
+
+        private func validateBackedUpLiveArtifactsForRollback(
+            _ replacement: Replacement,
+            installedIncomingArtifacts: [ArtifactPath],
+            fileManager: FileManager
+        ) throws -> [ArtifactPath] {
+            let root = try Self.artifactRootURLs(
+                for: artifactRoot,
+                fileManager: fileManager
+            )
+            let volumeSupportsCaseSensitiveNames =
+                try Self.destinationVolumeSupportsCaseSensitiveNames(
+                    for: root,
+                    fileManager: fileManager
+                )
+            var replacementDirectories = Set<ArtifactPath>()
+            for artifact in replacement.backedUpArtifacts {
+                switch try Self.inspectArtifactPath(
+                    artifact,
+                    root: root,
+                    fileManager: fileManager
+                ) {
+                case .missingParent, .leaf(_, nil):
+                    continue
+                case .leaf(let url, .some(.regularFile)):
+                    let actualDigest = try Self.sha256(of: url)
+                    if actualDigest == replacement.backedUpDigests[artifact] {
+                        continue
+                    }
+                    guard installedIncomingArtifacts.contains(where: {
+                        Self.artifactPathsAreEquivalent(
+                            artifact,
+                            $0,
+                            volumeSupportsCaseSensitiveNames:
+                                volumeSupportsCaseSensitiveNames
+                        ) && replacement.incomingDigests[$0] == actualDigest
+                    }) else {
+                        throw ArtifactStoreError.artifactContentChanged(
+                            artifactPath: artifact,
+                            path: url.path
+                        )
+                    }
+                case .leaf(let directory, .some(.directory)):
+                    guard replacement.incomingArtifacts.contains(where: {
+                        Self.pathIsAncestor(
+                            artifact,
+                            of: $0,
+                            volumeSupportsCaseSensitiveNames:
+                                volumeSupportsCaseSensitiveNames
+                        )
+                    }) else {
+                        throw ArtifactStoreError.artifactContentChanged(
+                            artifactPath: artifact,
+                            path: Self.artifactURL(artifact, under: artifactRoot).path
+                        )
+                    }
+                    replacementDirectories.formUnion(
+                        try validateReplacementDirectoryContents(
+                            at: directory,
+                            artifact: artifact,
+                            incomingArtifacts: replacement.incomingArtifacts,
+                            installedIncomingArtifacts: installedIncomingArtifacts,
+                            volumeSupportsCaseSensitiveNames:
+                                volumeSupportsCaseSensitiveNames,
+                            fileManager: fileManager
+                        )
+                    )
+                case .occupiedParent(_, .regularFile):
+                    guard installedIncomingArtifacts.contains(where: {
+                        Self.pathIsAncestor(
+                            $0,
+                            of: artifact,
+                            volumeSupportsCaseSensitiveNames:
+                                volumeSupportsCaseSensitiveNames
+                        )
+                    }) else {
+                        throw ArtifactStoreError.artifactContentChanged(
+                            artifactPath: artifact,
+                            path: Self.artifactURL(artifact, under: artifactRoot).path
+                        )
+                    }
+                case .occupiedParent(let url, let kind):
+                    throw ArtifactStoreError.cleanupParentTypeMismatch(
+                        artifactPath: artifact,
+                        parentPath: url.path,
+                        actual: Self.artifactItemKindDescription(kind)
+                    )
+                case .symbolicLinkParent(let url), .leaf(let url, .some(.symbolicLink)):
+                    throw ArtifactStoreError.symbolicLinkInArtifactPath(
+                        artifactPath: artifact,
+                        symbolicLinkPath: url.path
+                    )
+                case .leaf(let url, .some(.other)):
+                    throw ArtifactStoreError.commitDestinationTypeMismatch(
+                        artifactPath: artifact,
+                        expected: "regular file, directory, or missing",
+                        actual: "special file at \(url.path)"
+                    )
+                }
+            }
+            return replacementDirectories.sorted {
+                let leftDepth = Self.pathDepth($0)
+                let rightDepth = Self.pathDepth($1)
+                return leftDepth == rightDepth
+                    ? $0.rawValue < $1.rawValue
+                    : leftDepth > rightDepth
+            }
+        }
+
+        private func validateReplacementDirectoryContents(
+            at directory: URL,
+            artifact: ArtifactPath,
+            incomingArtifacts: [ArtifactPath],
+            installedIncomingArtifacts: [ArtifactPath],
+            volumeSupportsCaseSensitiveNames: Bool,
+            fileManager: FileManager
+        ) throws -> Set<ArtifactPath> {
+            var directories: Set<ArtifactPath> = [artifact]
+            var pending: [(url: URL, artifact: ArtifactPath)] = [(directory, artifact)]
+            while let current = pending.popLast() {
+                for childURL in try fileManager.contentsOfDirectory(
+                    at: current.url,
+                    includingPropertiesForKeys: nil,
+                    options: []
+                ) {
+                    let child = try ArtifactPath(
+                        current.artifact.rawValue + "/" + childURL.lastPathComponent
+                    )
+                    guard let kind = try Self.artifactItemKind(
+                        at: childURL,
+                        fileManager: fileManager
+                    ) else { continue }
+                    switch kind {
+                    case .directory:
+                        guard incomingArtifacts.contains(where: {
+                            Self.pathIsAncestor(
+                                child,
+                                of: $0,
+                                volumeSupportsCaseSensitiveNames:
+                                    volumeSupportsCaseSensitiveNames
+                            )
+                        }) else {
+                            throw ArtifactStoreError.artifactContentChanged(
+                                artifactPath: child,
+                                path: childURL.path
+                            )
+                        }
+                        directories.insert(child)
+                        pending.append((childURL, child))
+                    case .regularFile:
+                        guard installedIncomingArtifacts.contains(where: {
+                            Self.artifactPathsAreEquivalent(
+                                child,
+                                $0,
+                                volumeSupportsCaseSensitiveNames:
+                                    volumeSupportsCaseSensitiveNames
+                            )
+                        }) else {
+                            throw ArtifactStoreError.artifactContentChanged(
+                                artifactPath: child,
+                                path: childURL.path
+                            )
+                        }
+                    case .symbolicLink:
+                        throw ArtifactStoreError.symbolicLinkInArtifactPath(
+                            artifactPath: child,
+                            symbolicLinkPath: childURL.path
+                        )
+                    case .other:
+                        throw ArtifactStoreError.commitDestinationTypeMismatch(
+                            artifactPath: child,
+                            expected: "generated replacement contents",
+                            actual: "special file at \(childURL.path)"
+                        )
+                    }
+                }
+            }
+            return directories
+        }
+
+        private func cleanupReplacementDirectories(
+            _ directories: [ArtifactPath],
+            root: ArtifactRootURLs,
+            fileManager: FileManager
+        ) throws {
+            for directory in directories {
+                switch try Self.inspectArtifactPath(
+                    directory,
+                    root: root,
+                    fileManager: fileManager
+                ) {
+                case .missingParent, .leaf(_, nil):
+                    continue
+                case .leaf(let url, .some(.directory)):
+                    guard try fileManager.contentsOfDirectory(atPath: url.path).isEmpty else {
+                        throw ArtifactStoreError.cleanupDirectoryNotEmpty(
+                            artifactPath: directory,
+                            directoryPath: url.path
+                        )
+                    }
+                    try fileManager.removeItem(at: url)
+                case .occupiedParent(let url, let kind):
+                    throw ArtifactStoreError.cleanupParentTypeMismatch(
+                        artifactPath: directory,
+                        parentPath: url.path,
+                        actual: Self.artifactItemKindDescription(kind)
+                    )
+                case .symbolicLinkParent(let url), .leaf(let url, .some(.symbolicLink)):
+                    throw ArtifactStoreError.symbolicLinkInArtifactPath(
+                        artifactPath: directory,
+                        symbolicLinkPath: url.path
+                    )
+                case .leaf(let url, .some(let kind)):
+                    throw ArtifactStoreError.commitDestinationTypeMismatch(
+                        artifactPath: directory,
+                        expected: "empty directory or missing",
+                        actual: "\(Self.artifactItemKindDescription(kind)) at \(url.path)"
+                    )
+                }
+            }
+        }
+
+        private func cleanupInstalledIncomingArtifacts(
+            _ plan: IncomingRollbackPlan,
+            expectedDigests: [ArtifactPath: String],
+            fileManager: FileManager
+        ) throws {
+            try Self.validateStagedRoot(plan.stagedRoot, fileManager: fileManager)
+            let candidates = Self.cleanupCandidates(
+                manifestArtifacts: plan.installedArtifacts
+            )
+            let candidateSet = Set(candidates)
+
+            for artifact in candidates {
+                guard
+                    case .leaf(let url, .some(.regularFile)) = try Self.inspectArtifactPath(
+                        artifact,
+                        root: plan.root,
+                        fileManager: fileManager
+                    ),
+                    try Self.sha256(of: url)
+                        == Self.requiredDigest(for: artifact, in: expectedDigests)
+                else {
+                    throw ArtifactStoreError.artifactContentChanged(
+                        artifactPath: artifact,
+                        path: Self.artifactURL(artifact, under: artifactRoot).path
+                    )
+                }
+            }
+
+            for artifact in Self.cleanupOperationOrder(candidates) {
+                guard
+                    case .leaf(let url, .some(.regularFile)) = try Self.inspectArtifactPath(
+                        artifact,
+                        root: plan.root,
+                        fileManager: fileManager
+                    ),
+                    try Self.sha256(of: url)
+                        == Self.requiredDigest(for: artifact, in: expectedDigests)
+                else {
+                    throw ArtifactStoreError.artifactContentChanged(
+                        artifactPath: artifact,
+                        path: Self.artifactURL(artifact, under: artifactRoot).path
+                    )
+                }
+                try fileManager.removeItem(at: url)
+                _ = try Self.pruneEmptyParentDirectories(
+                    afterDeleting: artifact,
+                    root: plan.root,
+                    cleanupCandidates: candidateSet,
+                    fileManager: fileManager
+                )
+            }
+        }
+
+        private func prepareBackedUpArtifactRestoration(
+            _ replacement: Replacement,
+            fileManager: FileManager
+        ) throws -> RestorationPlan? {
+            guard !replacement.backedUpArtifacts.isEmpty else { return nil }
+            let backupSourceRoot = try Self.artifactRootURLs(
+                for: replacement.backupRoot,
+                fileManager: fileManager
+            )
+            let sourceRoot = try Self.artifactRootURLs(
+                for: replacement.restoreRoot,
+                fileManager: fileManager
+            )
+            let destinationRoot = try Self.artifactRootURLs(
+                for: artifactRoot,
+                fileManager: fileManager
+            )
+            try Self.validateStagedRoot(backupSourceRoot, fileManager: fileManager)
+            try Self.validateStagedRoot(sourceRoot, fileManager: fileManager)
+            let artifacts = Self.cleanupCandidates(
+                manifestArtifacts: replacement.backedUpArtifacts
+            )
+            try Self.validateDestinationCollisions(artifacts)
+            let volumeSupportsCaseSensitiveNames =
+                try Self.destinationVolumeSupportsCaseSensitiveNames(
+                    for: destinationRoot,
+                    fileManager: fileManager
+                )
+            var entries: [RestorationEntry] = []
+            entries.reserveCapacity(artifacts.count)
+
+            for artifact in artifacts {
+                let backupInspection = try Self.inspectArtifactPath(
+                    artifact,
+                    root: backupSourceRoot,
+                    fileManager: fileManager
+                )
+                let backupSource: URL
+                switch backupInspection {
+                case .leaf(let url, .some(.regularFile)):
+                    backupSource = url
+                case .symbolicLinkParent(let url), .leaf(let url, .some(.symbolicLink)):
+                    throw ArtifactStoreError.symbolicLinkInStagingDirectory(url.path)
+                case .missingParent, .leaf(_, nil):
+                    throw ArtifactStoreError.missingStagedArtifact(
+                        Self.artifactURL(artifact, under: replacement.backupRoot).path
+                    )
+                case .occupiedParent(let url, _), .leaf(let url, .some(.directory)),
+                    .leaf(let url, .some(.other)):
+                    throw ArtifactStoreError.stagedArtifactIsNotRegularFile(url.path)
+                }
+                let expectedDigest = try Self.requiredDigest(
+                    for: artifact,
+                    in: replacement.backedUpDigests
+                )
+                guard try Self.sha256(of: backupSource) == expectedDigest else {
+                    throw ArtifactStoreError.artifactContentChanged(
+                        artifactPath: artifact,
+                        path: backupSource.path
+                    )
+                }
+
+                let restoreSource: URL?
+                switch try Self.inspectArtifactPath(
+                    artifact,
+                    root: sourceRoot,
+                    fileManager: fileManager
+                ) {
+                case .leaf(let url, .some(.regularFile)):
+                    guard try Self.sha256(of: url) == expectedDigest else {
+                        throw ArtifactStoreError.artifactContentChanged(
+                            artifactPath: artifact,
+                            path: url.path
+                        )
+                    }
+                    restoreSource = url
+                case .missingParent, .leaf(_, nil):
+                    restoreSource = nil
+                case .symbolicLinkParent(let url), .leaf(let url, .some(.symbolicLink)):
+                    throw ArtifactStoreError.symbolicLinkInStagingDirectory(url.path)
+                case .occupiedParent(let url, _), .leaf(let url, .some(.directory)),
+                    .leaf(let url, .some(.other)):
+                    throw ArtifactStoreError.stagedArtifactIsNotRegularFile(url.path)
+                }
+                let destination = try Self.commitDestinationURL(
+                    for: artifact,
+                    root: destinationRoot,
+                    fileManager: fileManager
+                )
+                let destinationAlreadyRestored: Bool
+                switch try Self.inspectArtifactPath(
+                    artifact,
+                    root: destinationRoot,
+                    fileManager: fileManager
+                ) {
+                case .leaf(let url, .some(.regularFile)):
+                    destinationAlreadyRestored = try Self.sha256(of: url) == expectedDigest
+                case .missingParent, .occupiedParent, .symbolicLinkParent, .leaf:
+                    destinationAlreadyRestored = false
+                }
+                if restoreSource == nil, destinationAlreadyRestored {
+                    continue
+                }
+                guard let restoreSource else {
+                    throw ArtifactStoreError.artifactContentChanged(
+                        artifactPath: artifact,
+                        path: destination.path
+                    )
+                }
+                guard !Self.pathsOverlap(
+                    restoreSource,
+                    destination,
+                    volumeSupportsCaseSensitiveNames: volumeSupportsCaseSensitiveNames
+                ) else {
+                    throw ArtifactStoreError.commitSourceDestinationOverlap(
+                        source: restoreSource.path,
+                        destination: destination.path
+                    )
+                }
+                entries.append(
+                    RestorationEntry(
+                        artifact: artifact,
+                        source: restoreSource,
+                        destination: destination,
+                        digest: expectedDigest
+                    )
+                )
+            }
+            return RestorationPlan(
+                sourceRoot: sourceRoot,
+                destinationRoot: destinationRoot,
+                entries: entries
+            )
+        }
+
+        private func restoreBackedUpArtifacts(
+            _ plan: RestorationPlan,
+            fileManager: FileManager
+        ) throws {
+            try Self.validateStagedRoot(plan.sourceRoot, fileManager: fileManager)
+            var preparedDestinationDirectories: Set<URL> = []
+            for entry in plan.entries {
+                guard
+                    case .leaf(let source, .some(.regularFile)) = try Self.inspectArtifactPath(
+                        entry.artifact,
+                        root: plan.sourceRoot,
+                        fileManager: fileManager
+                    ),
+                    try Self.sha256(of: source) == entry.digest
+                else {
+                    throw ArtifactStoreError.artifactContentChanged(
+                        artifactPath: entry.artifact,
+                        path: entry.source.path
+                    )
+                }
+                switch try Self.inspectArtifactPath(
+                    entry.artifact,
+                    root: plan.destinationRoot,
+                    fileManager: fileManager
+                ) {
+                case .missingParent, .leaf(_, nil):
+                    break
+                case .symbolicLinkParent(let url), .leaf(let url, .some(.symbolicLink)):
+                    throw ArtifactStoreError.symbolicLinkInArtifactPath(
+                        artifactPath: entry.artifact,
+                        symbolicLinkPath: url.path
+                    )
+                case .occupiedParent(let url, let kind):
+                    throw ArtifactStoreError.cleanupParentTypeMismatch(
+                        artifactPath: entry.artifact,
+                        parentPath: url.path,
+                        actual: Self.artifactItemKindDescription(kind)
+                    )
+                case .leaf(_, .some(let kind)):
+                    throw ArtifactStoreError.commitDestinationTypeMismatch(
+                        artifactPath: entry.artifact,
+                        expected: "missing destination",
+                        actual: Self.artifactItemKindDescription(kind)
+                    )
+                }
+            }
+
+            for entry in plan.entries {
+                try Self.validateStagedRoot(plan.sourceRoot, fileManager: fileManager)
+                guard
+                    case .leaf(let source, .some(.regularFile)) = try Self.inspectArtifactPath(
+                        entry.artifact,
+                        root: plan.sourceRoot,
+                        fileManager: fileManager
+                    ),
+                    try Self.sha256(of: source) == entry.digest
+                else {
+                    throw ArtifactStoreError.artifactContentChanged(
+                        artifactPath: entry.artifact,
+                        path: entry.source.path
+                    )
+                }
+                let destinationDirectory =
+                    entry.destination.deletingLastPathComponent().standardizedFileURL
+                if preparedDestinationDirectories.insert(destinationDirectory).inserted {
+                    try ManagedFileSystem.ensureRealDirectory(destinationDirectory)
+                }
+                guard
+                    case .leaf(_, nil) = try Self.inspectArtifactPath(
+                        entry.artifact,
+                        root: plan.destinationRoot,
+                        fileManager: fileManager
+                    )
+                else {
+                    throw ArtifactStoreError.commitDestinationTypeMismatch(
+                        artifactPath: entry.artifact,
+                        expected: "missing destination",
+                        actual: "changed destination"
+                    )
+                }
+                try ManagedFileSystem.atomicRenameExclusively(
+                    from: entry.source,
+                    to: entry.destination
+                )
+            }
+        }
+
+        private static func validateStagedRoot(
+            _ root: ArtifactRootURLs,
+            fileManager: FileManager
+        ) throws {
+            try validateStagedItem(
+                at: root.unresolved,
+                expectedKind: .directory,
+                fileManager: fileManager
+            )
+            guard
+                root.unresolved.resolvingSymlinksInPath().standardizedFileURL.path
+                    == root.resolved.path
+            else {
+                throw ArtifactStoreError.stagingDirectoryChanged(root.unresolved.path)
+            }
+        }
+
+        private func markReplacementApplyStarted(
+            _ replacement: Replacement,
+            fileManager: FileManager
+        ) throws {
+            let markerURL = replacement.directory.appendingPathComponent(
+                "apply.started",
+                isDirectory: false
+            )
+            guard try Self.artifactItemKind(at: markerURL, fileManager: fileManager) == nil else {
+                throw ArtifactStoreError.invalidReplacementManifest(
+                    "replacement apply marker already exists at \(markerURL.path)"
+                )
+            }
+            try Data("started\n".utf8).write(to: markerURL, options: .withoutOverwriting)
+            try ManagedFileSystem.syncFile(markerURL)
+            try ManagedFileSystem.syncDirectory(replacement.directory)
+        }
+
+        private func replacementApplyHasStarted(
+            _ replacement: Replacement,
+            fileManager: FileManager
+        ) throws -> Bool {
+            let markerURL = replacement.directory.appendingPathComponent(
+                "apply.started",
+                isDirectory: false
+            )
+            guard let kind = try Self.artifactItemKind(at: markerURL, fileManager: fileManager)
+            else { return false }
+            guard kind == .regularFile else {
+                throw ArtifactStoreError.invalidReplacementManifest(
+                    "replacement apply marker is not a regular file at \(markerURL.path)"
+                )
+            }
+            return true
         }
 
         internal func finalizeReplacement(
             _ replacement: Replacement,
             fileManager: FileManager = .default
+        ) throws {
+            try removeReplacementTransaction(replacement, fileManager: fileManager)
+        }
+
+        private func removeReplacementTransaction(
+            _ replacement: Replacement,
+            fileManager: FileManager
         ) throws {
             guard
                 let kind = try Self.artifactItemKind(
@@ -382,6 +1744,22 @@ extension PrivateHeaderGeneration {
                 throw ArtifactStoreError.invalidReplacementManifest(
                     "transaction is not a directory at \(replacement.directory.path)"
                 )
+            }
+            let manifestURL = replacement.directory.appendingPathComponent(
+                "manifest.json",
+                isDirectory: false
+            )
+            if let manifestKind = try Self.artifactItemKind(
+                at: manifestURL,
+                fileManager: fileManager
+            ) {
+                guard manifestKind == .regularFile else {
+                    throw ArtifactStoreError.invalidReplacementManifest(
+                        "manifest is not a regular file at \(manifestURL.path)"
+                    )
+                }
+                try fileManager.removeItem(at: manifestURL)
+                try ManagedFileSystem.syncDirectory(replacement.directory)
             }
             try fileManager.removeItem(at: replacement.directory)
         }
@@ -461,6 +1839,7 @@ extension PrivateHeaderGeneration {
             fileManager: FileManager
         ) throws {
             try preflightCommit(plan, fileManager: fileManager)
+            try validateIncomingDestinationsAreMissing(plan, fileManager: fileManager)
             for entry in plan.entries where entry.kind == .directory {
                 let destination = try revalidate(entry, in: plan, fileManager: fileManager)
                 try fileManager.createDirectory(
@@ -470,42 +1849,148 @@ extension PrivateHeaderGeneration {
             }
             for entry in plan.entries where entry.kind == .file {
                 let destination = try revalidate(entry, in: plan, fileManager: fileManager)
-                try ManagedFileSystem.atomicRename(from: entry.source, to: destination)
+                try ManagedFileSystem.atomicRenameExclusively(
+                    from: entry.source,
+                    to: destination
+                )
             }
         }
 
-        private func backupExistingArtifacts(
+        private func validateIncomingDestinationsAreMissing(
+            _ plan: CommitPlan,
+            fileManager: FileManager
+        ) throws {
+            for entry in plan.entries where entry.kind == .file {
+                let destination = try Self.commitDestinationURL(
+                    for: entry.artifact,
+                    root: plan.root,
+                    fileManager: fileManager
+                )
+                guard
+                    let kind = try Self.artifactItemKind(
+                        at: destination,
+                        fileManager: fileManager
+                    )
+                else { continue }
+                if kind == .symbolicLink {
+                    throw ArtifactStoreError.symbolicLinkInArtifactPath(
+                        artifactPath: entry.artifact,
+                        symbolicLinkPath: destination.path
+                    )
+                }
+                throw ArtifactStoreError.commitDestinationTypeMismatch(
+                    artifactPath: entry.artifact,
+                    expected: "missing destination",
+                    actual: Self.artifactItemKindDescription(kind)
+                )
+            }
+        }
+
+        private func prepareMutation(
             _ artifacts: [ArtifactPath],
+            preferring preferredArtifacts: [ArtifactPath],
             from root: ArtifactRootURLs,
             to backupRoot: URL,
+            volumeSupportsCaseSensitiveNames: Bool,
             fileManager: FileManager
-        ) throws -> [ArtifactPath] {
+        ) throws -> PreparedMutation {
             var backedUpArtifacts: [ArtifactPath] = []
-            for artifact in artifacts {
-                let inspection = try Self.preflightCleanupArtifact(
-                    for: artifact,
+            var pathKinds: [ArtifactPath: MutationPathKind] = [:]
+            var sourceByPortablePath:
+                [String: (artifact: ArtifactPath, canonicalSourcePath: String)] = [:]
+            let preferredArtifacts = Set(preferredArtifacts)
+            let candidates = Self.cleanupCandidates(manifestArtifacts: artifacts).sorted {
+                let leftDepth = Self.pathDepth($0)
+                let rightDepth = Self.pathDepth($1)
+                if leftDepth == rightDepth {
+                    let leftIsPreferred = preferredArtifacts.contains($0)
+                    let rightIsPreferred = preferredArtifacts.contains($1)
+                    if leftIsPreferred != rightIsPreferred {
+                        return leftIsPreferred
+                    }
+                    return $0.rawValue < $1.rawValue
+                }
+                return leftDepth < rightDepth
+            }
+            for artifact in candidates {
+                let inspection = try Self.inspectArtifactPath(
+                    artifact,
                     root: root,
                     fileManager: fileManager
+                )
+                pathKinds[artifact] = try Self.mutationPathKind(
+                    for: inspection,
+                    artifact: artifact
                 )
                 switch inspection {
                 case .missingParent, .leaf(_, nil):
                     continue
-                case .occupiedParent, .symbolicLinkParent:
-                    preconditionFailure("preflightCleanupArtifact rejects invalid parents")
+                case .occupiedParent(_, .regularFile):
+                    guard backedUpArtifacts.contains(where: {
+                        Self.pathIsAncestor(
+                            $0,
+                            of: artifact,
+                            volumeSupportsCaseSensitiveNames:
+                                volumeSupportsCaseSensitiveNames
+                        )
+                    }) else {
+                        throw ArtifactStoreError.artifactContentChanged(
+                            artifactPath: artifact,
+                            path: Self.artifactURL(artifact, under: root.unresolved).path
+                        )
+                    }
+                case .occupiedParent(let url, let kind):
+                    throw ArtifactStoreError.cleanupParentTypeMismatch(
+                        artifactPath: artifact,
+                        parentPath: url.path,
+                        actual: Self.artifactItemKindDescription(kind)
+                    )
+                case .symbolicLinkParent(let url):
+                    throw ArtifactStoreError.symbolicLinkInArtifactPath(
+                        artifactPath: artifact,
+                        symbolicLinkPath: url.path
+                    )
                 case .leaf(let source, .some(.regularFile)):
+                    let portablePath = Self.portableCollisionKey(for: artifact.rawValue)
+                    let canonicalSourcePath =
+                        source.resolvingSymlinksInPath().standardizedFileURL.path
+                    if let existing = sourceByPortablePath[portablePath] {
+                        guard existing.canonicalSourcePath == canonicalSourcePath else {
+                            throw ArtifactStoreError.commitDestinationCollision(
+                                first: existing.artifact,
+                                second: artifact
+                            )
+                        }
+                        continue
+                    }
                     let destination = Self.artifactURL(artifact, under: backupRoot)
                     try fileManager.createDirectory(
                         at: destination.deletingLastPathComponent(),
                         withIntermediateDirectories: true
                     )
                     try fileManager.copyItem(at: source, to: destination)
+                    sourceByPortablePath[portablePath] = (artifact, canonicalSourcePath)
                     backedUpArtifacts.append(artifact)
                 case .leaf(let source, .some(.symbolicLink)):
                     throw ArtifactStoreError.symbolicLinkInArtifactPath(
                         artifactPath: artifact,
                         symbolicLinkPath: source.path
                     )
-                case .leaf(_, .some(.directory)), .leaf(_, .some(.other)):
+                case .leaf(_, .some(.directory)):
+                    guard candidates.contains(where: {
+                        Self.pathIsAncestor(
+                            artifact,
+                            of: $0,
+                            volumeSupportsCaseSensitiveNames: volumeSupportsCaseSensitiveNames
+                        )
+                    }) else {
+                        throw ArtifactStoreError.commitDestinationTypeMismatch(
+                            artifactPath: artifact,
+                            expected: "regular file",
+                            actual: Self.artifactItemKindDescription(.directory)
+                        )
+                    }
+                case .leaf(_, .some(.other)):
                     throw ArtifactStoreError.commitDestinationTypeMismatch(
                         artifactPath: artifact,
                         expected: "regular file",
@@ -513,7 +1998,77 @@ extension PrivateHeaderGeneration {
                     )
                 }
             }
-            return backedUpArtifacts
+            return PreparedMutation(
+                backedUpArtifacts: backedUpArtifacts.sorted { $0.rawValue < $1.rawValue },
+                pathKinds: pathKinds
+            )
+        }
+
+        private static func mutationPathKind(
+            for inspection: ArtifactPathInspection,
+            artifact: ArtifactPath
+        ) throws -> MutationPathKind {
+            switch inspection {
+            case .missingParent, .leaf(_, nil):
+                return .missing
+            case .occupiedParent(_, .regularFile):
+                return .occupiedByRegularFile
+            case .leaf(_, .some(.regularFile)):
+                return .regularFile
+            case .leaf(_, .some(.directory)):
+                return .directory
+            case .occupiedParent(let url, let kind):
+                throw ArtifactStoreError.cleanupParentTypeMismatch(
+                    artifactPath: artifact,
+                    parentPath: url.path,
+                    actual: artifactItemKindDescription(kind)
+                )
+            case .symbolicLinkParent(let url), .leaf(let url, .some(.symbolicLink)):
+                throw ArtifactStoreError.symbolicLinkInArtifactPath(
+                    artifactPath: artifact,
+                    symbolicLinkPath: url.path
+                )
+            case .leaf(let url, .some(.other)):
+                throw ArtifactStoreError.commitDestinationTypeMismatch(
+                    artifactPath: artifact,
+                    expected: "regular file, directory, or missing",
+                    actual: "special file at \(url.path)"
+                )
+            }
+        }
+
+        private static func mutationPathKinds(
+            for artifacts: [ArtifactPath],
+            root: ArtifactRootURLs,
+            fileManager: FileManager
+        ) throws -> [ArtifactPath: MutationPathKind] {
+            var kinds: [ArtifactPath: MutationPathKind] = [:]
+            kinds.reserveCapacity(artifacts.count)
+            for artifact in artifacts {
+                kinds[artifact] = try mutationPathKind(
+                    for: inspectArtifactPath(
+                        artifact,
+                        root: root,
+                        fileManager: fileManager
+                    ),
+                    artifact: artifact
+                )
+            }
+            return kinds
+        }
+
+        private static func pathIsAncestor(
+            _ ancestor: ArtifactPath,
+            of descendant: ArtifactPath,
+            volumeSupportsCaseSensitiveNames: Bool
+        ) -> Bool {
+            let ancestorKey = volumeSupportsCaseSensitiveNames
+                ? ancestor.rawValue.precomposedStringWithCanonicalMapping
+                : portableCollisionKey(for: ancestor.rawValue)
+            let descendantKey = volumeSupportsCaseSensitiveNames
+                ? descendant.rawValue.precomposedStringWithCanonicalMapping
+                : portableCollisionKey(for: descendant.rawValue)
+            return descendantKey.hasPrefix(ancestorKey + "/")
         }
 
         private func writeManifest(
@@ -529,16 +2084,45 @@ extension PrivateHeaderGeneration {
                     "manifest already exists at \(manifestURL.path)"
                 )
             }
-            let manifest = ReplacementManifest(
-                version: 1,
+            try persistManifest(
+                replacementManifest(for: replacement),
+                at: manifestURL,
+                transactionDirectory: replacement.directory
+            )
+        }
+
+        private func replacementManifest(
+            for replacement: Replacement
+        ) throws -> ReplacementManifest {
+            return ReplacementManifest(
+                version: Self.replacementManifestVersion,
                 runID: replacement.runID.rawValue,
                 targetID: replacement.targetID,
                 artifactRoot: replacement.artifactRoot.rawValue,
                 incomingArtifacts: replacement.incomingArtifacts.map(\.rawValue),
                 mutationArtifacts: replacement.mutationArtifacts.map(\.rawValue),
-                backedUpArtifacts: replacement.backedUpArtifacts.map(\.rawValue)
+                mutationPathKinds: Dictionary(uniqueKeysWithValues:
+                    replacement.mutationPathKinds.map { ($0.key.rawValue, $0.value) }
+                ),
+                backedUpArtifacts: replacement.backedUpArtifacts.map(\.rawValue),
+                incomingDigests: Dictionary(uniqueKeysWithValues:
+                    replacement.incomingDigests.map { ($0.key.rawValue, $0.value) }
+                ),
+                backedUpDigests: Dictionary(uniqueKeysWithValues:
+                    replacement.backedUpDigests.map { ($0.key.rawValue, $0.value) }
+                ),
+                artifactRootIdentity: replacement.artifactRootIdentity
             )
+        }
+
+        private func persistManifest(
+            _ manifest: ReplacementManifest,
+            at manifestURL: URL,
+            transactionDirectory: URL
+        ) throws {
             try JSONEncoder().encode(manifest).write(to: manifestURL, options: .atomic)
+            try ManagedFileSystem.syncFile(manifestURL)
+            try ManagedFileSystem.syncDirectory(transactionDirectory)
         }
 
         private static func loadReplacement(
@@ -553,20 +2137,39 @@ extension PrivateHeaderGeneration {
                     "manifest is not a regular file at \(manifestURL.path)"
                 )
             }
-            let manifest: ReplacementManifest
+            let manifestData: Data
             do {
-                manifest = try JSONDecoder().decode(
-                    ReplacementManifest.self,
-                    from: Data(contentsOf: manifestURL)
+                manifestData = try Data(contentsOf: manifestURL)
+            } catch {
+                throw ArtifactStoreError.invalidReplacementManifest(
+                    "could not read \(manifestURL.path): \(error)"
                 )
+            }
+            let version: Int
+            do {
+                version = try JSONDecoder().decode(
+                    ReplacementManifestVersion.self,
+                    from: manifestData
+                ).version
             } catch {
                 throw ArtifactStoreError.invalidReplacementManifest(
                     "could not decode \(manifestURL.path): \(error)"
                 )
             }
-            guard manifest.version == 1 else {
+            guard version == Self.replacementManifestVersion else {
                 throw ArtifactStoreError.invalidReplacementManifest(
-                    "unsupported version \(manifest.version) at \(manifestURL.path)"
+                    "unsupported version \(version) at \(manifestURL.path)"
+                )
+            }
+            let manifest: ReplacementManifest
+            do {
+                manifest = try JSONDecoder().decode(
+                    ReplacementManifest.self,
+                    from: manifestData
+                )
+            } catch {
+                throw ArtifactStoreError.invalidReplacementManifest(
+                    "could not decode \(manifestURL.path): \(error)"
                 )
             }
             let runID = try PrivateHeaderGeneration.RunID(manifest.runID)
@@ -583,12 +2186,42 @@ extension PrivateHeaderGeneration {
             let artifactRootPath = try ArtifactPath(manifest.artifactRoot)
             let incomingArtifacts = try manifest.incomingArtifacts.map { try ArtifactPath($0) }
             let mutationArtifacts = try manifest.mutationArtifacts.map { try ArtifactPath($0) }
+            var mutationPathKinds: [ArtifactPath: MutationPathKind] = [:]
+            mutationPathKinds.reserveCapacity(manifest.mutationPathKinds.count)
+            for (rawPath, kind) in manifest.mutationPathKinds {
+                let artifact = try ArtifactPath(rawPath)
+                guard mutationPathKinds[artifact] == nil else {
+                    throw ArtifactStoreError.invalidReplacementManifest(
+                        "manifest contains duplicate mutation path kinds at \(manifestURL.path)"
+                    )
+                }
+                mutationPathKinds[artifact] = kind
+            }
             let backedUpArtifacts = try manifest.backedUpArtifacts.map {
                 try ArtifactPath($0)
             }
+            guard Set(incomingArtifacts).count == incomingArtifacts.count,
+                Set(mutationArtifacts).count == mutationArtifacts.count,
+                Set(backedUpArtifacts).count == backedUpArtifacts.count
+            else {
+                throw ArtifactStoreError.invalidReplacementManifest(
+                    "manifest contains duplicate paths at \(manifestURL.path)"
+                )
+            }
+            let incomingDigests = try decodeDigests(
+                manifest.incomingDigests,
+                expectedArtifacts: incomingArtifacts,
+                manifestURL: manifestURL
+            )
+            let backedUpDigests = try decodeDigests(
+                manifest.backedUpDigests,
+                expectedArtifacts: backedUpArtifacts,
+                manifestURL: manifestURL
+            )
             let mutationSet = Set(mutationArtifacts)
             guard incomingArtifacts.allSatisfy(mutationSet.contains),
-                backedUpArtifacts.allSatisfy(mutationSet.contains)
+                backedUpArtifacts.allSatisfy(mutationSet.contains),
+                Set(mutationPathKinds.keys) == mutationSet
             else {
                 throw ArtifactStoreError.invalidReplacementManifest(
                     "manifest paths do not form one mutation set at \(manifestURL.path)"
@@ -596,18 +2229,439 @@ extension PrivateHeaderGeneration {
             }
             let incomingRoot = directory.appendingPathComponent("incoming", isDirectory: true)
             let backupRoot = directory.appendingPathComponent("backup", isDirectory: true)
-            _ = try artifactRootURLs(for: artifactRoot)
+            let restoreRoot = directory.appendingPathComponent("restore", isDirectory: true)
             return Replacement(
                 directory: directory,
                 incomingRoot: incomingRoot,
                 backupRoot: backupRoot,
+                restoreRoot: restoreRoot,
                 runID: runID,
                 targetID: manifest.targetID,
                 artifactRoot: artifactRootPath,
                 incomingArtifacts: incomingArtifacts,
                 mutationArtifacts: mutationArtifacts,
-                backedUpArtifacts: backedUpArtifacts
+                mutationPathKinds: mutationPathKinds,
+                backedUpArtifacts: backedUpArtifacts,
+                incomingDigests: incomingDigests,
+                backedUpDigests: backedUpDigests,
+                artifactRootIdentity: manifest.artifactRootIdentity
             )
+        }
+
+        private func validateReplacementArtifactRoot(
+            _ replacement: Replacement,
+            fileManager: FileManager
+        ) throws {
+            try Self.validateDirectoryIdentity(
+                replacement.artifactRootIdentity,
+                at: artifactRoot,
+                fileManager: fileManager
+            )
+        }
+
+        private func validateTransactionArtifacts(
+            _ replacement: Replacement,
+            fileManager: FileManager
+        ) throws {
+            try Self.validateArtifactDigests(
+                replacement.incomingDigests,
+                for: replacement.incomingArtifacts,
+                under: replacement.incomingRoot,
+                fileManager: fileManager
+            )
+            try Self.validateArtifactDigests(
+                replacement.backedUpDigests,
+                for: replacement.backedUpArtifacts,
+                under: replacement.backupRoot,
+                fileManager: fileManager
+            )
+            try Self.validateArtifactDigests(
+                replacement.backedUpDigests,
+                for: replacement.backedUpArtifacts,
+                under: replacement.restoreRoot,
+                fileManager: fileManager
+            )
+        }
+
+        private static func artifactDigests(
+            for artifacts: [ArtifactPath],
+            under rootURL: URL,
+            fileManager: FileManager
+        ) throws -> [ArtifactPath: String] {
+            let root = try artifactRootURLs(for: rootURL, fileManager: fileManager)
+            try validateStagedRoot(root, fileManager: fileManager)
+            var digests: [ArtifactPath: String] = [:]
+            digests.reserveCapacity(artifacts.count)
+            for artifact in artifacts {
+                guard
+                    case .leaf(let url, .some(.regularFile)) = try inspectArtifactPath(
+                        artifact,
+                        root: root,
+                        fileManager: fileManager
+                    )
+                else {
+                    throw ArtifactStoreError.missingStagedArtifact(
+                        artifactURL(artifact, under: rootURL).path
+                    )
+                }
+                digests[artifact] = try sha256(of: url)
+            }
+            return digests
+        }
+
+        private static func copyArtifacts(
+            _ artifacts: [ArtifactPath],
+            from sourceRoot: URL,
+            to destinationRoot: URL,
+            expectedDigests: [ArtifactPath: String],
+            fileManager: FileManager
+        ) throws {
+            var preparedDestinationDirectories: Set<URL> = []
+            for artifact in artifacts {
+                let source = artifactURL(artifact, under: sourceRoot)
+                let destination = artifactURL(artifact, under: destinationRoot)
+                let expectedDigest = try requiredDigest(for: artifact, in: expectedDigests)
+                guard try sha256(of: source) == expectedDigest else {
+                    throw ArtifactStoreError.artifactContentChanged(
+                        artifactPath: artifact,
+                        path: source.path
+                    )
+                }
+                let destinationDirectory =
+                    destination.deletingLastPathComponent().standardizedFileURL
+                if preparedDestinationDirectories.insert(destinationDirectory).inserted {
+                    try ManagedFileSystem.ensureRealDirectory(destinationDirectory)
+                }
+                try fileManager.copyItem(at: source, to: destination)
+                guard try sha256(of: destination) == expectedDigest else {
+                    throw ArtifactStoreError.artifactContentChanged(
+                        artifactPath: artifact,
+                        path: destination.path
+                    )
+                }
+            }
+        }
+
+        private static func validateArtifactDigests(
+            _ expectedDigests: [ArtifactPath: String],
+            for artifacts: [ArtifactPath],
+            under rootURL: URL,
+            fileManager: FileManager
+        ) throws {
+            let actualDigests = try artifactDigests(
+                for: artifacts,
+                under: rootURL,
+                fileManager: fileManager
+            )
+            for artifact in artifacts {
+                guard actualDigests[artifact] == expectedDigests[artifact] else {
+                    throw ArtifactStoreError.artifactContentChanged(
+                        artifactPath: artifact,
+                        path: artifactURL(artifact, under: rootURL).path
+                    )
+                }
+            }
+        }
+
+        private static func requiredDigest(
+            for artifact: ArtifactPath,
+            in digests: [ArtifactPath: String]
+        ) throws -> String {
+            guard let digest = digests[artifact] else {
+                throw ArtifactStoreError.invalidReplacementManifest(
+                    "missing digest for \(artifact.rawValue)"
+                )
+            }
+            return digest
+        }
+
+        private static func decodeDigests(
+            _ rawDigests: [String: String],
+            expectedArtifacts: [ArtifactPath],
+            manifestURL: URL
+        ) throws -> [ArtifactPath: String] {
+            var digests: [ArtifactPath: String] = [:]
+            digests.reserveCapacity(rawDigests.count)
+            for (rawPath, digest) in rawDigests {
+                let artifact = try ArtifactPath(rawPath)
+                guard digests[artifact] == nil, isValidSHA256(digest) else {
+                    throw ArtifactStoreError.invalidReplacementManifest(
+                        "invalid digest entry for \(rawPath) at \(manifestURL.path)"
+                    )
+                }
+                digests[artifact] = digest
+            }
+            guard Set(digests.keys) == Set(expectedArtifacts) else {
+                throw ArtifactStoreError.invalidReplacementManifest(
+                    "digest paths do not match artifact paths at \(manifestURL.path)"
+                )
+            }
+            return digests
+        }
+
+        private static func sha256(of url: URL) throws -> String {
+            let handle = try FileHandle(forReadingFrom: url)
+            defer { handle.closeFile() }
+            var hasher = SHA256()
+            while let chunk = try handle.read(upToCount: 1_048_576), !chunk.isEmpty {
+                hasher.update(data: chunk)
+            }
+            return hasher.finalize().map { String(format: "%02x", $0) }.joined()
+        }
+
+        private static func isValidSHA256(_ digest: String) -> Bool {
+            digest.utf8.count == 64 && digest.utf8.allSatisfy {
+                (48...57).contains($0) || (97...102).contains($0)
+            }
+        }
+
+        private static func directoryIdentity(
+            at url: URL,
+            fileManager: FileManager
+        ) throws -> FileSystemIdentity {
+            guard try artifactItemKind(at: url, fileManager: fileManager) == .directory else {
+                throw ArtifactStoreError.artifactRootTypeMismatch(
+                    path: url.path,
+                    actual: "missing or non-directory"
+                )
+            }
+            let attributes = try fileManager.attributesOfItem(atPath: url.path)
+            guard let device = (attributes[.systemNumber] as? NSNumber)?.uint64Value,
+                let inode = (attributes[.systemFileNumber] as? NSNumber)?.uint64Value
+            else {
+                throw ArtifactStoreError.invalidReplacementManifest(
+                    "filesystem identity is unavailable at \(url.path)"
+                )
+            }
+            return FileSystemIdentity(device: device, inode: inode)
+        }
+
+        private static func validateDirectoryIdentity(
+            _ expected: FileSystemIdentity,
+            at url: URL,
+            fileManager: FileManager
+        ) throws {
+            let actual = try directoryIdentity(at: url, fileManager: fileManager)
+            guard actual == expected else {
+                throw ArtifactStoreError.artifactRootChanged(
+                    expected: expected.description,
+                    actual: actual.description
+                )
+            }
+        }
+
+        private func validateReplacementVolumes(
+            _ replacement: Replacement,
+            fileManager: FileManager
+        ) throws {
+            try Self.validateReplacementVolumes(
+                liveRoot: artifactRoot,
+                liveRootIdentity: replacement.artifactRootIdentity,
+                transactionRoots: [replacement.incomingRoot, replacement.restoreRoot],
+                fileManager: fileManager
+            )
+        }
+
+        private static func validateReplacementVolumes(
+            liveRoot: URL,
+            liveRootIdentity: FileSystemIdentity,
+            transactionRoots: [URL],
+            fileManager: FileManager
+        ) throws {
+            for transactionRoot in transactionRoots {
+                let transactionIdentity = try directoryIdentity(
+                    at: transactionRoot,
+                    fileManager: fileManager
+                )
+                guard transactionIdentity.device == liveRootIdentity.device else {
+                    throw ArtifactStoreError.replacementVolumeMismatch(
+                        liveRoot: liveRoot.path,
+                        transactionRoot: transactionRoot.path
+                    )
+                }
+            }
+        }
+
+        private static func validateExclusiveRenameSupport(
+            in transactionDirectory: URL,
+            fileManager: FileManager,
+            exclusiveRename: (URL, URL) throws -> Void
+        ) throws {
+            let probeID = UUID().uuidString.lowercased()
+            let source = transactionDirectory.appendingPathComponent(
+                ".rename-excl-source-\(probeID)",
+                isDirectory: false
+            )
+            let destination = transactionDirectory.appendingPathComponent(
+                ".rename-excl-destination-\(probeID)",
+                isDirectory: false
+            )
+            try Data("probe\n".utf8).write(to: source, options: .withoutOverwriting)
+            try exclusiveRename(source, destination)
+            try fileManager.removeItem(at: destination)
+        }
+
+        private static func artifactPathsAreEquivalent(
+            _ first: ArtifactPath,
+            _ second: ArtifactPath,
+            volumeSupportsCaseSensitiveNames: Bool
+        ) -> Bool {
+            artifactPathIdentityKey(
+                for: first,
+                volumeSupportsCaseSensitiveNames: volumeSupportsCaseSensitiveNames
+            ) == artifactPathIdentityKey(
+                for: second,
+                volumeSupportsCaseSensitiveNames: volumeSupportsCaseSensitiveNames
+            )
+        }
+
+        private static func artifactPathIdentityKey(
+            for artifact: ArtifactPath,
+            volumeSupportsCaseSensitiveNames: Bool
+        ) -> String {
+            let normalized = artifact.rawValue.precomposedStringWithCanonicalMapping
+            guard !volumeSupportsCaseSensitiveNames else { return normalized }
+            return portableCollisionKey(for: normalized)
+        }
+
+        private func synchronizeReplacementMutations(
+            _ replacement: Replacement,
+            sourceRoot: URL?,
+            sourceArtifacts: [ArtifactPath],
+            fileManager: FileManager
+        ) throws {
+            var directories = Self.mutationDirectories(
+                for: replacement.mutationArtifacts,
+                under: artifactRoot
+            )
+            if let sourceRoot {
+                directories.formUnion(
+                    Self.mutationDirectories(
+                        for: sourceArtifacts,
+                        under: sourceRoot
+                    )
+                )
+            }
+            try Self.syncExistingMutationDirectories(
+                directories,
+                fileManager: fileManager
+            )
+        }
+
+        private static func mutationDirectories(
+            for artifacts: [ArtifactPath],
+            under root: URL
+        ) -> Set<URL> {
+            let root = root.standardizedFileURL
+            var directories: Set<URL> = [root]
+            for artifact in artifacts {
+                var directory = root
+                for component in artifact.rawValue.split(separator: "/").dropLast() {
+                    directory.appendPathComponent(String(component), isDirectory: true)
+                    directories.insert(directory.standardizedFileURL)
+                }
+            }
+            return directories
+        }
+
+        private static func syncExistingMutationDirectories(
+            _ directories: Set<URL>,
+            fileManager: FileManager
+        ) throws {
+            for directory in directories.sorted(by: {
+                let leftDepth = $0.standardizedFileURL.pathComponents.count
+                let rightDepth = $1.standardizedFileURL.pathComponents.count
+                return leftDepth == rightDepth ? $0.path < $1.path : leftDepth > rightDepth
+            }) {
+                switch try artifactItemKind(at: directory, fileManager: fileManager) {
+                case nil, .some(.regularFile):
+                    continue
+                case .some(.directory):
+                    try ManagedFileSystem.syncDirectory(directory)
+                case .some(.symbolicLink):
+                    throw ArtifactStoreError.symbolicLinkInStagingDirectory(directory.path)
+                case .some(.other):
+                    throw ArtifactStoreError.stagedArtifactIsNotDirectory(directory.path)
+                }
+            }
+        }
+
+        private static func syncTree(
+            at root: URL,
+            fileManager: FileManager
+        ) throws {
+            guard try artifactItemKind(at: root, fileManager: fileManager) == .directory else {
+                throw ArtifactStoreError.stagedArtifactIsNotDirectory(root.path)
+            }
+            for child in try fileManager.contentsOfDirectory(
+                at: root,
+                includingPropertiesForKeys: nil,
+                options: []
+            ) {
+                switch try artifactItemKind(at: child, fileManager: fileManager) {
+                case .some(.directory):
+                    try syncTree(at: child, fileManager: fileManager)
+                case .some(.regularFile):
+                    try ManagedFileSystem.syncFile(child)
+                case .some(.symbolicLink):
+                    throw ArtifactStoreError.symbolicLinkInStagingDirectory(child.path)
+                case .some(.other):
+                    throw ArtifactStoreError.stagedArtifactIsNotRegularFile(child.path)
+                case nil:
+                    throw ArtifactStoreError.missingStagedArtifact(child.path)
+                }
+            }
+            try ManagedFileSystem.syncDirectory(root)
+        }
+
+        private static func nearestExistingRealDirectory(
+            startingAt url: URL,
+            fileManager: FileManager
+        ) throws -> URL {
+            var candidate = url.standardizedFileURL
+            while true {
+                if let kind = try artifactItemKind(at: candidate, fileManager: fileManager) {
+                    guard kind == .directory else {
+                        throw ArtifactStoreError.artifactRootTypeMismatch(
+                            path: candidate.path,
+                            actual: artifactItemKindDescription(kind)
+                        )
+                    }
+                    return candidate
+                }
+                let parent = candidate.deletingLastPathComponent().standardizedFileURL
+                guard parent.path != candidate.path else {
+                    throw ArtifactStoreError.artifactRootTypeMismatch(
+                        path: candidate.path,
+                        actual: "missing"
+                    )
+                }
+                candidate = parent
+            }
+        }
+
+        private static func syncDirectoryChain(
+            from directory: URL,
+            through ancestor: URL,
+            fileManager: FileManager
+        ) throws {
+            let ancestor = ancestor.standardizedFileURL
+            var current = directory.standardizedFileURL
+            guard isSameOrDescendant(current, of: ancestor) else {
+                throw ArtifactStoreError.invalidReplacementManifest(
+                    "directory \(current.path) is outside durable ancestor \(ancestor.path)"
+                )
+            }
+            while true {
+                guard try artifactItemKind(at: current, fileManager: fileManager) == .directory else {
+                    throw ArtifactStoreError.stagedArtifactIsNotDirectory(current.path)
+                }
+                try ManagedFileSystem.syncDirectory(current)
+                if current.path == ancestor.path {
+                    return
+                }
+                current = current.deletingLastPathComponent().standardizedFileURL
+            }
         }
 
         private static func artifactURL(_ artifact: ArtifactPath, under root: URL) -> URL {
@@ -658,7 +2712,7 @@ extension PrivateHeaderGeneration {
             artifacts: [ArtifactPath],
             fileManager: FileManager = .default
         ) throws -> ArtifactCleanupResult {
-            let root = try artifactRootURLs(for: artifactRoot)
+            let root = try artifactRootURLs(for: artifactRoot, fileManager: fileManager)
             let candidates = cleanupCandidates(manifestArtifacts: artifacts)
             let candidateSet = Set(candidates)
             let artifactInspections = try cleanupArtifactInspections(
@@ -670,41 +2724,113 @@ extension PrivateHeaderGeneration {
             var missingArtifacts: [ArtifactPath] = []
             var prunedDirectories: [ArtifactPath] = []
             var prunedDirectorySet = Set<ArtifactPath>()
+            var mutatedParentDirectories: [URL] = []
 
-            for artifact in cleanupOperationOrder(candidates) {
-                guard case .leaf = artifactInspections[artifact]! else {
-                    missingArtifacts.append(artifact)
-                    continue
-                }
-                let inspection = try preflightCleanupArtifact(
-                    for: artifact,
-                    root: root,
-                    fileManager: fileManager
-                )
-                guard case .leaf(let artifactURL, .some(_)) = inspection else {
-                    missingArtifacts.append(artifact)
-                    continue
-                }
+            do {
+                for artifact in cleanupOperationOrder(candidates) {
+                    guard case .leaf = artifactInspections[artifact]! else {
+                        missingArtifacts.append(artifact)
+                        mutatedParentDirectories.append(
+                            Self.artifactURL(artifact, under: root.unresolved)
+                                .deletingLastPathComponent()
+                                .standardizedFileURL
+                        )
+                        continue
+                    }
+                    let inspection = try preflightCleanupArtifact(
+                        for: artifact,
+                        root: root,
+                        fileManager: fileManager
+                    )
+                    guard case .leaf(let artifactURL, .some(_)) = inspection else {
+                        missingArtifacts.append(artifact)
+                        mutatedParentDirectories.append(
+                            Self.artifactURL(artifact, under: root.unresolved)
+                                .deletingLastPathComponent()
+                                .standardizedFileURL
+                        )
+                        continue
+                    }
 
-                try fileManager.removeItem(at: artifactURL)
-                deletedArtifacts.append(artifact)
+                    try fileManager.removeItem(at: artifactURL)
+                    deletedArtifacts.append(artifact)
+                    mutatedParentDirectories.append(
+                        artifactURL.deletingLastPathComponent().standardizedFileURL
+                    )
 
-                let pruned = try pruneEmptyParentDirectories(
-                    afterDeleting: artifact,
-                    root: root,
-                    cleanupCandidates: candidateSet,
-                    fileManager: fileManager
-                )
-                for directory in pruned where prunedDirectorySet.insert(directory).inserted {
-                    prunedDirectories.append(directory)
+                    let pruned = try pruneEmptyParentDirectories(
+                        afterDeleting: artifact,
+                        root: root,
+                        cleanupCandidates: candidateSet,
+                        fileManager: fileManager
+                    )
+                    for directory in pruned where prunedDirectorySet.insert(directory).inserted {
+                        prunedDirectories.append(directory)
+                    }
                 }
+            } catch {
+                let primary = error
+                do {
+                    try synchronizeCleanupDirectories(
+                        mutatedParentDirectories,
+                        root: root,
+                        fileManager: fileManager
+                    )
+                } catch {
+                    throw ArtifactStoreError.cleanupSynchronizationFailed(
+                        primary: String(describing: primary),
+                        synchronization: String(describing: error)
+                    )
+                }
+                throw primary
             }
+            try synchronizeCleanupDirectories(
+                mutatedParentDirectories,
+                root: root,
+                fileManager: fileManager
+            )
 
             return ArtifactCleanupResult(
                 deletedArtifacts: cleanupCandidates(manifestArtifacts: deletedArtifacts),
                 missingArtifacts: cleanupCandidates(manifestArtifacts: missingArtifacts),
                 prunedDirectories: cleanupCandidates(manifestArtifacts: prunedDirectories)
             )
+        }
+
+        private static func synchronizeCleanupDirectories(
+            _ directories: [URL],
+            root: ArtifactRootURLs,
+            fileManager: FileManager
+        ) throws {
+            var survivingDirectories: Set<URL> = []
+            for directory in directories {
+                var current = directory
+                while true {
+                    switch try artifactItemKind(at: current, fileManager: fileManager) {
+                    case .directory:
+                        survivingDirectories.insert(current)
+                        break
+                    case nil:
+                        guard current.path != root.unresolved.path else {
+                            throw ArtifactStoreError.artifactRootTypeMismatch(
+                                path: root.unresolved.path,
+                                actual: "missing"
+                            )
+                        }
+                        current = current.deletingLastPathComponent().standardizedFileURL
+                        continue
+                    case .some(let kind):
+                        throw ArtifactStoreError.artifactRootTypeMismatch(
+                            path: current.path,
+                            actual: artifactItemKindDescription(kind)
+                        )
+                    }
+                    break
+                }
+            }
+            for directory in survivingDirectories.sorted(by: { $0.path < $1.path }) {
+                try ManagedFileSystem.syncDirectory(directory)
+            }
         }
 
         public static func cleanupCandidates(
@@ -750,12 +2876,23 @@ extension PrivateHeaderGeneration {
             case regularFile
         }
 
-        private static func artifactRootURLs(for artifactRoot: URL) throws -> ArtifactRootURLs {
+        private static func artifactRootURLs(
+            for artifactRoot: URL,
+            fileManager: FileManager
+        ) throws -> ArtifactRootURLs {
             guard artifactRoot.isFileURL else {
                 throw ArtifactStoreError.nonFileArtifactRoot(artifactRoot.absoluteString)
             }
 
             let unresolved = artifactRoot.standardizedFileURL
+            if let kind = try artifactItemKind(at: unresolved, fileManager: fileManager),
+                kind != .directory
+            {
+                throw ArtifactStoreError.artifactRootTypeMismatch(
+                    path: unresolved.path,
+                    actual: artifactItemKindDescription(kind)
+                )
+            }
             return ArtifactRootURLs(
                 unresolved: unresolved,
                 resolved: unresolved.resolvingSymlinksInPath().standardizedFileURL
@@ -1122,22 +3259,7 @@ extension PrivateHeaderGeneration {
             _ plan: CommitPlan,
             fileManager: FileManager
         ) throws {
-            try validateArtifactRoot(of: plan)
-            try validateDestinationVolumeSemantics(of: plan, fileManager: fileManager)
-            try validateStagingBoundary(of: plan, fileManager: fileManager)
-            let currentEntries = try Self.commitEntries(
-                stagingDirectory: plan.stagingDirectory,
-                stagedSourceDirectory: plan.stagedSourceDirectory,
-                artifactRoot: plan.artifactRoot,
-                artifacts: plan.artifacts,
-                fileManager: fileManager
-            )
-            guard currentEntries == plan.entries else {
-                throw ArtifactStoreError.stagingDirectoryChanged(
-                    plan.stagedSourceDirectory.path
-                )
-            }
-            try Self.validateSourceDestinationDisjoint(plan)
+            try preflightCommitInputs(plan, fileManager: fileManager)
 
             for entry in plan.entries {
                 let destination = try Self.commitDestinationURL(
@@ -1153,12 +3275,34 @@ extension PrivateHeaderGeneration {
             }
         }
 
+        private func preflightCommitInputs(
+            _ plan: CommitPlan,
+            fileManager: FileManager
+        ) throws {
+            try validateArtifactRoot(of: plan, fileManager: fileManager)
+            try validateDestinationVolumeSemantics(of: plan, fileManager: fileManager)
+            try validateStagingBoundary(of: plan, fileManager: fileManager)
+            let currentEntries = try Self.commitEntries(
+                stagingDirectory: plan.stagingDirectory,
+                stagedSourceDirectory: plan.stagedSourceDirectory,
+                artifactRoot: plan.artifactRoot,
+                artifacts: plan.artifacts,
+                fileManager: fileManager
+            )
+            guard currentEntries == plan.entries else {
+                throw ArtifactStoreError.stagingDirectoryChanged(
+                    plan.stagedSourceDirectory.path
+                )
+            }
+            try Self.validateSourceDestinationDisjoint(plan)
+        }
+
         private func revalidate(
             _ entry: CommitEntry,
             in plan: CommitPlan,
             fileManager: FileManager
         ) throws -> URL {
-            try validateArtifactRoot(of: plan)
+            try validateArtifactRoot(of: plan, fileManager: fileManager)
             try validateDestinationVolumeSemantics(of: plan, fileManager: fileManager)
             try validateStagingBoundary(of: plan, fileManager: fileManager)
             guard
@@ -1304,8 +3448,14 @@ extension PrivateHeaderGeneration {
             }
         }
 
-        private func validateArtifactRoot(of plan: CommitPlan) throws {
-            let current = try Self.artifactRootURLs(for: artifactRoot)
+        private func validateArtifactRoot(
+            of plan: CommitPlan,
+            fileManager: FileManager
+        ) throws {
+            let current = try Self.artifactRootURLs(
+                for: artifactRoot,
+                fileManager: fileManager
+            )
             guard current.unresolved.path == plan.root.unresolved.path,
                 current.resolved.path == plan.root.resolved.path
             else {

--- a/Sources/PrivateHeaderKitCore/PrivateHeaderGenerationArtifactStore.swift
+++ b/Sources/PrivateHeaderKitCore/PrivateHeaderGenerationArtifactStore.swift
@@ -40,6 +40,9 @@ extension PrivateHeaderGeneration {
         case destinationVolumeCaseSensitivityChanged(root: String, expected: Bool, actual: Bool)
         case stagingDirectoryChanged(String)
         case artifactRootChanged(expected: String, actual: String)
+        case invalidReplacementManifest(String)
+        case replacementPreparationCleanupFailed(primary: String, cleanup: String)
+        case replacementRollbackFailed(primary: String, rollback: String)
 
         public var description: String {
             switch self {
@@ -81,6 +84,12 @@ extension PrivateHeaderGeneration {
                 "staging directory changed after commit preflight: \(path)"
             case .artifactRootChanged(let expected, let actual):
                 "artifact root changed after commit preflight: expected \(expected), found \(actual)"
+            case .invalidReplacementManifest(let message):
+                "invalid artifact replacement manifest: \(message)"
+            case .replacementPreparationCleanupFailed(let primary, let cleanup):
+                "artifact replacement preparation failed: \(primary); cleanup also failed: \(cleanup)"
+            case .replacementRollbackFailed(let primary, let rollback):
+                "artifact replacement failed: \(primary); rollback also failed: \(rollback)"
             }
         }
     }
@@ -96,6 +105,28 @@ extension PrivateHeaderGeneration {
             fileprivate let artifacts: [ArtifactPath]
             fileprivate let entries: [CommitEntry]
             fileprivate let destinationVolumeSupportsCaseSensitiveNames: Bool
+        }
+
+        internal struct Replacement: Sendable {
+            fileprivate let directory: URL
+            fileprivate let incomingRoot: URL
+            fileprivate let backupRoot: URL
+            internal let runID: PrivateHeaderGeneration.RunID
+            internal let targetID: String
+            fileprivate let artifactRoot: ArtifactPath
+            internal let incomingArtifacts: [ArtifactPath]
+            fileprivate let mutationArtifacts: [ArtifactPath]
+            fileprivate let backedUpArtifacts: [ArtifactPath]
+        }
+
+        private struct ReplacementManifest: Codable {
+            let version: Int
+            let runID: String
+            let targetID: String
+            let artifactRoot: String
+            let incomingArtifacts: [String]
+            let mutationArtifacts: [String]
+            let backedUpArtifacts: [String]
         }
 
         public let artifactRoot: URL
@@ -190,6 +221,399 @@ extension PrivateHeaderGeneration {
             fileManager: FileManager = .default
         ) throws {
             try write(plan, preservingSources: true, fileManager: fileManager)
+        }
+
+        internal func prepareReplacement(
+            _ plan: CommitPlan,
+            removing artifactsToRemove: [ArtifactPath],
+            runID: PrivateHeaderGeneration.RunID,
+            targetID: String,
+            at transactionDirectory: URL,
+            fileManager: FileManager = .default
+        ) throws -> Replacement {
+            try preflightCommit(plan, fileManager: fileManager)
+            let incomingArtifacts = plan.artifacts.sorted { $0.rawValue < $1.rawValue }
+            let mutationArtifacts = Self.cleanupCandidates(
+                manifestArtifacts: artifactsToRemove,
+                attemptedArtifacts: incomingArtifacts
+            )
+            _ = try Self.cleanupArtifactInspections(
+                for: mutationArtifacts,
+                root: plan.root,
+                fileManager: fileManager
+            )
+
+            let directory = transactionDirectory.standardizedFileURL
+            let incomingRoot = directory.appendingPathComponent("incoming", isDirectory: true)
+            let backupRoot = directory.appendingPathComponent("backup", isDirectory: true)
+            do {
+                guard try Self.artifactItemKind(at: directory, fileManager: fileManager) == nil else {
+                    throw ArtifactStoreError.invalidReplacementManifest(
+                        "transaction directory already exists at \(directory.path)"
+                    )
+                }
+                try ManagedFileSystem.ensureRealDirectory(
+                    directory.deletingLastPathComponent()
+                )
+                try fileManager.createDirectory(
+                    at: incomingRoot,
+                    withIntermediateDirectories: true
+                )
+                try fileManager.createDirectory(
+                    at: backupRoot,
+                    withIntermediateDirectories: true
+                )
+
+                let incomingStore = ArtifactStore(artifactRoot: incomingRoot)
+                let incomingPlan = try incomingStore.prepareCommit(
+                    stagingDirectory: plan.stagingDirectory,
+                    stagedSourceDirectory: plan.stagedSourceDirectory,
+                    artifactRoot: plan.artifactRoot,
+                    artifacts: incomingArtifacts,
+                    fileManager: fileManager
+                )
+                try incomingStore.copy(incomingPlan, fileManager: fileManager)
+
+                let backedUpArtifacts = try backupExistingArtifacts(
+                    mutationArtifacts,
+                    from: plan.root,
+                    to: backupRoot,
+                    fileManager: fileManager
+                )
+                let replacement = Replacement(
+                    directory: directory,
+                    incomingRoot: incomingRoot,
+                    backupRoot: backupRoot,
+                    runID: runID,
+                    targetID: targetID,
+                    artifactRoot: plan.artifactRoot,
+                    incomingArtifacts: incomingArtifacts,
+                    mutationArtifacts: mutationArtifacts,
+                    backedUpArtifacts: backedUpArtifacts
+                )
+                try writeManifest(for: replacement, fileManager: fileManager)
+                return replacement
+            } catch {
+                let primary = error
+                do {
+                    if try Self.artifactItemKind(at: directory, fileManager: fileManager) != nil {
+                        try fileManager.removeItem(at: directory)
+                    }
+                } catch {
+                    throw ArtifactStoreError.replacementPreparationCleanupFailed(
+                        primary: String(describing: primary),
+                        cleanup: String(describing: error)
+                    )
+                }
+                throw primary
+            }
+        }
+
+        internal func applyReplacement(
+            _ replacement: Replacement,
+            fileManager: FileManager = .default
+        ) throws {
+            do {
+                let incomingSourceDirectory = Self.artifactURL(
+                    replacement.artifactRoot,
+                    under: replacement.incomingRoot
+                )
+                let incomingPlan = try prepareCommit(
+                    stagingDirectory: replacement.incomingRoot,
+                    stagedSourceDirectory: incomingSourceDirectory,
+                    artifactRoot: replacement.artifactRoot,
+                    artifacts: replacement.incomingArtifacts,
+                    fileManager: fileManager
+                )
+                try applyPreparedIncoming(incomingPlan, fileManager: fileManager)
+                let incomingArtifactSet = Set(replacement.incomingArtifacts)
+                let obsoleteArtifacts = replacement.mutationArtifacts.filter {
+                    !incomingArtifactSet.contains($0)
+                }
+                _ = try cleanupManagedArtifacts(obsoleteArtifacts, fileManager: fileManager)
+            } catch {
+                let primary = error
+                do {
+                    try rollbackReplacement(replacement, fileManager: fileManager)
+                } catch {
+                    throw ArtifactStoreError.replacementRollbackFailed(
+                        primary: String(describing: primary),
+                        rollback: String(describing: error)
+                    )
+                }
+                throw primary
+            }
+        }
+
+        internal func rollbackReplacement(
+            _ replacement: Replacement,
+            fileManager: FileManager = .default
+        ) throws {
+            _ = try cleanupManagedArtifacts(
+                replacement.mutationArtifacts,
+                fileManager: fileManager
+            )
+            guard !replacement.backedUpArtifacts.isEmpty else { return }
+            let backupSourceDirectory = Self.artifactURL(
+                replacement.artifactRoot,
+                under: replacement.backupRoot
+            )
+            let restorePlan = try prepareCommit(
+                stagingDirectory: replacement.backupRoot,
+                stagedSourceDirectory: backupSourceDirectory,
+                artifactRoot: replacement.artifactRoot,
+                artifacts: replacement.backedUpArtifacts,
+                fileManager: fileManager
+            )
+            try copy(restorePlan, fileManager: fileManager)
+        }
+
+        internal func finalizeReplacement(
+            _ replacement: Replacement,
+            fileManager: FileManager = .default
+        ) throws {
+            guard
+                let kind = try Self.artifactItemKind(
+                    at: replacement.directory,
+                    fileManager: fileManager
+                )
+            else { return }
+            guard kind == .directory else {
+                throw ArtifactStoreError.invalidReplacementManifest(
+                    "transaction is not a directory at \(replacement.directory.path)"
+                )
+            }
+            try fileManager.removeItem(at: replacement.directory)
+        }
+
+        internal static func pendingReplacements(
+            in replacementsRoot: URL,
+            artifactRoot: URL,
+            fileManager: FileManager = .default
+        ) throws -> [Replacement] {
+            guard let rootKind = try artifactItemKind(at: replacementsRoot, fileManager: fileManager)
+            else { return [] }
+            guard rootKind == .directory else {
+                throw ArtifactStoreError.invalidReplacementManifest(
+                    "replacement root is not a directory at \(replacementsRoot.path)"
+                )
+            }
+            var replacements: [Replacement] = []
+            for runDirectory in try fileManager.contentsOfDirectory(
+                at: replacementsRoot,
+                includingPropertiesForKeys: nil,
+                options: []
+            ).sorted(by: { $0.path < $1.path }) {
+                guard try artifactItemKind(at: runDirectory, fileManager: fileManager) == .directory
+                else {
+                    throw ArtifactStoreError.invalidReplacementManifest(
+                        "replacement run entry is not a directory at \(runDirectory.path)"
+                    )
+                }
+                for transactionDirectory in try fileManager.contentsOfDirectory(
+                    at: runDirectory,
+                    includingPropertiesForKeys: nil,
+                    options: []
+                ).sorted(by: { $0.path < $1.path }) {
+                    guard
+                        try artifactItemKind(at: transactionDirectory, fileManager: fileManager)
+                            == .directory
+                    else {
+                        throw ArtifactStoreError.invalidReplacementManifest(
+                            "replacement target entry is not a directory at \(transactionDirectory.path)"
+                        )
+                    }
+                    let manifestURL = transactionDirectory.appendingPathComponent(
+                        "manifest.json",
+                        isDirectory: false
+                    )
+                    guard try artifactItemKind(at: manifestURL, fileManager: fileManager) != nil else {
+                        continue
+                    }
+                    replacements.append(
+                        try loadReplacement(
+                            at: transactionDirectory,
+                            artifactRoot: artifactRoot,
+                            fileManager: fileManager
+                        )
+                    )
+                }
+            }
+            return replacements
+        }
+
+        internal static func cleanupReplacementStaging(
+            _ replacementsRoot: URL,
+            fileManager: FileManager = .default
+        ) throws {
+            guard let kind = try artifactItemKind(at: replacementsRoot, fileManager: fileManager)
+            else { return }
+            guard kind == .directory else {
+                throw ArtifactStoreError.invalidReplacementManifest(
+                    "replacement root is not a directory at \(replacementsRoot.path)"
+                )
+            }
+            try fileManager.removeItem(at: replacementsRoot)
+        }
+
+        private func applyPreparedIncoming(
+            _ plan: CommitPlan,
+            fileManager: FileManager
+        ) throws {
+            try preflightCommit(plan, fileManager: fileManager)
+            for entry in plan.entries where entry.kind == .directory {
+                let destination = try revalidate(entry, in: plan, fileManager: fileManager)
+                try fileManager.createDirectory(
+                    at: destination,
+                    withIntermediateDirectories: true
+                )
+            }
+            for entry in plan.entries where entry.kind == .file {
+                let destination = try revalidate(entry, in: plan, fileManager: fileManager)
+                try ManagedFileSystem.atomicRename(from: entry.source, to: destination)
+            }
+        }
+
+        private func backupExistingArtifacts(
+            _ artifacts: [ArtifactPath],
+            from root: ArtifactRootURLs,
+            to backupRoot: URL,
+            fileManager: FileManager
+        ) throws -> [ArtifactPath] {
+            var backedUpArtifacts: [ArtifactPath] = []
+            for artifact in artifacts {
+                let inspection = try Self.preflightCleanupArtifact(
+                    for: artifact,
+                    root: root,
+                    fileManager: fileManager
+                )
+                switch inspection {
+                case .missingParent, .leaf(_, nil):
+                    continue
+                case .occupiedParent, .symbolicLinkParent:
+                    preconditionFailure("preflightCleanupArtifact rejects invalid parents")
+                case .leaf(let source, .some(.regularFile)):
+                    let destination = Self.artifactURL(artifact, under: backupRoot)
+                    try fileManager.createDirectory(
+                        at: destination.deletingLastPathComponent(),
+                        withIntermediateDirectories: true
+                    )
+                    try fileManager.copyItem(at: source, to: destination)
+                    backedUpArtifacts.append(artifact)
+                case .leaf(let source, .some(.symbolicLink)):
+                    throw ArtifactStoreError.symbolicLinkInArtifactPath(
+                        artifactPath: artifact,
+                        symbolicLinkPath: source.path
+                    )
+                case .leaf(_, .some(.directory)), .leaf(_, .some(.other)):
+                    throw ArtifactStoreError.commitDestinationTypeMismatch(
+                        artifactPath: artifact,
+                        expected: "regular file",
+                        actual: "non-regular file"
+                    )
+                }
+            }
+            return backedUpArtifacts
+        }
+
+        private func writeManifest(
+            for replacement: Replacement,
+            fileManager: FileManager
+        ) throws {
+            let manifestURL = replacement.directory.appendingPathComponent(
+                "manifest.json",
+                isDirectory: false
+            )
+            guard try Self.artifactItemKind(at: manifestURL, fileManager: fileManager) == nil else {
+                throw ArtifactStoreError.invalidReplacementManifest(
+                    "manifest already exists at \(manifestURL.path)"
+                )
+            }
+            let manifest = ReplacementManifest(
+                version: 1,
+                runID: replacement.runID.rawValue,
+                targetID: replacement.targetID,
+                artifactRoot: replacement.artifactRoot.rawValue,
+                incomingArtifacts: replacement.incomingArtifacts.map(\.rawValue),
+                mutationArtifacts: replacement.mutationArtifacts.map(\.rawValue),
+                backedUpArtifacts: replacement.backedUpArtifacts.map(\.rawValue)
+            )
+            try JSONEncoder().encode(manifest).write(to: manifestURL, options: .atomic)
+        }
+
+        private static func loadReplacement(
+            at directory: URL,
+            artifactRoot: URL,
+            fileManager: FileManager
+        ) throws -> Replacement {
+            let manifestURL = directory.appendingPathComponent("manifest.json", isDirectory: false)
+            guard try artifactItemKind(at: manifestURL, fileManager: fileManager) == .regularFile
+            else {
+                throw ArtifactStoreError.invalidReplacementManifest(
+                    "manifest is not a regular file at \(manifestURL.path)"
+                )
+            }
+            let manifest: ReplacementManifest
+            do {
+                manifest = try JSONDecoder().decode(
+                    ReplacementManifest.self,
+                    from: Data(contentsOf: manifestURL)
+                )
+            } catch {
+                throw ArtifactStoreError.invalidReplacementManifest(
+                    "could not decode \(manifestURL.path): \(error)"
+                )
+            }
+            guard manifest.version == 1 else {
+                throw ArtifactStoreError.invalidReplacementManifest(
+                    "unsupported version \(manifest.version) at \(manifestURL.path)"
+                )
+            }
+            let runID = try PrivateHeaderGeneration.RunID(manifest.runID)
+            guard directory.deletingLastPathComponent().lastPathComponent == runID.rawValue else {
+                throw ArtifactStoreError.invalidReplacementManifest(
+                    "run identifier does not match its directory at \(manifestURL.path)"
+                )
+            }
+            guard !manifest.targetID.isEmpty else {
+                throw ArtifactStoreError.invalidReplacementManifest(
+                    "target identifier is empty at \(manifestURL.path)"
+                )
+            }
+            let artifactRootPath = try ArtifactPath(manifest.artifactRoot)
+            let incomingArtifacts = try manifest.incomingArtifacts.map { try ArtifactPath($0) }
+            let mutationArtifacts = try manifest.mutationArtifacts.map { try ArtifactPath($0) }
+            let backedUpArtifacts = try manifest.backedUpArtifacts.map {
+                try ArtifactPath($0)
+            }
+            let mutationSet = Set(mutationArtifacts)
+            guard incomingArtifacts.allSatisfy(mutationSet.contains),
+                backedUpArtifacts.allSatisfy(mutationSet.contains)
+            else {
+                throw ArtifactStoreError.invalidReplacementManifest(
+                    "manifest paths do not form one mutation set at \(manifestURL.path)"
+                )
+            }
+            let incomingRoot = directory.appendingPathComponent("incoming", isDirectory: true)
+            let backupRoot = directory.appendingPathComponent("backup", isDirectory: true)
+            _ = try artifactRootURLs(for: artifactRoot)
+            return Replacement(
+                directory: directory,
+                incomingRoot: incomingRoot,
+                backupRoot: backupRoot,
+                runID: runID,
+                targetID: manifest.targetID,
+                artifactRoot: artifactRootPath,
+                incomingArtifacts: incomingArtifacts,
+                mutationArtifacts: mutationArtifacts,
+                backedUpArtifacts: backedUpArtifacts
+            )
+        }
+
+        private static func artifactURL(_ artifact: ArtifactPath, under root: URL) -> URL {
+            artifact.rawValue.split(separator: "/").reduce(into: root) { url, component in
+                url.appendPathComponent(String(component), isDirectory: false)
+            }
         }
 
         private func write(

--- a/Sources/PrivateHeaderKitCore/PrivateHeaderGenerationArtifactStore.swift
+++ b/Sources/PrivateHeaderKitCore/PrivateHeaderGenerationArtifactStore.swift
@@ -1,0 +1,1033 @@
+import Foundation
+
+extension PrivateHeaderGeneration {
+    struct ArtifactCleanupResult: Equatable, Sendable {
+        public let deletedArtifacts: [ArtifactPath]
+        public let missingArtifacts: [ArtifactPath]
+        public let prunedDirectories: [ArtifactPath]
+
+        public init(
+            deletedArtifacts: [ArtifactPath],
+            missingArtifacts: [ArtifactPath],
+            prunedDirectories: [ArtifactPath]
+        ) {
+            self.deletedArtifacts = deletedArtifacts
+            self.missingArtifacts = missingArtifacts
+            self.prunedDirectories = prunedDirectories
+        }
+    }
+
+    enum ArtifactStoreError: Error, Equatable, CustomStringConvertible, Sendable {
+        case nonFileArtifactRoot(String)
+        case nonFileStagingDirectory(String)
+        case artifactPathEscapesRoot(
+            artifactPath: ArtifactPath, artifactRoot: String, resolvedPath: String)
+        case symbolicLinkInArtifactPath(artifactPath: ArtifactPath, symbolicLinkPath: String)
+        case cleanupParentTypeMismatch(
+            artifactPath: ArtifactPath, parentPath: String, actual: String)
+        case cleanupDirectoryNotEmpty(artifactPath: ArtifactPath, directoryPath: String)
+        case commitDestinationTypeMismatch(
+            artifactPath: ArtifactPath, expected: String, actual: String)
+        case symbolicLinkInStagingDirectory(String)
+        case missingStagedArtifact(String)
+        case stagedArtifactIsNotDirectory(String)
+        case stagedArtifactIsNotRegularFile(String)
+        case stagedSourceOutsideStagingDirectory(stagedSource: String, stagingDirectory: String)
+        case artifactPathOutsideCommitRoot(artifactPath: ArtifactPath, artifactRoot: ArtifactPath)
+        case commitSourceDestinationOverlap(source: String, destination: String)
+        case commitDestinationCollision(first: ArtifactPath, second: ArtifactPath)
+        case destinationVolumeCaseSensitivityUnavailable(String)
+        case destinationVolumeCaseSensitivityChanged(root: String, expected: Bool, actual: Bool)
+        case stagingDirectoryChanged(String)
+        case artifactRootChanged(expected: String, actual: String)
+
+        public var description: String {
+            switch self {
+            case .nonFileArtifactRoot(let artifactRoot):
+                "artifact root must be a file URL: \(artifactRoot)"
+            case .nonFileStagingDirectory(let stagingDirectory):
+                "staging directory must be a file URL: \(stagingDirectory)"
+            case .artifactPathEscapesRoot(let artifactPath, let artifactRoot, let resolvedPath):
+                "artifact path escapes artifact root: \(artifactPath.rawValue) resolved to \(resolvedPath) outside \(artifactRoot)"
+            case .symbolicLinkInArtifactPath(let artifactPath, let symbolicLinkPath):
+                "artifact path contains a symbolic link: \(artifactPath.rawValue) traverses \(symbolicLinkPath)"
+            case .cleanupParentTypeMismatch(let artifactPath, let parentPath, let actual):
+                "cleanup artifact parent has unexpected type: \(artifactPath.rawValue) traverses \(parentPath), found \(actual)"
+            case .cleanupDirectoryNotEmpty(let artifactPath, let directoryPath):
+                "cleanup artifact directory is not empty: \(artifactPath.rawValue) at \(directoryPath)"
+            case .commitDestinationTypeMismatch(let artifactPath, let expected, let actual):
+                "commit destination has unexpected type: \(artifactPath.rawValue) expected \(expected), found \(actual)"
+            case .symbolicLinkInStagingDirectory(let path):
+                "staging directory contains a symbolic link: \(path)"
+            case .missingStagedArtifact(let path):
+                "staged artifact disappeared before commit: \(path)"
+            case .stagedArtifactIsNotDirectory(let path):
+                "staged artifact path is not a directory: \(path)"
+            case .stagedArtifactIsNotRegularFile(let path):
+                "staged artifact is not a regular file: \(path)"
+            case .stagedSourceOutsideStagingDirectory(let stagedSource, let stagingDirectory):
+                "staged source is outside staging directory: \(stagedSource) is not under \(stagingDirectory)"
+            case .artifactPathOutsideCommitRoot(let artifactPath, let artifactRoot):
+                "artifact path is outside commit root: \(artifactPath.rawValue) is not under \(artifactRoot.rawValue)"
+            case .commitSourceDestinationOverlap(let source, let destination):
+                "commit source and destination overlap: \(source) and \(destination)"
+            case .commitDestinationCollision(let first, let second):
+                "commit destinations collide: \(first.rawValue) and \(second.rawValue)"
+            case .destinationVolumeCaseSensitivityUnavailable(let root):
+                "destination volume case sensitivity is unavailable: \(root)"
+            case .destinationVolumeCaseSensitivityChanged(let root, let expected, let actual):
+                "destination volume case sensitivity changed: \(root) expected \(expected), found \(actual)"
+            case .stagingDirectoryChanged(let path):
+                "staging directory changed after commit preflight: \(path)"
+            case .artifactRootChanged(let expected, let actual):
+                "artifact root changed after commit preflight: expected \(expected), found \(actual)"
+            }
+        }
+    }
+
+    struct ArtifactStore: Sendable {
+        internal struct CommitPlan: Sendable {
+            fileprivate let root: ArtifactRootURLs
+            fileprivate let stagingDirectory: URL
+            fileprivate let resolvedStagingDirectory: URL
+            fileprivate let stagedSourceDirectory: URL
+            fileprivate let resolvedStagedSourceDirectory: URL
+            fileprivate let artifactRoot: ArtifactPath
+            fileprivate let artifacts: [ArtifactPath]
+            fileprivate let entries: [CommitEntry]
+            fileprivate let destinationVolumeSupportsCaseSensitiveNames: Bool
+        }
+
+        public let artifactRoot: URL
+
+        public init(artifactRoot: URL) {
+            self.artifactRoot = artifactRoot
+        }
+
+        public func contains(
+            _ artifact: ArtifactPath,
+            fileManager: FileManager = .default
+        ) throws -> Bool {
+            let root = try Self.artifactRootURLs(for: artifactRoot)
+            switch try Self.inspectArtifactPath(
+                artifact,
+                root: root,
+                fileManager: fileManager
+            ) {
+            case .leaf(_, .some(.regularFile)):
+                return true
+            case .missingParent, .occupiedParent, .symbolicLinkParent, .leaf:
+                return false
+            }
+        }
+
+        @discardableResult
+        public func cleanupManagedArtifacts(
+            _ artifacts: [ArtifactPath],
+            fileManager: FileManager = .default
+        ) throws -> ArtifactCleanupResult {
+            try Self.cleanupManagedArtifacts(
+                in: artifactRoot,
+                artifacts: artifacts,
+                fileManager: fileManager
+            )
+        }
+
+        internal func prepareCommit(
+            stagingDirectory: URL,
+            stagedSourceDirectory: URL,
+            artifactRoot: ArtifactPath,
+            artifacts: [ArtifactPath],
+            fileManager: FileManager = .default
+        ) throws -> CommitPlan {
+            let root = try Self.artifactRootURLs(for: self.artifactRoot)
+            let destinationVolumeSupportsCaseSensitiveNames =
+                try Self
+                .destinationVolumeSupportsCaseSensitiveNames(
+                    for: root,
+                    fileManager: fileManager
+                )
+            let artifacts = artifacts.sorted { $0.rawValue < $1.rawValue }
+            try Self.validateDestinationCollisions(artifacts)
+            let entries = try Self.commitEntries(
+                stagingDirectory: stagingDirectory,
+                stagedSourceDirectory: stagedSourceDirectory,
+                artifactRoot: artifactRoot,
+                artifacts: artifacts,
+                fileManager: fileManager
+            )
+            let plan = CommitPlan(
+                root: root,
+                stagingDirectory: stagingDirectory.standardizedFileURL,
+                resolvedStagingDirectory:
+                    stagingDirectory
+                    .resolvingSymlinksInPath()
+                    .standardizedFileURL,
+                stagedSourceDirectory: stagedSourceDirectory.standardizedFileURL,
+                resolvedStagedSourceDirectory:
+                    stagedSourceDirectory
+                    .resolvingSymlinksInPath()
+                    .standardizedFileURL,
+                artifactRoot: artifactRoot,
+                artifacts: artifacts,
+                entries: entries,
+                destinationVolumeSupportsCaseSensitiveNames:
+                    destinationVolumeSupportsCaseSensitiveNames
+            )
+            try preflightCommit(plan, fileManager: fileManager)
+            return plan
+        }
+
+        internal func commit(
+            _ plan: CommitPlan,
+            fileManager: FileManager = .default
+        ) throws {
+            try write(plan, preservingSources: false, fileManager: fileManager)
+        }
+
+        internal func copy(
+            _ plan: CommitPlan,
+            fileManager: FileManager = .default
+        ) throws {
+            try write(plan, preservingSources: true, fileManager: fileManager)
+        }
+
+        private func write(
+            _ plan: CommitPlan,
+            preservingSources: Bool,
+            fileManager: FileManager
+        ) throws {
+            try preflightCommit(plan, fileManager: fileManager)
+
+            for entry in plan.entries where entry.kind == .directory {
+                let destination = try revalidate(
+                    entry,
+                    in: plan,
+                    fileManager: fileManager
+                )
+                try fileManager.createDirectory(
+                    at: destination,
+                    withIntermediateDirectories: true
+                )
+            }
+
+            for entry in plan.entries where entry.kind == .file {
+                let destination = try revalidate(
+                    entry,
+                    in: plan,
+                    fileManager: fileManager
+                )
+                if try Self.artifactItemKind(at: destination, fileManager: fileManager) != nil {
+                    try fileManager.removeItem(at: destination)
+                }
+                if preservingSources {
+                    try fileManager.copyItem(at: entry.source, to: destination)
+                } else {
+                    try fileManager.moveItem(at: entry.source, to: destination)
+                }
+            }
+        }
+
+        @discardableResult
+        public static func cleanupManagedArtifacts(
+            in artifactRoot: URL,
+            artifacts: [ArtifactPath],
+            fileManager: FileManager = .default
+        ) throws -> ArtifactCleanupResult {
+            let root = try artifactRootURLs(for: artifactRoot)
+            let candidates = cleanupCandidates(manifestArtifacts: artifacts)
+            let candidateSet = Set(candidates)
+            let artifactInspections = try cleanupArtifactInspections(
+                for: candidates,
+                root: root,
+                fileManager: fileManager
+            )
+            var deletedArtifacts: [ArtifactPath] = []
+            var missingArtifacts: [ArtifactPath] = []
+            var prunedDirectories: [ArtifactPath] = []
+            var prunedDirectorySet = Set<ArtifactPath>()
+
+            for artifact in cleanupOperationOrder(candidates) {
+                guard case .leaf = artifactInspections[artifact]! else {
+                    missingArtifacts.append(artifact)
+                    continue
+                }
+                let inspection = try preflightCleanupArtifact(
+                    for: artifact,
+                    root: root,
+                    fileManager: fileManager
+                )
+                guard case .leaf(let artifactURL, .some(_)) = inspection else {
+                    missingArtifacts.append(artifact)
+                    continue
+                }
+
+                try fileManager.removeItem(at: artifactURL)
+                deletedArtifacts.append(artifact)
+
+                let pruned = try pruneEmptyParentDirectories(
+                    afterDeleting: artifact,
+                    root: root,
+                    cleanupCandidates: candidateSet,
+                    fileManager: fileManager
+                )
+                for directory in pruned where prunedDirectorySet.insert(directory).inserted {
+                    prunedDirectories.append(directory)
+                }
+            }
+
+            return ArtifactCleanupResult(
+                deletedArtifacts: cleanupCandidates(manifestArtifacts: deletedArtifacts),
+                missingArtifacts: cleanupCandidates(manifestArtifacts: missingArtifacts),
+                prunedDirectories: cleanupCandidates(manifestArtifacts: prunedDirectories)
+            )
+        }
+
+        public static func cleanupCandidates(
+            manifestArtifacts: [ArtifactPath],
+            attemptedArtifacts: [ArtifactPath] = []
+        ) -> [ArtifactPath] {
+            Array(Set(manifestArtifacts + attemptedArtifacts))
+                .sorted { $0.rawValue < $1.rawValue }
+        }
+
+        fileprivate struct ArtifactRootURLs: Equatable, Sendable {
+            let unresolved: URL
+            let resolved: URL
+        }
+
+        fileprivate struct CommitEntry: Equatable, Sendable {
+            let source: URL
+            let artifact: ArtifactPath
+            let kind: CommitEntryKind
+        }
+
+        fileprivate enum CommitEntryKind: Equatable, Sendable {
+            case directory
+            case file
+        }
+
+        private enum ArtifactItemKind: Equatable {
+            case directory
+            case regularFile
+            case symbolicLink
+            case other
+        }
+
+        private enum ArtifactPathInspection {
+            case missingParent
+            case occupiedParent(URL, ArtifactItemKind)
+            case symbolicLinkParent(URL)
+            case leaf(URL, ArtifactItemKind?)
+        }
+
+        private enum ExpectedStagedItemKind {
+            case directory
+            case regularFile
+        }
+
+        private static func artifactRootURLs(for artifactRoot: URL) throws -> ArtifactRootURLs {
+            guard artifactRoot.isFileURL else {
+                throw ArtifactStoreError.nonFileArtifactRoot(artifactRoot.absoluteString)
+            }
+
+            let unresolved = artifactRoot.standardizedFileURL
+            return ArtifactRootURLs(
+                unresolved: unresolved,
+                resolved: unresolved.resolvingSymlinksInPath().standardizedFileURL
+            )
+        }
+
+        private static func destinationVolumeSupportsCaseSensitiveNames(
+            for root: ArtifactRootURLs,
+            fileManager: FileManager
+        ) throws -> Bool {
+            var candidate = root.resolved
+            while true {
+                let kind: ArtifactItemKind?
+                do {
+                    kind = try artifactItemKind(at: candidate, fileManager: fileManager)
+                } catch {
+                    throw ArtifactStoreError.destinationVolumeCaseSensitivityUnavailable(
+                        root.resolved.path
+                    )
+                }
+
+                if kind != nil {
+                    let values: URLResourceValues
+                    do {
+                        values = try candidate.resourceValues(
+                            forKeys: [.volumeSupportsCaseSensitiveNamesKey]
+                        )
+                    } catch {
+                        throw ArtifactStoreError.destinationVolumeCaseSensitivityUnavailable(
+                            root.resolved.path
+                        )
+                    }
+                    guard let supportsCaseSensitiveNames = values.volumeSupportsCaseSensitiveNames
+                    else {
+                        throw ArtifactStoreError.destinationVolumeCaseSensitivityUnavailable(
+                            root.resolved.path
+                        )
+                    }
+                    return supportsCaseSensitiveNames
+                }
+
+                let parent = candidate.deletingLastPathComponent().standardizedFileURL
+                guard parent.path != candidate.path else {
+                    throw ArtifactStoreError.destinationVolumeCaseSensitivityUnavailable(
+                        root.resolved.path
+                    )
+                }
+                candidate = parent
+            }
+        }
+
+        private static func cleanupArtifactInspections(
+            for artifacts: [ArtifactPath],
+            root: ArtifactRootURLs,
+            fileManager: FileManager
+        ) throws -> [ArtifactPath: ArtifactPathInspection] {
+            var inspections: [ArtifactPath: ArtifactPathInspection] = [:]
+            for artifact in artifacts {
+                inspections[artifact] = try preflightCleanupArtifact(
+                    for: artifact,
+                    root: root,
+                    fileManager: fileManager
+                )
+            }
+            return inspections
+        }
+
+        private static func preflightCleanupArtifact(
+            for artifact: ArtifactPath,
+            root: ArtifactRootURLs,
+            fileManager: FileManager
+        ) throws -> ArtifactPathInspection {
+            let inspection = try cleanupArtifactInspection(
+                for: artifact,
+                root: root,
+                fileManager: fileManager
+            )
+            if case .leaf(let url, .some(.directory)) = inspection {
+                let contents = try fileManager.contentsOfDirectory(atPath: url.path)
+                if !contents.isEmpty {
+                    throw ArtifactStoreError.cleanupDirectoryNotEmpty(
+                        artifactPath: artifact,
+                        directoryPath: url.path
+                    )
+                }
+            }
+            return inspection
+        }
+
+        private static func cleanupArtifactInspection(
+            for artifact: ArtifactPath,
+            root: ArtifactRootURLs,
+            fileManager: FileManager
+        ) throws -> ArtifactPathInspection {
+            let inspection = try inspectArtifactPath(
+                artifact,
+                root: root,
+                fileManager: fileManager
+            )
+            if case .symbolicLinkParent(let url) = inspection {
+                throw ArtifactStoreError.symbolicLinkInArtifactPath(
+                    artifactPath: artifact,
+                    symbolicLinkPath: url.path
+                )
+            }
+            if case .occupiedParent(let url, let kind) = inspection {
+                throw ArtifactStoreError.cleanupParentTypeMismatch(
+                    artifactPath: artifact,
+                    parentPath: url.path,
+                    actual: artifactItemKindDescription(kind)
+                )
+            }
+            return inspection
+        }
+
+        private static func inspectArtifactPath(
+            _ artifact: ArtifactPath,
+            root: ArtifactRootURLs,
+            fileManager: FileManager
+        ) throws -> ArtifactPathInspection {
+            let components = artifact.rawValue.split(
+                separator: "/",
+                omittingEmptySubsequences: false
+            )
+            var url = root.unresolved
+            for (index, component) in components.enumerated() {
+                url.appendPathComponent(String(component))
+                let kind = try artifactItemKind(at: url, fileManager: fileManager)
+                if index == components.count - 1 {
+                    return .leaf(url, kind)
+                }
+                guard let kind else {
+                    return .missingParent
+                }
+                if kind == .symbolicLink {
+                    return .symbolicLinkParent(url)
+                }
+                guard kind == .directory else {
+                    return .occupiedParent(url, kind)
+                }
+            }
+
+            preconditionFailure("ArtifactPath validation guarantees at least one component")
+        }
+
+        private static func artifactItemKindDescription(_ kind: ArtifactItemKind) -> String {
+            switch kind {
+            case .directory:
+                "directory"
+            case .regularFile:
+                "regular file"
+            case .symbolicLink:
+                "symbolic link"
+            case .other:
+                "special file"
+            }
+        }
+
+        private static func commitEntries(
+            stagingDirectory: URL,
+            stagedSourceDirectory: URL,
+            artifactRoot: ArtifactPath,
+            artifacts: [ArtifactPath],
+            fileManager: FileManager
+        ) throws -> [CommitEntry] {
+            try validateStagingBoundary(
+                stagingDirectory: stagingDirectory,
+                stagedSourceDirectory: stagedSourceDirectory,
+                fileManager: fileManager
+            )
+            let sourceDirectory = stagedSourceDirectory.standardizedFileURL
+
+            let rootComponents = artifactRoot.rawValue.split(separator: "/").map(String.init)
+            var entriesByArtifact: [ArtifactPath: CommitEntry] = [
+                artifactRoot: CommitEntry(
+                    source: sourceDirectory,
+                    artifact: artifactRoot,
+                    kind: .directory
+                )
+            ]
+
+            for artifact in artifacts {
+                let components = artifact.rawValue.split(separator: "/").map(String.init)
+                guard components.count > rootComponents.count,
+                    components.prefix(rootComponents.count).elementsEqual(rootComponents)
+                else {
+                    throw ArtifactStoreError.artifactPathOutsideCommitRoot(
+                        artifactPath: artifact,
+                        artifactRoot: artifactRoot
+                    )
+                }
+
+                let relativeComponents = Array(components.dropFirst(rootComponents.count))
+                var source = sourceDirectory
+                for (index, component) in relativeComponents.enumerated() {
+                    source.appendPathComponent(component)
+                    let isLeaf = index == relativeComponents.count - 1
+                    try validateStagedItem(
+                        at: source,
+                        expectedKind: isLeaf ? .regularFile : .directory,
+                        fileManager: fileManager
+                    )
+
+                    let entryArtifact = try ArtifactPath(
+                        (rootComponents + relativeComponents.prefix(index + 1)).joined(
+                            separator: "/")
+                    )
+                    entriesByArtifact[entryArtifact] = CommitEntry(
+                        source: source,
+                        artifact: entryArtifact,
+                        kind: isLeaf ? .file : .directory
+                    )
+                }
+            }
+
+            let entries = entriesByArtifact.values.sorted {
+                let leftDepth = pathDepth($0.artifact)
+                let rightDepth = pathDepth($1.artifact)
+                if leftDepth == rightDepth {
+                    if $0.artifact == $1.artifact {
+                        return $0.kind == .directory && $1.kind == .file
+                    }
+                    return $0.artifact.rawValue < $1.artifact.rawValue
+                }
+                return leftDepth < rightDepth
+            }
+            try validateDestinationCollisions(entries.map(\.artifact))
+            return entries
+        }
+
+        private static func validateStagedItem(
+            at url: URL,
+            expectedKind: ExpectedStagedItemKind,
+            fileManager: FileManager
+        ) throws {
+            guard let kind = try artifactItemKind(at: url, fileManager: fileManager) else {
+                throw ArtifactStoreError.missingStagedArtifact(url.path)
+            }
+            guard kind != .symbolicLink else {
+                throw ArtifactStoreError.symbolicLinkInStagingDirectory(url.path)
+            }
+            let hasExpectedKind =
+                switch expectedKind {
+                case .directory:
+                    kind == .directory
+                case .regularFile:
+                    kind == .regularFile
+                }
+            guard hasExpectedKind else {
+                switch expectedKind {
+                case .directory:
+                    throw ArtifactStoreError.stagedArtifactIsNotDirectory(url.path)
+                case .regularFile:
+                    throw ArtifactStoreError.stagedArtifactIsNotRegularFile(url.path)
+                }
+            }
+        }
+
+        private static func validateStagingBoundary(
+            stagingDirectory: URL,
+            stagedSourceDirectory: URL,
+            fileManager: FileManager
+        ) throws {
+            guard stagingDirectory.isFileURL else {
+                throw ArtifactStoreError.nonFileStagingDirectory(
+                    stagingDirectory.absoluteString
+                )
+            }
+            guard stagedSourceDirectory.isFileURL else {
+                throw ArtifactStoreError.nonFileStagingDirectory(
+                    stagedSourceDirectory.absoluteString
+                )
+            }
+
+            let stagingDirectory = stagingDirectory.standardizedFileURL
+            let stagedSourceDirectory = stagedSourceDirectory.standardizedFileURL
+            let stagingComponents = stagingDirectory.pathComponents
+            let sourceComponents = stagedSourceDirectory.pathComponents
+            guard sourceComponents.count >= stagingComponents.count,
+                sourceComponents.prefix(stagingComponents.count).elementsEqual(stagingComponents)
+            else {
+                throw ArtifactStoreError.stagedSourceOutsideStagingDirectory(
+                    stagedSource: stagedSourceDirectory.path,
+                    stagingDirectory: stagingDirectory.path
+                )
+            }
+
+            var current = stagingDirectory
+            try validateStagedItem(
+                at: current,
+                expectedKind: .directory,
+                fileManager: fileManager
+            )
+            for component in sourceComponents.dropFirst(stagingComponents.count) {
+                current.appendPathComponent(component, isDirectory: true)
+                try validateStagedItem(
+                    at: current,
+                    expectedKind: .directory,
+                    fileManager: fileManager
+                )
+            }
+        }
+
+        private static func validateDestinationCollisions(
+            _ artifacts: [ArtifactPath]
+        ) throws {
+            var artifactByCollisionKey: [String: ArtifactPath] = [:]
+            for artifact in artifacts {
+                let key = portableCollisionKey(for: artifact.rawValue)
+                if let existing = artifactByCollisionKey[key] {
+                    throw ArtifactStoreError.commitDestinationCollision(
+                        first: existing,
+                        second: artifact
+                    )
+                }
+                artifactByCollisionKey[key] = artifact
+            }
+        }
+
+        private static func portableCollisionKey(for path: String) -> String {
+            // Do not derive this from the current volume. Persisted state and artifacts must
+            // remain portable across volumes, and the ObjC header resolver disambiguates
+            // case-only names.
+            path
+                .precomposedStringWithCanonicalMapping
+                .folding(
+                    options: [.caseInsensitive],
+                    locale: Locale(identifier: "en_US_POSIX")
+                )
+                .precomposedStringWithCanonicalMapping
+        }
+
+        private static func commitDestinationURL(
+            for artifact: ArtifactPath,
+            root: ArtifactRootURLs,
+            fileManager: FileManager
+        ) throws -> URL {
+            var url = root.unresolved
+            var resolvedURL = root.resolved
+            for component in artifact.rawValue.split(
+                separator: "/", omittingEmptySubsequences: false)
+            {
+                url.appendPathComponent(String(component))
+                resolvedURL.appendPathComponent(String(component))
+                if try artifactItemKind(at: url, fileManager: fileManager) == .symbolicLink {
+                    throw ArtifactStoreError.symbolicLinkInArtifactPath(
+                        artifactPath: artifact,
+                        symbolicLinkPath: url.path
+                    )
+                }
+            }
+            resolvedURL = resolvedURL.standardizedFileURL
+            guard isSameOrDescendant(resolvedURL, of: root.resolved) else {
+                throw ArtifactStoreError.artifactPathEscapesRoot(
+                    artifactPath: artifact,
+                    artifactRoot: root.resolved.path,
+                    resolvedPath: resolvedURL.path
+                )
+            }
+            return url
+        }
+
+        private func preflightCommit(
+            _ plan: CommitPlan,
+            fileManager: FileManager
+        ) throws {
+            try validateArtifactRoot(of: plan)
+            try validateDestinationVolumeSemantics(of: plan, fileManager: fileManager)
+            try validateStagingBoundary(of: plan, fileManager: fileManager)
+            let currentEntries = try Self.commitEntries(
+                stagingDirectory: plan.stagingDirectory,
+                stagedSourceDirectory: plan.stagedSourceDirectory,
+                artifactRoot: plan.artifactRoot,
+                artifacts: plan.artifacts,
+                fileManager: fileManager
+            )
+            guard currentEntries == plan.entries else {
+                throw ArtifactStoreError.stagingDirectoryChanged(
+                    plan.stagedSourceDirectory.path
+                )
+            }
+            try Self.validateSourceDestinationDisjoint(plan)
+
+            for entry in plan.entries {
+                let destination = try Self.commitDestinationURL(
+                    for: entry.artifact,
+                    root: plan.root,
+                    fileManager: fileManager
+                )
+                try Self.validateCommitDestination(
+                    destination,
+                    for: entry,
+                    fileManager: fileManager
+                )
+            }
+        }
+
+        private func revalidate(
+            _ entry: CommitEntry,
+            in plan: CommitPlan,
+            fileManager: FileManager
+        ) throws -> URL {
+            try validateArtifactRoot(of: plan)
+            try validateDestinationVolumeSemantics(of: plan, fileManager: fileManager)
+            try validateStagingBoundary(of: plan, fileManager: fileManager)
+            guard
+                let sourceKind = try Self.artifactItemKind(
+                    at: entry.source,
+                    fileManager: fileManager
+                )
+            else {
+                throw ArtifactStoreError.missingStagedArtifact(entry.source.path)
+            }
+            guard sourceKind != .symbolicLink else {
+                throw ArtifactStoreError.symbolicLinkInStagingDirectory(entry.source.path)
+            }
+            let expectedSourceKind: ArtifactItemKind =
+                entry.kind == .directory ? .directory : .regularFile
+            guard sourceKind == expectedSourceKind else {
+                throw ArtifactStoreError.stagingDirectoryChanged(
+                    plan.stagedSourceDirectory.path
+                )
+            }
+
+            let destination = try Self.commitDestinationURL(
+                for: entry.artifact,
+                root: plan.root,
+                fileManager: fileManager
+            )
+            try Self.validateCommitDestination(
+                destination,
+                for: entry,
+                fileManager: fileManager
+            )
+            return destination
+        }
+
+        private func validateStagingBoundary(
+            of plan: CommitPlan,
+            fileManager: FileManager
+        ) throws {
+            try Self.validateStagingBoundary(
+                stagingDirectory: plan.stagingDirectory,
+                stagedSourceDirectory: plan.stagedSourceDirectory,
+                fileManager: fileManager
+            )
+            let resolvedStagingDirectory = plan.stagingDirectory
+                .resolvingSymlinksInPath()
+                .standardizedFileURL
+            let resolvedStagedSourceDirectory = plan.stagedSourceDirectory
+                .resolvingSymlinksInPath()
+                .standardizedFileURL
+            guard resolvedStagingDirectory.path == plan.resolvedStagingDirectory.path,
+                resolvedStagedSourceDirectory.path == plan.resolvedStagedSourceDirectory.path
+            else {
+                throw ArtifactStoreError.stagingDirectoryChanged(
+                    plan.stagingDirectory.path
+                )
+            }
+        }
+
+        private static func validateSourceDestinationDisjoint(
+            _ plan: CommitPlan
+        ) throws {
+            let sources = [
+                plan.resolvedStagingDirectory,
+                plan.resolvedStagedSourceDirectory,
+            ]
+            for entry in plan.entries {
+                let destination = resolvedArtifactURL(
+                    for: entry.artifact,
+                    root: plan.root
+                )
+                for source in sources
+                where pathsOverlap(
+                    source,
+                    destination,
+                    volumeSupportsCaseSensitiveNames: plan
+                        .destinationVolumeSupportsCaseSensitiveNames
+                ) {
+                    throw ArtifactStoreError.commitSourceDestinationOverlap(
+                        source: source.path,
+                        destination: destination.path
+                    )
+                }
+            }
+        }
+
+        private static func resolvedArtifactURL(
+            for artifact: ArtifactPath,
+            root: ArtifactRootURLs
+        ) -> URL {
+            var url = root.resolved
+            for component in artifact.rawValue.split(
+                separator: "/", omittingEmptySubsequences: false)
+            {
+                url.appendPathComponent(String(component))
+            }
+            return url.standardizedFileURL
+        }
+
+        internal static func pathsOverlap(
+            _ first: URL,
+            _ second: URL,
+            volumeSupportsCaseSensitiveNames: Bool
+        ) -> Bool {
+            let firstComponents = normalizedPathComponents(
+                of: first,
+                volumeSupportsCaseSensitiveNames: volumeSupportsCaseSensitiveNames
+            )
+            let secondComponents = normalizedPathComponents(
+                of: second,
+                volumeSupportsCaseSensitiveNames: volumeSupportsCaseSensitiveNames
+            )
+            return firstComponents.prefix(secondComponents.count).elementsEqual(secondComponents)
+                || secondComponents.prefix(firstComponents.count).elementsEqual(firstComponents)
+        }
+
+        private static func normalizedPathComponents(
+            of url: URL,
+            volumeSupportsCaseSensitiveNames: Bool
+        ) -> [String] {
+            url.standardizedFileURL.pathComponents.map { component in
+                let normalized = component.precomposedStringWithCanonicalMapping
+                guard !volumeSupportsCaseSensitiveNames else {
+                    return normalized
+                }
+                return portableCollisionKey(for: normalized)
+            }
+        }
+
+        private func validateDestinationVolumeSemantics(
+            of plan: CommitPlan,
+            fileManager: FileManager
+        ) throws {
+            let current = try Self.destinationVolumeSupportsCaseSensitiveNames(
+                for: plan.root,
+                fileManager: fileManager
+            )
+            guard current == plan.destinationVolumeSupportsCaseSensitiveNames else {
+                throw ArtifactStoreError.destinationVolumeCaseSensitivityChanged(
+                    root: plan.root.resolved.path,
+                    expected: plan.destinationVolumeSupportsCaseSensitiveNames,
+                    actual: current
+                )
+            }
+        }
+
+        private func validateArtifactRoot(of plan: CommitPlan) throws {
+            let current = try Self.artifactRootURLs(for: artifactRoot)
+            guard current.unresolved.path == plan.root.unresolved.path,
+                current.resolved.path == plan.root.resolved.path
+            else {
+                throw ArtifactStoreError.artifactRootChanged(
+                    expected: plan.root.resolved.path,
+                    actual: current.resolved.path
+                )
+            }
+        }
+
+        private static func validateCommitDestination(
+            _ destination: URL,
+            for entry: CommitEntry,
+            fileManager: FileManager
+        ) throws {
+            guard let existingKind = try artifactItemKind(at: destination, fileManager: fileManager)
+            else {
+                return
+            }
+
+            switch (entry.kind, existingKind) {
+            case (.directory, .directory), (.file, .regularFile):
+                return
+            case (.directory, .symbolicLink), (.file, .symbolicLink):
+                throw ArtifactStoreError.symbolicLinkInArtifactPath(
+                    artifactPath: entry.artifact,
+                    symbolicLinkPath: destination.path
+                )
+            case (.directory, .regularFile), (.directory, .other):
+                throw ArtifactStoreError.commitDestinationTypeMismatch(
+                    artifactPath: entry.artifact,
+                    expected: "directory",
+                    actual: "file"
+                )
+            case (.file, .directory):
+                throw ArtifactStoreError.commitDestinationTypeMismatch(
+                    artifactPath: entry.artifact,
+                    expected: "file",
+                    actual: "directory"
+                )
+            case (.file, .other):
+                throw ArtifactStoreError.commitDestinationTypeMismatch(
+                    artifactPath: entry.artifact,
+                    expected: "regular file",
+                    actual: "special file"
+                )
+            }
+        }
+
+        private static func artifactItemKind(
+            at url: URL,
+            fileManager: FileManager
+        ) throws -> ArtifactItemKind? {
+            do {
+                let attributes = try fileManager.attributesOfItem(atPath: url.path)
+                let fileType = attributes[.type] as? FileAttributeType
+                if fileType == .typeDirectory {
+                    return .directory
+                }
+                if fileType == .typeRegular {
+                    return .regularFile
+                }
+                if fileType == .typeSymbolicLink {
+                    return .symbolicLink
+                }
+                return .other
+            } catch {
+                let nsError = error as NSError
+                if nsError.domain == NSCocoaErrorDomain,
+                    nsError.code == CocoaError.Code.fileReadNoSuchFile.rawValue
+                {
+                    return nil
+                }
+                throw error
+            }
+        }
+
+        private static func cleanupOperationOrder(_ artifacts: [ArtifactPath]) -> [ArtifactPath] {
+            artifacts.sorted {
+                let leftDepth = pathDepth($0)
+                let rightDepth = pathDepth($1)
+                if leftDepth == rightDepth {
+                    return $0.rawValue < $1.rawValue
+                }
+                return leftDepth > rightDepth
+            }
+        }
+
+        private static func pathDepth(_ artifact: ArtifactPath) -> Int {
+            artifact.rawValue.split(separator: "/").count
+        }
+
+        private static func pruneEmptyParentDirectories(
+            afterDeleting artifact: ArtifactPath,
+            root: ArtifactRootURLs,
+            cleanupCandidates: Set<ArtifactPath>,
+            fileManager: FileManager
+        ) throws -> [ArtifactPath] {
+            var prunedDirectories: [ArtifactPath] = []
+
+            for parent in try parentDirectories(for: artifact) {
+                if cleanupCandidates.contains(parent) {
+                    break
+                }
+
+                let inspection = try cleanupArtifactInspection(
+                    for: parent,
+                    root: root,
+                    fileManager: fileManager
+                )
+                guard case .leaf(let parentURL, .some(.directory)) = inspection else {
+                    continue
+                }
+
+                guard try fileManager.contentsOfDirectory(atPath: parentURL.path).isEmpty else {
+                    break
+                }
+
+                try fileManager.removeItem(at: parentURL)
+                prunedDirectories.append(parent)
+            }
+
+            return prunedDirectories
+        }
+
+        private static func parentDirectories(for artifact: ArtifactPath) throws -> [ArtifactPath] {
+            let components = artifact.rawValue.split(separator: "/").map(String.init)
+            guard components.count > 1 else {
+                return []
+            }
+
+            return try stride(from: components.count - 1, through: 1, by: -1).map { count in
+                try ArtifactPath(components.prefix(count).joined(separator: "/"))
+            }
+        }
+
+        private static func isSameOrDescendant(_ url: URL, of root: URL) -> Bool {
+            let path = url.path
+            let rootPath = root.path
+            if path == rootPath {
+                return true
+            }
+            if rootPath == "/" {
+                return path.hasPrefix("/")
+            }
+            return path.hasPrefix(rootPath + "/")
+        }
+    }
+}

--- a/Sources/PrivateHeaderKitCore/PrivateHeaderGenerationExecutor.swift
+++ b/Sources/PrivateHeaderKitCore/PrivateHeaderGenerationExecutor.swift
@@ -218,6 +218,11 @@ extension PrivateHeaderGeneration.GenerationExecutor {
     progressReporter: ProgressReporter?
   ) async throws -> PrivateHeaderGeneration.Result {
     try await Self.recover(store: store, publisher: publisher, at: dateProvider())
+    try await Self.recoverTargetReplacements(
+      in: stateDirectory,
+      artifactDirectory: plan.artifactDirectory,
+      store: store
+    )
     try publisher.cleanupStaging()
     try Self.cleanupStateStaging(in: stateDirectory)
     let publication = try publisher.inspect()
@@ -383,21 +388,60 @@ extension PrivateHeaderGeneration.GenerationExecutor {
             artifactRoot: artifactRoot,
             artifacts: execution.result.artifacts
           )
-          try await store.prepareTargetPublication(execution.result, in: runID)
-          _ = try liveArtifactStore.cleanupManagedArtifacts(
-            PrivateHeaderGeneration.ArtifactStore.cleanupCandidates(
-              manifestArtifacts: ownedArtifactsByTarget[targetID] ?? [],
-              attemptedArtifacts: previousAttemptedArtifactsByTarget[targetID] ?? []
-            )
+          let artifactsToRemove = PrivateHeaderGeneration.ArtifactStore.cleanupCandidates(
+            manifestArtifacts: ownedArtifactsByTarget[targetID] ?? [],
+            attemptedArtifacts: previousAttemptedArtifactsByTarget[targetID] ?? []
           )
-          try liveArtifactStore.copy(commitPlan)
+          let replacementDirectory = Self.replacementStagingDirectory(in: stateDirectory)
+            .appendingPathComponent(runID.rawValue, isDirectory: true)
+            .appendingPathComponent(
+              Self.safeTargetDirectoryName(targetID),
+              isDirectory: true
+            )
+          let replacement = try liveArtifactStore.prepareReplacement(
+            commitPlan,
+            removing: artifactsToRemove,
+            runID: runID,
+            targetID: targetID,
+            at: replacementDirectory
+          )
+          try await store.prepareTargetPublication(execution.result, in: runID)
+          try liveArtifactStore.applyReplacement(replacement)
+          do {
+            try await store.recordPublishedTargetAttempt(execution.result, in: runID)
+          } catch {
+            let persistenceError = error
+            do {
+              try liveArtifactStore.rollbackReplacement(replacement)
+            } catch {
+              throw PrivateHeaderGeneration.ArtifactStoreError.replacementRollbackFailed(
+                primary: String(describing: persistenceError),
+                rollback: String(describing: error)
+              )
+            }
+            throw persistenceError
+          }
           ownedArtifactsByTarget[targetID] = execution.result.artifacts
           liveArtifactsByTarget[targetID] = execution.result.artifacts
           let publishedArtifactSet = Set(execution.result.artifacts)
           liveOpaquePaths.removeAll { publishedArtifactSet.contains($0) }
           completedFilesByTarget[targetID] = execution.completedFiles
-          try await store.recordPublishedTargetAttempt(execution.result, in: runID)
           generatedTargetIDs.append(targetID)
+          do {
+            try liveArtifactStore.finalizeReplacement(replacement)
+          } catch {
+            warnings.append(
+              await surfacePostCommitWarning(
+                runID: runID,
+                kind: "cleanup-warning",
+                relativePath:
+                  "replacements/\(runID.rawValue)/\(Self.safeTargetDirectoryName(targetID))",
+                error: error,
+                store: store,
+                progressReporter: progressReporter
+              )
+            )
+          }
         } else {
           try await store.recordTargetAttempt(execution.result, in: runID)
         }
@@ -459,6 +503,11 @@ extension PrivateHeaderGeneration.GenerationExecutor {
           to: initialDraft
         )
         let prepared = try publisher.prepareGeneration(draft, planFingerprint: fingerprint)
+        try Self.prepareLiveArtifactDirectory(
+          plan.artifactDirectory,
+          from: prepared.draftDirectory,
+          marker: prepared.marker
+        )
         let previousGenerationID = publication.currentGenerationID
         _ = try await store.preparePublication(
           generationID: generationID,
@@ -646,6 +695,11 @@ extension PrivateHeaderGeneration.GenerationExecutor {
       )
     }
     var warnings: [PrivateHeaderGeneration.GenerationWarning] = []
+    try await Self.recoverTargetReplacements(
+      in: stateDirectory,
+      artifactDirectory: artifactDirectory,
+      store: store
+    )
     do {
       try publisher.cleanupStaging()
     } catch {
@@ -1113,6 +1167,11 @@ extension PrivateHeaderGeneration.GenerationExecutor {
         toolCompatibilityIdentity: plan.options.toolCompatibilityIdentity
       )
       try await recover(store: store, publisher: publisher, at: Date())
+      try await recoverTargetReplacements(
+        in: stateDirectory,
+        artifactDirectory: plan.artifactDirectory,
+        store: store
+      )
       try publisher.cleanupStaging()
       try cleanupStateStaging(in: stateDirectory)
       let publication = try publisher.inspect()
@@ -1542,6 +1601,37 @@ extension PrivateHeaderGeneration.GenerationExecutor {
       _ = try PrivateHeaderGeneration.RunID(entry.lastPathComponent)
       try FileManager.default.removeItem(at: entry)
     }
+  }
+
+  fileprivate static func replacementStagingDirectory(in stateDirectory: URL) -> URL {
+    stateDirectory.appendingPathComponent("replacements", isDirectory: true)
+  }
+
+  fileprivate static func recoverTargetReplacements(
+    in stateDirectory: URL,
+    artifactDirectory: URL,
+    store: GenerationStore
+  ) async throws {
+    let replacementsRoot = replacementStagingDirectory(in: stateDirectory)
+    let artifactStore = PrivateHeaderGeneration.ArtifactStore(
+      artifactRoot: artifactDirectory
+    )
+    let replacements = try PrivateHeaderGeneration.ArtifactStore.pendingReplacements(
+      in: replacementsRoot,
+      artifactRoot: artifactDirectory
+    )
+    for replacement in replacements {
+      let publishedTarget = try await store.targetSnapshot(targetID: replacement.targetID)
+      let wasCommitted =
+        publishedTarget?.status == .completed
+        && publishedTarget?.lastSuccessfulRunID == replacement.runID
+        && Set(publishedTarget?.artifacts ?? []) == Set(replacement.incomingArtifacts)
+      if !wasCommitted {
+        try artifactStore.rollbackReplacement(replacement)
+      }
+      try artifactStore.finalizeReplacement(replacement)
+    }
+    try PrivateHeaderGeneration.ArtifactStore.cleanupReplacementStaging(replacementsRoot)
   }
 
   fileprivate static func directoryExists(_ url: URL) throws -> Bool {

--- a/Sources/PrivateHeaderKitCore/PrivateHeaderGenerationExecutor.swift
+++ b/Sources/PrivateHeaderKitCore/PrivateHeaderGenerationExecutor.swift
@@ -504,9 +504,9 @@ extension PrivateHeaderGeneration.GenerationExecutor {
           generationID: generationID,
           allowLegacyMigration: plan.options.resumeBehavior.isFresh
         )
-        let draft = try publisher.applyCompletedTargets(
+        let draft = try publisher.replaceCompletedTargets(
           snapshotFilesByTarget,
-          to: initialDraft
+          in: initialDraft
         )
         let prepared = try publisher.prepareGeneration(draft, planFingerprint: fingerprint)
         try Self.prepareLiveArtifactDirectory(

--- a/Sources/PrivateHeaderKitCore/PrivateHeaderGenerationExecutor.swift
+++ b/Sources/PrivateHeaderKitCore/PrivateHeaderGenerationExecutor.swift
@@ -232,12 +232,18 @@ extension PrivateHeaderGeneration.GenerationExecutor {
         ($0.targetID, $0.artifacts)
       }
     )
+    let publishedArtifactsByTarget = try await store.publishedArtifactsByTarget()
+    let targetIDsCoveredByCurrentGeneration = try await Self.targetIDsCoveredByCurrentGeneration(
+      publication,
+      store: store
+    )
     try Self.prepareLiveArtifactDirectory(
       plan.artifactDirectory,
       from: publication.currentMarker == nil ? nil : publisher.stableURL,
-      marker: publication.currentMarker
+      marker: publication.currentMarker,
+      publishedArtifactsByTarget: publishedArtifactsByTarget,
+      targetIDsCoveredByMarker: targetIDsCoveredByCurrentGeneration
     )
-    let publishedArtifactsByTarget = try await store.publishedArtifactsByTarget()
     let currentLiveArtifactsByTarget = try Self.availableLiveArtifactsByTarget(
       publishedArtifactsByTarget,
       under: plan.artifactDirectory
@@ -917,7 +923,9 @@ extension PrivateHeaderGeneration.GenerationExecutor {
   fileprivate static func prepareLiveArtifactDirectory(
     _ directory: URL,
     from publishedDirectory: URL?,
-    marker: PrivateHeaderGeneration.GenerationMarkerSnapshot?
+    marker: PrivateHeaderGeneration.GenerationMarkerSnapshot?,
+    publishedArtifactsByTarget: [String: [PrivateHeaderGeneration.ArtifactPath]] = [:],
+    targetIDsCoveredByMarker: Set<String> = []
   ) throws {
     if let kind = try ManagedFileSystem.itemKind(at: directory) {
       guard kind == .directory else {
@@ -932,8 +940,33 @@ extension PrivateHeaderGeneration.GenerationExecutor {
     }
 
     guard let publishedDirectory, let marker else { return }
+    let publishedArtifactSet = Set(publishedArtifactsByTarget.values.flatMap { $0 })
+    let supersededTargetIDs = Set(publishedArtifactsByTarget.keys)
+      .subtracting(targetIDsCoveredByMarker)
+    for targetID in targetIDsCoveredByMarker {
+      guard let markerArtifacts = marker.artifactsByTarget[targetID],
+        let publishedArtifacts = publishedArtifactsByTarget[targetID]
+      else { continue }
+      guard Set(markerArtifacts) == Set(publishedArtifacts) else {
+        throw PrivateHeaderGeneration.StateError.corruptPublication(
+          "current generation artifacts disagree with published target \(targetID)"
+        )
+      }
+    }
+    let staleArtifacts = supersededTargetIDs.flatMap {
+      marker.artifactsByTarget[$0] ?? []
+    }.filter { !publishedArtifactSet.contains($0) }
+    if !staleArtifacts.isEmpty {
+      _ = try PrivateHeaderGeneration.ArtifactStore(
+        artifactRoot: directory
+      ).cleanupManagedArtifacts(staleArtifacts)
+    }
     let publishedArtifacts = Set(
-      marker.artifactsByTarget.values.flatMap { $0 } + marker.opaquePaths
+      marker.artifactsByTarget
+        .filter { !supersededTargetIDs.contains($0.key) }
+        .values
+        .flatMap { $0 }
+        + marker.opaquePaths.filter { !publishedArtifactSet.contains($0) }
     ).sorted { $0.rawValue < $1.rawValue }
     for artifact in publishedArtifacts {
       let source = artifactURL(artifact, under: publishedDirectory)
@@ -964,6 +997,14 @@ extension PrivateHeaderGeneration.GenerationExecutor {
     artifact.rawValue.split(separator: "/").reduce(into: root) { url, component in
       url.appendPathComponent(String(component), isDirectory: false)
     }
+  }
+
+  fileprivate static func targetIDsCoveredByCurrentGeneration(
+    _ publication: PrivateHeaderGeneration.PublicationSnapshot,
+    store: GenerationStore
+  ) async throws -> Set<String> {
+    guard let generationID = publication.currentGenerationID else { return [] }
+    return try await store.targetIDsCoveredByGeneration(generationID)
   }
 
   fileprivate static func availableLiveArtifactsByTarget(
@@ -1182,12 +1223,18 @@ extension PrivateHeaderGeneration.GenerationExecutor {
           .artifacts(path: publisher.stableURL.path)
         )
       }
+      let publishedArtifactsByTarget = try await store.publishedArtifactsByTarget()
+      let coveredTargetIDs = try await targetIDsCoveredByCurrentGeneration(
+        publication,
+        store: store
+      )
       try prepareLiveArtifactDirectory(
         plan.artifactDirectory,
         from: publication.currentMarker == nil ? nil : publisher.stableURL,
-        marker: publication.currentMarker
+        marker: publication.currentMarker,
+        publishedArtifactsByTarget: publishedArtifactsByTarget,
+        targetIDsCoveredByMarker: coveredTargetIDs
       )
-      let publishedArtifactsByTarget = try await store.publishedArtifactsByTarget()
       let currentLiveArtifactsByTarget = try availableLiveArtifactsByTarget(
         publishedArtifactsByTarget,
         under: plan.artifactDirectory

--- a/Sources/PrivateHeaderKitCore/PrivateHeaderGenerationExecutor.swift
+++ b/Sources/PrivateHeaderKitCore/PrivateHeaderGenerationExecutor.swift
@@ -131,6 +131,10 @@ extension PrivateHeaderGeneration {
       )
       try publisher.prepareForLease()
       return try await GenerationLease.withExclusiveLease(at: publisher.lockURL) {
+        let artifactDirectory = Self.canonicalArtifactDirectory(
+          outputBase: publisher.artifactBaseDirectory,
+          sourceLabel: plan.source.storageIdentifier
+        )
         let stateDirectory = Self.canonicalStateDirectory(
           outputBase: publisher.artifactBaseDirectory,
           sourceLabel: plan.source.storageIdentifier
@@ -163,6 +167,7 @@ extension PrivateHeaderGeneration {
         )
         return try await runWithLease(
           plan: plan,
+          artifactDirectory: artifactDirectory,
           stateDirectory: stateDirectory,
           databaseURL: databaseURL,
           selectedTargets: preparedPlan.selectedTargets,
@@ -191,6 +196,13 @@ extension PrivateHeaderGeneration.GenerationExecutor {
     let sourceDirectory: URL?
   }
 
+  fileprivate enum PublishedTargetSource: Equatable {
+    case currentGeneration
+    case newerLiveOutput
+    case unverifiedLiveOutput
+    case unavailable
+  }
+
   fileprivate func cancellationRequested() -> Bool {
     Task.isCancelled
   }
@@ -207,6 +219,7 @@ extension PrivateHeaderGeneration.GenerationExecutor {
 
   fileprivate func runWithLease(
     plan: PrivateHeaderGeneration.Plan,
+    artifactDirectory: URL,
     stateDirectory: URL,
     databaseURL: URL,
     selectedTargets: [PrivateHeaderGeneration.TargetDiscovery.DiscoveredTarget],
@@ -217,10 +230,18 @@ extension PrivateHeaderGeneration.GenerationExecutor {
     executionMode: PrivateHeaderGeneration.RawDumping.ExecutionMode,
     progressReporter: ProgressReporter?
   ) async throws -> PrivateHeaderGeneration.Result {
+    if plan.options.resumeBehavior.isFresh {
+      _ = try await store.bootstrapPublishedGenerationIfEmpty(
+        sourceIdentity: plan.source.storageIdentifier,
+        publication: publisher.inspect(),
+        at: dateProvider()
+      )
+    }
     try await Self.recover(store: store, publisher: publisher, at: dateProvider())
     try await Self.recoverTargetReplacements(
       in: stateDirectory,
-      artifactDirectory: plan.artifactDirectory,
+      artifactDirectory: artifactDirectory,
+      currentMarker: try publisher.inspect().currentMarker,
       store: store
     )
     try publisher.cleanupStaging()
@@ -232,21 +253,34 @@ extension PrivateHeaderGeneration.GenerationExecutor {
         ($0.targetID, $0.artifacts)
       }
     )
-    let publishedArtifactsByTarget = try await store.publishedArtifactsByTarget()
+    let publishedTargetsByID = try await store.publishedTargetsByID()
+    let publishedArtifactsByTarget = publishedTargetsByID.mapValues(\.artifacts)
+    let liveArtifactStore = PrivateHeaderGeneration.ArtifactStore(
+      artifactRoot: artifactDirectory
+    )
     let targetIDsCoveredByCurrentGeneration = try await Self.targetIDsCoveredByCurrentGeneration(
       publication,
       store: store
     )
-    try Self.prepareLiveArtifactDirectory(
-      plan.artifactDirectory,
-      from: publication.currentMarker == nil ? nil : publisher.stableURL,
+    let publishedTargetSources = try Self.publishedTargetSources(
       marker: publication.currentMarker,
+      publishedTargetsByID: publishedTargetsByID,
+      targetIDsCoveredByMarker: targetIDsCoveredByCurrentGeneration,
+      liveArtifactStore: liveArtifactStore
+    )
+    try await Self.reconcileLiveArtifactDirectory(
+      artifactDirectory,
+      publication: publication,
+      publishedDirectory: publisher.stableURL,
       publishedArtifactsByTarget: publishedArtifactsByTarget,
-      targetIDsCoveredByMarker: targetIDsCoveredByCurrentGeneration
+      publishedTargetSources: publishedTargetSources,
+      stagingDirectory: Self.hydrationStagingDirectory(in: stateDirectory),
+      store: store
     )
     let currentLiveArtifactsByTarget = try Self.availableLiveArtifactsByTarget(
       publishedArtifactsByTarget,
-      under: plan.artifactDirectory
+      publishedTargetSources: publishedTargetSources,
+      under: artifactDirectory
     )
 
     if publication.stablePathState == .legacyDirectory,
@@ -314,14 +348,18 @@ extension PrivateHeaderGeneration.GenerationExecutor {
         .appendingPathComponent("staging", isDirectory: true)
         .appendingPathComponent(runID.rawValue, isDirectory: true)
       try Self.ensureEmptyDirectory(runStagingDirectory)
-      let liveArtifactStore = PrivateHeaderGeneration.ArtifactStore(
-        artifactRoot: plan.artifactDirectory
+      let initialOpaquePaths = try publisher.opaquePathsForTargetValidation(
+        in: publication,
+        allowLegacyMigration: plan.options.resumeBehavior.isFresh,
+        claimedBy: publishedArtifactsByTarget.values.flatMap { $0 }
       )
       var generatedTargetIDs: [String] = []
       var ownedArtifactsByTarget = publishedArtifactsByTarget
       var liveArtifactsByTarget = currentLiveArtifactsByTarget
-      var liveOpaquePaths = publication.currentMarker?.opaquePaths ?? []
+      var unclaimedOpaquePaths = initialOpaquePaths
       var completedFilesByTarget: [String: [PrivateHeaderGeneration.ArtifactPath: URL]] = [:]
+      var completedArtifactDigestsByTarget:
+        [String: [PrivateHeaderGeneration.ArtifactPath: String]] = [:]
       var warnings: [PrivateHeaderGeneration.GenerationWarning] = []
       var wasCancelled = false
       var executedIndex = 0
@@ -382,21 +420,24 @@ extension PrivateHeaderGeneration.GenerationExecutor {
               "completed target \(targetID) has no staged artifact source"
             )
           }
-          try publisher.validateTargetReplacement(
+          let opaquePathsAfterReplacement = try publisher.validateTargetReplacement(
             targetID: targetID,
             artifacts: execution.result.artifacts,
             existingArtifactsByTarget: ownedArtifactsByTarget,
-            opaquePaths: liveOpaquePaths
+            opaquePaths: unclaimedOpaquePaths
           )
-          let commitPlan = try liveArtifactStore.prepareCommit(
-            stagingDirectory: targetStagingDirectory,
-            stagedSourceDirectory: stagedSourceDirectory,
-            artifactRoot: artifactRoot,
-            artifacts: execution.result.artifacts
-          )
-          let artifactsToRemove = PrivateHeaderGeneration.ArtifactStore.cleanupCandidates(
+          let removalCandidates = PrivateHeaderGeneration.ArtifactStore.cleanupCandidates(
             manifestArtifacts: ownedArtifactsByTarget[targetID] ?? [],
             attemptedArtifacts: previousAttemptedArtifactsByTarget[targetID] ?? []
+          )
+          let artifactsToRemove = try liveArtifactStore.artifactsExcludingEquivalentPaths(
+            removalCandidates,
+            retainedArtifacts:
+              ownedArtifactsByTarget
+              .filter { $0.key != targetID }
+              .values
+              .flatMap { $0 }
+              + opaquePathsAfterReplacement
           )
           let replacementDirectory = Self.replacementStagingDirectory(in: stateDirectory)
             .appendingPathComponent(runID.rawValue, isDirectory: true)
@@ -405,7 +446,10 @@ extension PrivateHeaderGeneration.GenerationExecutor {
               isDirectory: true
             )
           let replacement = try liveArtifactStore.prepareReplacement(
-            commitPlan,
+            stagingDirectory: targetStagingDirectory,
+            stagedSourceDirectory: stagedSourceDirectory,
+            artifactRoot: artifactRoot,
+            artifacts: execution.result.artifacts,
             removing: artifactsToRemove,
             runID: runID,
             targetID: targetID,
@@ -414,7 +458,11 @@ extension PrivateHeaderGeneration.GenerationExecutor {
           try await store.prepareTargetPublication(execution.result, in: runID)
           try liveArtifactStore.applyReplacement(replacement)
           do {
-            try await store.recordPublishedTargetAttempt(execution.result, in: runID)
+            try await store.recordPublishedTargetAttempt(
+              execution.result,
+              artifactDigests: replacement.artifactDigests,
+              in: runID
+            )
           } catch {
             let persistenceError = error
             do {
@@ -429,9 +477,9 @@ extension PrivateHeaderGeneration.GenerationExecutor {
           }
           ownedArtifactsByTarget[targetID] = execution.result.artifacts
           liveArtifactsByTarget[targetID] = execution.result.artifacts
-          let publishedArtifactSet = Set(execution.result.artifacts)
-          liveOpaquePaths.removeAll { publishedArtifactSet.contains($0) }
+          unclaimedOpaquePaths = opaquePathsAfterReplacement
           completedFilesByTarget[targetID] = execution.completedFiles
+          completedArtifactDigestsByTarget[targetID] = replacement.artifactDigests
           generatedTargetIDs.append(targetID)
           do {
             try liveArtifactStore.finalizeReplacement(replacement)
@@ -490,10 +538,44 @@ extension PrivateHeaderGeneration.GenerationExecutor {
         )
         wasCancelled = finalSnapshot.status == .interrupted
       } else {
-        var snapshotFilesByTarget = liveArtifactsByTarget.mapValues { artifacts in
-          Dictionary(
+        let generatedTargetSet = Set(generatedTargetIDs)
+        var snapshotFilesByTarget:
+          [String: [PrivateHeaderGeneration.ArtifactPath: URL]] = [:]
+        for (targetID, artifacts) in liveArtifactsByTarget
+        where !generatedTargetSet.contains(targetID) {
+          let sourceRoot: URL
+          switch publishedTargetSources[targetID] {
+          case .currentGeneration:
+            sourceRoot = publisher.stableURL
+          case .newerLiveOutput:
+            guard let publishedTarget = publishedTargetsByID[targetID] else {
+              throw PrivateHeaderGeneration.StateError.corruptPublication(
+                "published target source is missing target \(targetID)"
+              )
+            }
+            guard
+              try liveArtifactStore.artifactsMatchDigests(
+                artifacts,
+                digests: publishedTarget.artifactDigests
+              )
+            else {
+              throw PrivateHeaderGeneration.StateError.corruptPublication(
+                "published target contents changed during generation: \(targetID)"
+              )
+            }
+            sourceRoot = artifactDirectory
+          case .unavailable:
+            continue
+          case .unverifiedLiveOutput:
+            continue
+          case nil:
+            throw PrivateHeaderGeneration.StateError.corruptPublication(
+              "published target source is missing for \(targetID)"
+            )
+          }
+          snapshotFilesByTarget[targetID] = Dictionary(
             uniqueKeysWithValues: artifacts.map {
-              ($0, Self.artifactURL($0, under: plan.artifactDirectory))
+              ($0, Self.artifactURL($0, under: sourceRoot))
             }
           )
         }
@@ -506,13 +588,39 @@ extension PrivateHeaderGeneration.GenerationExecutor {
         )
         let draft = try publisher.replaceCompletedTargets(
           snapshotFilesByTarget,
+          retiringOpaquePaths: ownedArtifactsByTarget.values.flatMap { $0 },
           in: initialDraft
         )
-        let prepared = try publisher.prepareGeneration(draft, planFingerprint: fingerprint)
-        try Self.prepareLiveArtifactDirectory(
-          plan.artifactDirectory,
-          from: prepared.draftDirectory,
-          marker: prepared.marker
+        var expectedArtifactDigestsByTarget = completedArtifactDigestsByTarget
+        expectedArtifactDigestsByTarget.merge(
+          Dictionary(
+            uniqueKeysWithValues: snapshotFilesByTarget.keys.compactMap { targetID in
+              guard publishedTargetSources[targetID] == .newerLiveOutput,
+                !generatedTargetSet.contains(targetID),
+                let publishedTarget = publishedTargetsByID[targetID]
+              else {
+                return nil
+              }
+              return (targetID, publishedTarget.artifactDigests)
+            }
+          )
+        ) { _, publishedDigests in
+          publishedDigests
+        }
+        let prepared = try publisher.prepareGeneration(
+          draft,
+          planFingerprint: fingerprint,
+          expectedArtifactDigestsByTarget: expectedArtifactDigestsByTarget
+        )
+        let retirementCandidates = ownedArtifactsByTarget.compactMap { targetID, artifacts in
+          generatedTargetSet.contains(targetID)
+            || publishedTargetSources[targetID] != .unverifiedLiveOutput
+            ? artifacts
+            : nil
+        }.flatMap { $0 }
+        let retiringArtifacts = try liveArtifactStore.artifactsExcludingEquivalentPaths(
+          retirementCandidates,
+          retainedArtifacts: prepared.marker.artifactsByTarget.values.flatMap { $0 }
         )
         let previousGenerationID = publication.currentGenerationID
         _ = try await store.preparePublication(
@@ -535,6 +643,17 @@ extension PrivateHeaderGeneration.GenerationExecutor {
           wasCancelled,
           runID: runID,
           store: store
+        )
+        try Self.prepareLiveArtifactDirectory(
+          artifactDirectory,
+          from: prepared.finalDirectory,
+          marker: prepared.marker,
+          publishedArtifactsByTarget: prepared.marker.artifactsByTarget,
+          publishedTargetSources: prepared.marker.artifactsByTarget.mapValues {
+            _ in PublishedTargetSource.currentGeneration
+          },
+          stagingDirectory: Self.hydrationStagingDirectory(in: stateDirectory),
+          retiringArtifacts: retiringArtifacts
         )
         try publisher.switchCurrent(to: generationID)
         try injectPublicationFault(.afterCurrentPointerSwitch)
@@ -601,7 +720,7 @@ extension PrivateHeaderGeneration.GenerationExecutor {
         runID: runID,
         status: finalSnapshot.status,
         targetCounts: finalSnapshot.counts,
-        artifactDirectory: plan.artifactDirectory,
+        artifactDirectory: artifactDirectory,
         stateDatabaseURL: databaseURL,
         warnings: warnings,
         targetFailures: Self.targetFailures(finalSnapshot.targets)
@@ -624,7 +743,7 @@ extension PrivateHeaderGeneration.GenerationExecutor {
 
       return PrivateHeaderGeneration.Result(
         plan: plan,
-        artifactDirectory: plan.artifactDirectory,
+        artifactDirectory: artifactDirectory,
         generatedTargets: generatedTargetIDs.map(
           PrivateHeaderGeneration.Target.generated(identifier:)),
         runID: runID,
@@ -642,7 +761,7 @@ extension PrivateHeaderGeneration.GenerationExecutor {
         runID: runID,
         generationID: generationID,
         databaseURL: databaseURL,
-        artifactDirectory: plan.artifactDirectory,
+        artifactDirectory: artifactDirectory,
         stateDirectory: stateDirectory,
         store: store,
         publisher: publisher,
@@ -704,6 +823,7 @@ extension PrivateHeaderGeneration.GenerationExecutor {
     try await Self.recoverTargetReplacements(
       in: stateDirectory,
       artifactDirectory: artifactDirectory,
+      currentMarker: try publisher.inspect().currentMarker,
       store: store
     )
     do {
@@ -920,46 +1040,105 @@ extension PrivateHeaderGeneration.GenerationExecutor {
     )
   }
 
+  fileprivate static func reconcileLiveArtifactDirectory(
+    _ directory: URL,
+    publication: PrivateHeaderGeneration.PublicationSnapshot,
+    publishedDirectory: URL,
+    publishedArtifactsByTarget: [String: [PrivateHeaderGeneration.ArtifactPath]],
+    publishedTargetSources: [String: PublishedTargetSource],
+    stagingDirectory: URL,
+    store: GenerationStore
+  ) async throws {
+    let bootstrapReconciliation = try await store.pendingBootstrapReconciliation()
+    if let bootstrapReconciliation {
+      switch bootstrapReconciliation {
+      case .empty:
+        guard publication.currentGenerationID == nil else {
+          throw PrivateHeaderGeneration.StateError.corruptPublication(
+            "empty bootstrap reconciliation has a current generation"
+          )
+        }
+      case .generation(let generationID):
+        guard publication.currentGenerationID == generationID else {
+          throw PrivateHeaderGeneration.StateError.corruptPublication(
+            "bootstrap reconciliation generation \(generationID.rawValue) is not current"
+          )
+        }
+      }
+    }
+    try prepareLiveArtifactDirectory(
+      directory,
+      from: publication.currentMarker == nil ? nil : publishedDirectory,
+      marker: publication.currentMarker,
+      publishedArtifactsByTarget: publishedArtifactsByTarget,
+      publishedTargetSources: publishedTargetSources,
+      stagingDirectory: stagingDirectory,
+      validateUntrackedArtifacts: bootstrapReconciliation != nil
+    )
+    if let bootstrapReconciliation {
+      try await store.completeBootstrapReconciliation(bootstrapReconciliation)
+    }
+  }
+
   fileprivate static func prepareLiveArtifactDirectory(
     _ directory: URL,
     from publishedDirectory: URL?,
     marker: PrivateHeaderGeneration.GenerationMarkerSnapshot?,
     publishedArtifactsByTarget: [String: [PrivateHeaderGeneration.ArtifactPath]] = [:],
-    targetIDsCoveredByMarker: Set<String> = []
+    publishedTargetSources: [String: PublishedTargetSource] = [:],
+    stagingDirectory: URL,
+    validateUntrackedArtifacts: Bool = false,
+    retiringArtifacts: [PrivateHeaderGeneration.ArtifactPath] = []
   ) throws {
-    if let kind = try ManagedFileSystem.itemKind(at: directory) {
-      guard kind == .directory else {
-        throw ManagedFileSystem.Failure.unexpectedKind(
-          path: directory.path,
-          expected: "directory",
-          actual: kind
+    try ManagedFileSystem.ensureRealDirectory(directory)
+
+    let liveArtifactStore = PrivateHeaderGeneration.ArtifactStore(artifactRoot: directory)
+    if validateUntrackedArtifacts {
+      let retainedArtifacts = marker.map {
+        $0.artifactsByTarget.values.flatMap { $0 } + $0.opaquePaths
+      } ?? []
+      if let marker {
+        try liveArtifactStore.validateExistingArtifacts(
+          retainedArtifacts,
+          digests: marker.contentDigests
         )
       }
-    } else {
-      try ManagedFileSystem.ensureRealDirectory(directory)
+      let untrackedArtifacts = try liveArtifactStore.artifactsExcludingEquivalentPaths(
+        liveArtifactStore.inventoryRegularArtifacts(),
+        retainedArtifacts: retainedArtifacts
+      )
+      if let firstUntrackedArtifact = untrackedArtifacts.first {
+        throw PrivateHeaderGeneration.StateError.corruptPublication(
+          "live output contains unauthenticated artifact \(firstUntrackedArtifact.rawValue) after state loss"
+        )
+      }
     }
 
     guard let publishedDirectory, let marker else { return }
-    let publishedArtifactSet = Set(publishedArtifactsByTarget.values.flatMap { $0 })
-    let supersededTargetIDs = Set(publishedArtifactsByTarget.keys)
-      .subtracting(targetIDsCoveredByMarker)
-    for targetID in targetIDsCoveredByMarker {
-      guard let markerArtifacts = marker.artifactsByTarget[targetID],
-        let publishedArtifacts = publishedArtifactsByTarget[targetID]
-      else { continue }
-      guard Set(markerArtifacts) == Set(publishedArtifacts) else {
-        throw PrivateHeaderGeneration.StateError.corruptPublication(
-          "current generation artifacts disagree with published target \(targetID)"
-        )
+    let publishedOwnedArtifacts = publishedArtifactsByTarget.values.flatMap { $0 }
+    let publishedArtifactSet = Set(publishedOwnedArtifacts)
+    let supersededTargetIDs = Set(
+      publishedTargetSources.compactMap { targetID, source in
+        source == .currentGeneration ? nil : targetID
       }
-    }
-    let staleArtifacts = supersededTargetIDs.flatMap {
-      marker.artifactsByTarget[$0] ?? []
-    }.filter { !publishedArtifactSet.contains($0) }
-    if !staleArtifacts.isEmpty {
-      _ = try PrivateHeaderGeneration.ArtifactStore(
-        artifactRoot: directory
-      ).cleanupManagedArtifacts(staleArtifacts)
+    )
+    let authoritativeArtifacts = Set(
+      publishedTargetSources.compactMap { targetID, source in
+        source == .currentGeneration ? marker.artifactsByTarget[targetID] : nil
+      }.flatMap { $0 }
+    )
+    let staleArtifacts = try liveArtifactStore.artifactsExcludingEquivalentPaths(
+      supersededTargetIDs.flatMap { marker.artifactsByTarget[$0] ?? [] },
+      retainedArtifacts: publishedOwnedArtifacts
+    )
+    let unavailableArtifacts = publishedTargetSources.compactMap { targetID, source in
+      source == .unavailable ? publishedArtifactsByTarget[targetID] : nil
+    }.flatMap { $0 }
+    let artifactsToRetire = PrivateHeaderGeneration.ArtifactStore.cleanupCandidates(
+      manifestArtifacts: staleArtifacts + unavailableArtifacts + retiringArtifacts
+    )
+    if !artifactsToRetire.isEmpty {
+      _ = try liveArtifactStore.cleanupManagedArtifacts(artifactsToRetire)
     }
     let publishedArtifacts = Set(
       marker.artifactsByTarget
@@ -968,6 +1147,9 @@ extension PrivateHeaderGeneration.GenerationExecutor {
         .flatMap { $0 }
         + marker.opaquePaths.filter { !publishedArtifactSet.contains($0) }
     ).sorted { $0.rawValue < $1.rawValue }
+    let isRecoveringInterruptedHydration = try prepareHydrationStagingDirectory(
+      stagingDirectory
+    )
     for artifact in publishedArtifacts {
       let source = artifactURL(artifact, under: publishedDirectory)
       guard try ManagedFileSystem.itemKind(at: source) == .regular else {
@@ -976,10 +1158,21 @@ extension PrivateHeaderGeneration.GenerationExecutor {
       let destination = artifactURL(artifact, under: directory)
       switch try ManagedFileSystem.itemKind(at: destination) {
       case nil:
-        try ManagedFileSystem.ensureRealDirectory(destination.deletingLastPathComponent())
-        try FileManager.default.copyItem(at: source, to: destination)
+        try liveArtifactStore.restoreArtifact(
+          artifact,
+          from: source,
+          stagingDirectory: stagingDirectory,
+          synchronizeExistingArtifact: isRecoveringInterruptedHydration
+        )
       case .regular:
-        break
+        if authoritativeArtifacts.contains(artifact) {
+          try liveArtifactStore.restoreArtifact(
+            artifact,
+            from: source,
+            stagingDirectory: stagingDirectory,
+            synchronizeExistingArtifact: isRecoveringInterruptedHydration
+          )
+        }
       case .some(let kind):
         throw ManagedFileSystem.Failure.unexpectedKind(
           path: destination.path,
@@ -988,6 +1181,8 @@ extension PrivateHeaderGeneration.GenerationExecutor {
         )
       }
     }
+    try FileManager.default.removeItem(at: stagingDirectory)
+    try ManagedFileSystem.syncDirectory(stagingDirectory.deletingLastPathComponent())
   }
 
   fileprivate static func artifactURL(
@@ -1007,12 +1202,50 @@ extension PrivateHeaderGeneration.GenerationExecutor {
     return try await store.targetIDsCoveredByGeneration(generationID)
   }
 
+  fileprivate static func publishedTargetSources(
+    marker: PrivateHeaderGeneration.GenerationMarkerSnapshot?,
+    publishedTargetsByID: [String: PrivateHeaderGeneration.TargetSnapshot],
+    targetIDsCoveredByMarker: Set<String>,
+    liveArtifactStore: PrivateHeaderGeneration.ArtifactStore
+  ) throws -> [String: PublishedTargetSource] {
+    try Dictionary(
+      uniqueKeysWithValues: publishedTargetsByID.map { targetID, publishedTarget in
+        guard targetIDsCoveredByMarker.contains(targetID) else {
+          guard !publishedTarget.artifactDigests.isEmpty else {
+            return (targetID, .unverifiedLiveOutput)
+          }
+          let matches = try liveArtifactStore.artifactsMatchDigests(
+            publishedTarget.artifacts,
+            digests: publishedTarget.artifactDigests
+          )
+          return (targetID, matches ? .newerLiveOutput : .unavailable)
+        }
+        guard let markerArtifacts = marker?.artifactsByTarget[targetID] else {
+          return (targetID, .unavailable)
+        }
+        guard Set(markerArtifacts) == Set(publishedTarget.artifacts) else {
+          throw PrivateHeaderGeneration.StateError.corruptPublication(
+            "current generation artifacts disagree with published target \(targetID)"
+          )
+        }
+        return (targetID, .currentGeneration)
+      }
+    )
+  }
+
   fileprivate static func availableLiveArtifactsByTarget(
     _ artifactsByTarget: [String: [PrivateHeaderGeneration.ArtifactPath]],
+    publishedTargetSources: [String: PublishedTargetSource],
     under root: URL
   ) throws -> [String: [PrivateHeaderGeneration.ArtifactPath]] {
     var available: [String: [PrivateHeaderGeneration.ArtifactPath]] = [:]
     for targetID in artifactsByTarget.keys.sorted() {
+      guard let source = publishedTargetSources[targetID] else {
+        throw PrivateHeaderGeneration.StateError.corruptPublication(
+          "published target \(targetID) has no artifact source"
+        )
+      }
+      guard source == .currentGeneration || source == .newerLiveOutput else { continue }
       let artifacts = artifactsByTarget[targetID] ?? []
       var allArtifactsExist = true
       for artifact in artifacts {
@@ -1179,12 +1412,17 @@ extension PrivateHeaderGeneration.GenerationExecutor {
     guard let executionMode = plan.options.executionMode else {
       throw PrivateHeaderGeneration.GenerationError.missingExecutionConfiguration("executionMode")
     }
+    guard !plan.options.resumeBehavior.isFresh else { return nil }
     let publisher = try ArtifactPublisher(
       artifactBaseDirectory: plan.output.baseDirectory,
       sourceLabel: plan.source.storageIdentifier
     )
     try publisher.prepareForLease()
     return try await GenerationLease.withExclusiveLease(at: publisher.lockURL) {
+      let artifactDirectory = canonicalArtifactDirectory(
+        outputBase: publisher.artifactBaseDirectory,
+        sourceLabel: plan.source.storageIdentifier
+      )
       let stateDirectory = canonicalStateDirectory(
         outputBase: publisher.artifactBaseDirectory,
         sourceLabel: plan.source.storageIdentifier
@@ -1210,7 +1448,8 @@ extension PrivateHeaderGeneration.GenerationExecutor {
       try await recover(store: store, publisher: publisher, at: Date())
       try await recoverTargetReplacements(
         in: stateDirectory,
-        artifactDirectory: plan.artifactDirectory,
+        artifactDirectory: artifactDirectory,
+        currentMarker: try publisher.inspect().currentMarker,
         store: store
       )
       try publisher.cleanupStaging()
@@ -1223,23 +1462,35 @@ extension PrivateHeaderGeneration.GenerationExecutor {
           .artifacts(path: publisher.stableURL.path)
         )
       }
-      let publishedArtifactsByTarget = try await store.publishedArtifactsByTarget()
+      let publishedTargetsByID = try await store.publishedTargetsByID()
+      let publishedArtifactsByTarget = publishedTargetsByID.mapValues(\.artifacts)
+      let liveArtifactStore = PrivateHeaderGeneration.ArtifactStore(
+        artifactRoot: artifactDirectory
+      )
       let coveredTargetIDs = try await targetIDsCoveredByCurrentGeneration(
         publication,
         store: store
       )
-      try prepareLiveArtifactDirectory(
-        plan.artifactDirectory,
-        from: publication.currentMarker == nil ? nil : publisher.stableURL,
+      let publishedTargetSources = try Self.publishedTargetSources(
         marker: publication.currentMarker,
+        publishedTargetsByID: publishedTargetsByID,
+        targetIDsCoveredByMarker: coveredTargetIDs,
+        liveArtifactStore: liveArtifactStore
+      )
+      try await reconcileLiveArtifactDirectory(
+        artifactDirectory,
+        publication: publication,
+        publishedDirectory: publisher.stableURL,
         publishedArtifactsByTarget: publishedArtifactsByTarget,
-        targetIDsCoveredByMarker: coveredTargetIDs
+        publishedTargetSources: publishedTargetSources,
+        stagingDirectory: hydrationStagingDirectory(in: stateDirectory),
+        store: store
       )
       let currentLiveArtifactsByTarget = try availableLiveArtifactsByTarget(
         publishedArtifactsByTarget,
-        under: plan.artifactDirectory
+        publishedTargetSources: publishedTargetSources,
+        under: artifactDirectory
       )
-      guard !plan.options.resumeBehavior.isFresh else { return nil }
       let summary = try await store.resumeSummary(
         planFingerprint: planFingerprint(
           plan,
@@ -1621,6 +1872,34 @@ extension PrivateHeaderGeneration.GenerationExecutor {
     }
   }
 
+  fileprivate static func prepareHydrationStagingDirectory(_ url: URL) throws -> Bool {
+    do {
+      try ManagedFileSystem.ensureRealDirectory(url.deletingLastPathComponent())
+      guard let kind = try ManagedFileSystem.itemKind(at: url) else {
+        try ManagedFileSystem.ensureRealDirectory(url)
+        return false
+      }
+      guard kind == .directory else {
+        throw ManagedFileSystem.Failure.unexpectedKind(
+          path: url.path,
+          expected: "directory or missing",
+          actual: kind
+        )
+      }
+      for child in try FileManager.default.contentsOfDirectory(
+        at: url,
+        includingPropertiesForKeys: nil,
+        options: []
+      ) {
+        try FileManager.default.removeItem(at: child)
+      }
+      try ManagedFileSystem.syncDirectory(url)
+      return true
+    } catch let error as ManagedFileSystem.Failure {
+      throw stateFileSystemError(error)
+    }
+  }
+
   fileprivate static func cleanupStateStaging(in stateDirectory: URL) throws {
     let stagingDirectory = stateDirectory.appendingPathComponent("staging", isDirectory: true)
     do {
@@ -1654,9 +1933,14 @@ extension PrivateHeaderGeneration.GenerationExecutor {
     stateDirectory.appendingPathComponent("replacements", isDirectory: true)
   }
 
+  fileprivate static func hydrationStagingDirectory(in stateDirectory: URL) -> URL {
+    stateDirectory.appendingPathComponent("hydration", isDirectory: true)
+  }
+
   fileprivate static func recoverTargetReplacements(
     in stateDirectory: URL,
     artifactDirectory: URL,
+    currentMarker: PrivateHeaderGeneration.GenerationMarkerSnapshot?,
     store: GenerationStore
   ) async throws {
     let replacementsRoot = replacementStagingDirectory(in: stateDirectory)
@@ -1673,10 +1957,23 @@ extension PrivateHeaderGeneration.GenerationExecutor {
         publishedTarget?.status == .completed
         && publishedTarget?.lastSuccessfulRunID == replacement.runID
         && Set(publishedTarget?.artifacts ?? []) == Set(replacement.incomingArtifacts)
-      if !wasCommitted {
+        && publishedTarget?.artifactDigests == replacement.artifactDigests
+      let isPublishedByCurrentGeneration = currentMarker.map { marker in
+        guard Set(marker.artifactsByTarget[replacement.targetID] ?? [])
+          == Set(replacement.incomingArtifacts)
+        else {
+          return false
+        }
+        return replacement.artifactDigests.allSatisfy { artifact, digest in
+          marker.contentDigests[artifact] == digest
+        }
+      } ?? false
+      if wasCommitted || isPublishedByCurrentGeneration {
+        try artifactStore.finalizeReplacement(replacement)
+      } else {
         try artifactStore.rollbackReplacement(replacement)
+        try artifactStore.finalizeReplacement(replacement)
       }
-      try artifactStore.finalizeReplacement(replacement)
     }
     try PrivateHeaderGeneration.ArtifactStore.cleanupReplacementStaging(replacementsRoot)
   }
@@ -1699,6 +1996,12 @@ extension PrivateHeaderGeneration.GenerationExecutor {
     } catch let error as ManagedFileSystem.Failure {
       throw stateFileSystemError(error)
     }
+  }
+
+  fileprivate static func canonicalArtifactDirectory(outputBase: URL, sourceLabel: String) -> URL {
+    outputBase
+      .appendingPathComponent("generated-headers", isDirectory: true)
+      .appendingPathComponent(sourceLabel, isDirectory: true)
   }
 
   fileprivate static func canonicalStateDirectory(outputBase: URL, sourceLabel: String) -> URL {

--- a/Sources/PrivateHeaderKitCore/PrivateHeaderGenerationExecutor.swift
+++ b/Sources/PrivateHeaderKitCore/PrivateHeaderGenerationExecutor.swift
@@ -230,14 +230,12 @@ extension PrivateHeaderGeneration.GenerationExecutor {
     executionMode: PrivateHeaderGeneration.RawDumping.ExecutionMode,
     progressReporter: ProgressReporter?
   ) async throws -> PrivateHeaderGeneration.Result {
-    if plan.options.resumeBehavior.isFresh {
-      _ = try await store.bootstrapPublishedGenerationIfEmpty(
-        sourceIdentity: plan.source.storageIdentifier,
-        publication: publisher.inspect(),
-        at: dateProvider()
-      )
-    }
-    try await Self.recover(store: store, publisher: publisher, at: dateProvider())
+    try await Self.bootstrapAndRecover(
+      sourceIdentity: plan.source.storageIdentifier,
+      store: store,
+      publisher: publisher,
+      at: dateProvider()
+    )
     try await Self.recoverTargetReplacements(
       in: stateDirectory,
       artifactDirectory: artifactDirectory,
@@ -1305,6 +1303,20 @@ extension PrivateHeaderGeneration.GenerationExecutor {
     }
   }
 
+  fileprivate static func bootstrapAndRecover(
+    sourceIdentity: String,
+    store: GenerationStore,
+    publisher: ArtifactPublisher,
+    at date: Date
+  ) async throws {
+    _ = try await store.bootstrapPublishedGenerationIfEmpty(
+      sourceIdentity: sourceIdentity,
+      publication: publisher.inspect(),
+      at: date
+    )
+    try await recover(store: store, publisher: publisher, at: date)
+  }
+
   fileprivate static func recover(
     store: GenerationStore,
     publisher: ArtifactPublisher,
@@ -1445,7 +1457,12 @@ extension PrivateHeaderGeneration.GenerationExecutor {
         databaseURL: databaseURL,
         toolCompatibilityIdentity: plan.options.toolCompatibilityIdentity
       )
-      try await recover(store: store, publisher: publisher, at: Date())
+      try await bootstrapAndRecover(
+        sourceIdentity: plan.source.storageIdentifier,
+        store: store,
+        publisher: publisher,
+        at: Date()
+      )
       try await recoverTargetReplacements(
         in: stateDirectory,
         artifactDirectory: artifactDirectory,

--- a/Sources/PrivateHeaderKitCore/PrivateHeaderGenerationExecutor.swift
+++ b/Sources/PrivateHeaderKitCore/PrivateHeaderGenerationExecutor.swift
@@ -182,10 +182,13 @@ extension PrivateHeaderGeneration.GenerationExecutor {
   fileprivate struct TargetExecution {
     let result: PrivateHeaderGeneration.TargetAttemptResult
     let completedFiles: [PrivateHeaderGeneration.ArtifactPath: URL]
+    let stagedSourceDirectory: URL?
+    let artifactRoot: PrivateHeaderGeneration.ArtifactPath?
   }
 
   fileprivate struct StagedArtifacts {
     let files: [PrivateHeaderGeneration.ArtifactPath: URL]
+    let sourceDirectory: URL?
   }
 
   fileprivate func cancellationRequested() -> Bool {
@@ -218,6 +221,22 @@ extension PrivateHeaderGeneration.GenerationExecutor {
     try publisher.cleanupStaging()
     try Self.cleanupStateStaging(in: stateDirectory)
     let publication = try publisher.inspect()
+    let previousRunSnapshot = try await store.latestRunSnapshot()
+    let previousAttemptedArtifactsByTarget = Dictionary(
+      uniqueKeysWithValues: (previousRunSnapshot?.targets ?? []).map {
+        ($0.targetID, $0.artifacts)
+      }
+    )
+    try Self.prepareLiveArtifactDirectory(
+      plan.artifactDirectory,
+      from: publication.currentMarker == nil ? nil : publisher.stableURL,
+      marker: publication.currentMarker
+    )
+    let publishedArtifactsByTarget = try await store.publishedArtifactsByTarget()
+    let currentLiveArtifactsByTarget = try Self.availableLiveArtifactsByTarget(
+      publishedArtifactsByTarget,
+      under: plan.artifactDirectory
+    )
 
     if publication.stablePathState == .legacyDirectory,
       !plan.options.resumeBehavior.isFresh
@@ -241,7 +260,7 @@ extension PrivateHeaderGeneration.GenerationExecutor {
       resumeSummary = try await store.resumeSummary(
         planFingerprint: fingerprint,
         selectedTargetIDs: targetIDs,
-        currentArtifactsByTarget: publication.currentMarker?.artifactsByTarget ?? [:],
+        currentArtifactsByTarget: currentLiveArtifactsByTarget,
         at: dateProvider()
       )
       if let resumeSummary,
@@ -279,50 +298,19 @@ extension PrivateHeaderGeneration.GenerationExecutor {
         )
       }
 
-      if targetIDsToRun.isEmpty {
-        let wasCancelled = cancellationRequested()
-        if wasCancelled {
-          try await store.requestInterruption(runID, at: dateProvider())
-        }
-        let snapshot = try await store.finishRunWithoutPublication(
-          runID,
-          at: dateProvider(),
-          shouldInterrupt: { cancellationRequested() }
-        )
-        let summary = PrivateHeaderGeneration.RunSummary(
-          runID: runID,
-          status: snapshot.status,
-          targetCounts: snapshot.counts,
-          artifactDirectory: publisher.stableURL,
-          stateDatabaseURL: databaseURL
-        )
-        progressReporter?(.runFinished(summary))
-        if snapshot.status == .interrupted {
-          throw PrivateHeaderGeneration.GenerationError.runInterrupted(
-            .init(summary: summary)
-          )
-        }
-        return PrivateHeaderGeneration.Result(
-          plan: plan,
-          artifactDirectory: publisher.stableURL,
-          generatedTargets: [],
-          runID: runID,
-          stateDatabaseURL: databaseURL,
-          targetCounts: snapshot.counts
-        )
-      }
-
-      var draft = try publisher.beginDraft(
-        generationID: generationID,
-        allowLegacyMigration: plan.options.resumeBehavior.isFresh
-      )
       let runStagingDirectory =
         stateDirectory
         .appendingPathComponent("staging", isDirectory: true)
         .appendingPathComponent(runID.rawValue, isDirectory: true)
       try Self.ensureEmptyDirectory(runStagingDirectory)
-
+      let liveArtifactStore = PrivateHeaderGeneration.ArtifactStore(
+        artifactRoot: plan.artifactDirectory
+      )
       var generatedTargetIDs: [String] = []
+      var ownedArtifactsByTarget = publishedArtifactsByTarget
+      var liveArtifactsByTarget = currentLiveArtifactsByTarget
+      var liveOpaquePaths = publication.currentMarker?.opaquePaths ?? []
+      var completedFilesByTarget: [String: [PrivateHeaderGeneration.ArtifactPath: URL]] = [:]
       var warnings: [PrivateHeaderGeneration.GenerationWarning] = []
       var wasCancelled = false
       var executedIndex = 0
@@ -353,7 +341,8 @@ extension PrivateHeaderGeneration.GenerationExecutor {
               index: executedIndex,
               total: targetIDsToRun.count,
               displayName: target.candidate.displayName,
-              status: .interrupted
+              status: .interrupted,
+              failureSummary: nil
             ))
           wasCancelled = true
           break
@@ -375,21 +364,50 @@ extension PrivateHeaderGeneration.GenerationExecutor {
         )
 
         if execution.result.status == .completed {
-          draft = try publisher.applyCompletedTarget(
+          guard let stagedSourceDirectory = execution.stagedSourceDirectory,
+            let artifactRoot = execution.artifactRoot
+          else {
+            throw PrivateHeaderGeneration.StateError.corruptPublication(
+              "completed target \(targetID) has no staged artifact source"
+            )
+          }
+          try publisher.validateTargetReplacement(
             targetID: targetID,
-            files: execution.completedFiles,
-            to: draft
+            artifacts: execution.result.artifacts,
+            existingArtifactsByTarget: ownedArtifactsByTarget,
+            opaquePaths: liveOpaquePaths
           )
+          let commitPlan = try liveArtifactStore.prepareCommit(
+            stagingDirectory: targetStagingDirectory,
+            stagedSourceDirectory: stagedSourceDirectory,
+            artifactRoot: artifactRoot,
+            artifacts: execution.result.artifacts
+          )
+          try await store.prepareTargetPublication(execution.result, in: runID)
+          _ = try liveArtifactStore.cleanupManagedArtifacts(
+            PrivateHeaderGeneration.ArtifactStore.cleanupCandidates(
+              manifestArtifacts: ownedArtifactsByTarget[targetID] ?? [],
+              attemptedArtifacts: previousAttemptedArtifactsByTarget[targetID] ?? []
+            )
+          )
+          try liveArtifactStore.copy(commitPlan)
+          ownedArtifactsByTarget[targetID] = execution.result.artifacts
+          liveArtifactsByTarget[targetID] = execution.result.artifacts
+          let publishedArtifactSet = Set(execution.result.artifacts)
+          liveOpaquePaths.removeAll { publishedArtifactSet.contains($0) }
+          completedFilesByTarget[targetID] = execution.completedFiles
+          try await store.recordPublishedTargetAttempt(execution.result, in: runID)
           generatedTargetIDs.append(targetID)
+        } else {
+          try await store.recordTargetAttempt(execution.result, in: runID)
         }
-
-        try await store.recordTargetAttempt(execution.result, in: runID)
         progressReporter?(
           .targetFinished(
             index: executedIndex,
             total: targetIDsToRun.count,
             displayName: target.candidate.displayName,
-            status: execution.result.status
+            status: execution.result.status,
+            failureSummary: execution.result.failureSummary
           ))
         if cancellationRequested(), execution.result.status != .interrupted {
           try await store.requestInterruption(runID, at: dateProvider())
@@ -410,28 +428,36 @@ extension PrivateHeaderGeneration.GenerationExecutor {
       }
 
       let finalSnapshot: PrivateHeaderGeneration.RunSnapshot
-      if generatedTargetIDs.isEmpty {
+      let shouldReconcileInterruptedPublication =
+        targetIDsToRun.isEmpty
+        && previousRunSnapshot?.status != .completed
+        && !liveArtifactsByTarget.isEmpty
+      if generatedTargetIDs.isEmpty && !shouldReconcileInterruptedPublication {
         finalSnapshot = try await store.finishRunWithoutPublication(
           runID,
           at: dateProvider(),
           shouldInterrupt: { cancellationRequested() }
         )
         wasCancelled = finalSnapshot.status == .interrupted
-        do {
-          try publisher.discardDraft(draft)
-        } catch {
-          warnings.append(
-            await surfacePostCommitWarning(
-              runID: runID,
-              kind: "cleanup-warning",
-              relativePath:
-                ".privateheaderkit/\(plan.source.storageIdentifier)/staging/\(generationID.rawValue).draft",
-              error: error,
-              store: store,
-              progressReporter: progressReporter
-            ))
-        }
       } else {
+        var snapshotFilesByTarget = liveArtifactsByTarget.mapValues { artifacts in
+          Dictionary(
+            uniqueKeysWithValues: artifacts.map {
+              ($0, Self.artifactURL($0, under: plan.artifactDirectory))
+            }
+          )
+        }
+        snapshotFilesByTarget.merge(completedFilesByTarget) { _, stagedFiles in
+          stagedFiles
+        }
+        let initialDraft = try publisher.beginDraft(
+          generationID: generationID,
+          allowLegacyMigration: plan.options.resumeBehavior.isFresh
+        )
+        let draft = try publisher.applyCompletedTargets(
+          snapshotFilesByTarget,
+          to: initialDraft
+        )
         let prepared = try publisher.prepareGeneration(draft, planFingerprint: fingerprint)
         let previousGenerationID = publication.currentGenerationID
         _ = try await store.preparePublication(
@@ -520,9 +546,10 @@ extension PrivateHeaderGeneration.GenerationExecutor {
         runID: runID,
         status: finalSnapshot.status,
         targetCounts: finalSnapshot.counts,
-        artifactDirectory: publisher.stableURL,
+        artifactDirectory: plan.artifactDirectory,
         stateDatabaseURL: databaseURL,
-        warnings: warnings
+        warnings: warnings,
+        targetFailures: Self.targetFailures(finalSnapshot.targets)
       )
       progressReporter?(.runFinished(summary))
       if wasCancelled {
@@ -542,7 +569,7 @@ extension PrivateHeaderGeneration.GenerationExecutor {
 
       return PrivateHeaderGeneration.Result(
         plan: plan,
-        artifactDirectory: publisher.stableURL,
+        artifactDirectory: plan.artifactDirectory,
         generatedTargets: generatedTargetIDs.map(
           PrivateHeaderGeneration.Target.generated(identifier:)),
         runID: runID,
@@ -560,6 +587,7 @@ extension PrivateHeaderGeneration.GenerationExecutor {
         runID: runID,
         generationID: generationID,
         databaseURL: databaseURL,
+        artifactDirectory: plan.artifactDirectory,
         stateDirectory: stateDirectory,
         store: store,
         publisher: publisher,
@@ -583,6 +611,7 @@ extension PrivateHeaderGeneration.GenerationExecutor {
     runID: PrivateHeaderGeneration.RunID,
     generationID: PrivateHeaderGeneration.GenerationID,
     databaseURL: URL,
+    artifactDirectory: URL,
     stateDirectory: URL,
     store: GenerationStore,
     publisher: ArtifactPublisher,
@@ -653,9 +682,10 @@ extension PrivateHeaderGeneration.GenerationExecutor {
       runID: runID,
       status: snapshot.status,
       targetCounts: snapshot.counts,
-      artifactDirectory: publisher.stableURL,
+      artifactDirectory: artifactDirectory,
       stateDatabaseURL: databaseURL,
-      warnings: warnings
+      warnings: warnings,
+      targetFailures: Self.targetFailures(snapshot.targets)
     )
     progressReporter?(.runFinished(summary))
     if interruptionRequested {
@@ -725,7 +755,9 @@ extension PrivateHeaderGeneration.GenerationExecutor {
     } catch is CancellationError {
       return TargetExecution(
         result: Self.interruptedResult(target: target, at: dateProvider()),
-        completedFiles: [:]
+        completedFiles: [:],
+        stagedSourceDirectory: nil,
+        artifactRoot: nil
       )
     } catch {
       return Self.failedExecution(
@@ -739,7 +771,9 @@ extension PrivateHeaderGeneration.GenerationExecutor {
     if cancellationRequested() {
       return TargetExecution(
         result: Self.interruptedResult(target: target, at: dateProvider()),
-        completedFiles: [:]
+        completedFiles: [:],
+        stagedSourceDirectory: nil,
+        artifactRoot: nil
       )
     }
     let artifactRoot = try Self.artifactRoot(for: target, layout: plan.options.layout)
@@ -774,7 +808,9 @@ extension PrivateHeaderGeneration.GenerationExecutor {
           artifacts: staged.files.keys.sorted { $0.rawValue < $1.rawValue },
           completedAt: dateProvider()
         ),
-        completedFiles: staged.files
+        completedFiles: staged.files,
+        stagedSourceDirectory: staged.sourceDirectory,
+        artifactRoot: artifactRoot
       )
     }
     return Self.failedExecution(
@@ -804,7 +840,9 @@ extension PrivateHeaderGeneration.GenerationExecutor {
         failureSummary: summary,
         completedAt: date
       ),
-      completedFiles: [:]
+      completedFiles: [:],
+      stagedSourceDirectory: nil,
+      artifactRoot: nil
     )
   }
 
@@ -820,6 +858,94 @@ extension PrivateHeaderGeneration.GenerationExecutor {
       failureSummary: "cancelled",
       completedAt: date
     )
+  }
+
+  fileprivate static func prepareLiveArtifactDirectory(
+    _ directory: URL,
+    from publishedDirectory: URL?,
+    marker: PrivateHeaderGeneration.GenerationMarkerSnapshot?
+  ) throws {
+    if let kind = try ManagedFileSystem.itemKind(at: directory) {
+      guard kind == .directory else {
+        throw ManagedFileSystem.Failure.unexpectedKind(
+          path: directory.path,
+          expected: "directory",
+          actual: kind
+        )
+      }
+    } else {
+      try ManagedFileSystem.ensureRealDirectory(directory)
+    }
+
+    guard let publishedDirectory, let marker else { return }
+    let publishedArtifacts = Set(
+      marker.artifactsByTarget.values.flatMap { $0 } + marker.opaquePaths
+    ).sorted { $0.rawValue < $1.rawValue }
+    for artifact in publishedArtifacts {
+      let source = artifactURL(artifact, under: publishedDirectory)
+      guard try ManagedFileSystem.itemKind(at: source) == .regular else {
+        throw ArtifactPublisher.PublisherError.missingArtifact(source.path)
+      }
+      let destination = artifactURL(artifact, under: directory)
+      switch try ManagedFileSystem.itemKind(at: destination) {
+      case nil:
+        try ManagedFileSystem.ensureRealDirectory(destination.deletingLastPathComponent())
+        try FileManager.default.copyItem(at: source, to: destination)
+      case .regular:
+        break
+      case .some(let kind):
+        throw ManagedFileSystem.Failure.unexpectedKind(
+          path: destination.path,
+          expected: "regular file or missing",
+          actual: kind
+        )
+      }
+    }
+  }
+
+  fileprivate static func artifactURL(
+    _ artifact: PrivateHeaderGeneration.ArtifactPath,
+    under root: URL
+  ) -> URL {
+    artifact.rawValue.split(separator: "/").reduce(into: root) { url, component in
+      url.appendPathComponent(String(component), isDirectory: false)
+    }
+  }
+
+  fileprivate static func availableLiveArtifactsByTarget(
+    _ artifactsByTarget: [String: [PrivateHeaderGeneration.ArtifactPath]],
+    under root: URL
+  ) throws -> [String: [PrivateHeaderGeneration.ArtifactPath]] {
+    var available: [String: [PrivateHeaderGeneration.ArtifactPath]] = [:]
+    for targetID in artifactsByTarget.keys.sorted() {
+      let artifacts = artifactsByTarget[targetID] ?? []
+      var allArtifactsExist = true
+      for artifact in artifacts {
+        guard try ManagedFileSystem.itemKind(at: artifactURL(artifact, under: root)) == .regular
+        else {
+          allArtifactsExist = false
+          break
+        }
+      }
+      if allArtifactsExist {
+        available[targetID] = artifacts
+      }
+    }
+    return available
+  }
+
+  fileprivate static func targetFailures(
+    _ targets: [PrivateHeaderGeneration.TargetAttemptSnapshot]
+  ) -> [PrivateHeaderGeneration.TargetFailure] {
+    targets.compactMap { target in
+      guard target.status == .partial || target.status == .failed else { return nil }
+      return PrivateHeaderGeneration.TargetFailure(
+        targetID: target.targetID,
+        displayName: target.displayName,
+        status: target.status,
+        message: target.failureSummary
+      )
+    }
   }
 }
 
@@ -997,6 +1123,16 @@ extension PrivateHeaderGeneration.GenerationExecutor {
           .artifacts(path: publisher.stableURL.path)
         )
       }
+      try prepareLiveArtifactDirectory(
+        plan.artifactDirectory,
+        from: publication.currentMarker == nil ? nil : publisher.stableURL,
+        marker: publication.currentMarker
+      )
+      let publishedArtifactsByTarget = try await store.publishedArtifactsByTarget()
+      let currentLiveArtifactsByTarget = try availableLiveArtifactsByTarget(
+        publishedArtifactsByTarget,
+        under: plan.artifactDirectory
+      )
       guard !plan.options.resumeBehavior.isFresh else { return nil }
       let summary = try await store.resumeSummary(
         planFingerprint: planFingerprint(
@@ -1006,7 +1142,7 @@ extension PrivateHeaderGeneration.GenerationExecutor {
           sharedCacheCohort: preparedPlan.sharedCacheCohort
         ),
         selectedTargetIDs: preparedPlan.selectedTargetIDs,
-        currentArtifactsByTarget: publication.currentMarker?.artifactsByTarget ?? [:],
+        currentArtifactsByTarget: currentLiveArtifactsByTarget,
         at: Date()
       )
       return summary?.isUnfinished == true ? summary : nil
@@ -1107,9 +1243,11 @@ extension PrivateHeaderGeneration.GenerationExecutor {
     )
     for candidate in candidates where try directoryExists(candidate) {
       let files = try artifactFiles(under: candidate, artifactRoot: artifactRoot)
-      if !files.isEmpty { return StagedArtifacts(files: files) }
+      if !files.isEmpty {
+        return StagedArtifacts(files: files, sourceDirectory: candidate)
+      }
     }
-    return StagedArtifacts(files: [:])
+    return StagedArtifacts(files: [:], sourceDirectory: nil)
   }
 
   fileprivate static func artifactFiles(

--- a/Sources/PrivateHeaderKitCore/PrivateHeaderGenerationState.swift
+++ b/Sources/PrivateHeaderKitCore/PrivateHeaderGenerationState.swift
@@ -188,6 +188,7 @@ extension PrivateHeaderGeneration {
     package let lastSuccessfulRunID: RunID
     package let status: RunTargetStatus
     package let artifacts: [ArtifactPath]
+    package let artifactDigests: [ArtifactPath: String]
     package let updatedAt: Date
   }
 
@@ -312,6 +313,23 @@ extension PrivateHeaderGeneration {
     package let artifactChecksum: String
     package let artifactsByTarget: [String: [ArtifactPath]]
     package let opaquePaths: [ArtifactPath]
+    package let contentDigests: [ArtifactPath: String]
+
+    package init(
+      generationID: GenerationID,
+      planFingerprint: String,
+      artifactChecksum: String,
+      artifactsByTarget: [String: [ArtifactPath]],
+      opaquePaths: [ArtifactPath],
+      contentDigests: [ArtifactPath: String] = [:]
+    ) {
+      self.generationID = generationID
+      self.planFingerprint = planFingerprint
+      self.artifactChecksum = artifactChecksum
+      self.artifactsByTarget = artifactsByTarget
+      self.opaquePaths = opaquePaths
+      self.contentDigests = contentDigests
+    }
   }
 
   package struct PublicationSnapshot: Equatable, Sendable {

--- a/Sources/PrivateHeaderKitCore/PrivateHeaderGenerationStore.swift
+++ b/Sources/PrivateHeaderKitCore/PrivateHeaderGenerationStore.swift
@@ -5,6 +5,38 @@ package actor GenerationStore {
   package typealias FaultInjector =
     @Sendable (PrivateHeaderGeneration.StoreFaultPoint) throws -> Void
 
+  package enum BootstrapReconciliation: Equatable, Sendable {
+    case empty
+    case generation(PrivateHeaderGeneration.GenerationID)
+
+    fileprivate var storedValue: String {
+      switch self {
+      case .empty:
+        "empty"
+      case .generation(let generationID):
+        "generation:\(generationID.rawValue)"
+      }
+    }
+
+    fileprivate init(storedValue: String) throws {
+      if storedValue == "empty" {
+        self = .empty
+      } else if storedValue.hasPrefix("generation:") {
+        self = .generation(
+          try PrivateHeaderGeneration.GenerationID(
+            String(storedValue.dropFirst("generation:".count))
+          )
+        )
+      } else {
+        throw PrivateHeaderGeneration.StateError.corruptPublication(
+          "invalid bootstrap reconciliation state \(storedValue)"
+        )
+      }
+    }
+  }
+
+  private static let bootstrapReconciliationKey = "bootstrapReconciliationGenerationID"
+
   private let databaseQueue: DatabaseQueue
   private let faultInjector: FaultInjector
 
@@ -48,6 +80,151 @@ package actor GenerationStore {
   package func appliedMigrationIdentifiers() throws -> [String] {
     try databaseQueue.read { db in
       try Self.migrator.completedMigrations(db)
+    }
+  }
+
+  @discardableResult
+  package func bootstrapPublishedGenerationIfEmpty(
+    sourceIdentity: String,
+    publication: PrivateHeaderGeneration.PublicationSnapshot,
+    at date: Date
+  ) throws -> Bool {
+    let reconciliation = publication.currentMarker.map {
+      BootstrapReconciliation.generation($0.generationID)
+    } ?? .empty
+    return try databaseQueue.write { db in
+      let stateRowCount =
+        (try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM runs") ?? 0)
+        + (try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM targets") ?? 0)
+        + (try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM publicationIntents") ?? 0)
+        + (try Int.fetchOne(
+          db,
+          sql: "SELECT COUNT(*) FROM metadata WHERE key = ?",
+          arguments: [Self.bootstrapReconciliationKey]
+        ) ?? 0)
+      guard stateRowCount == 0 else { return false }
+
+      guard let marker = publication.currentMarker else {
+        try db.execute(
+          sql: "INSERT INTO metadata(key, value) VALUES (?, ?)",
+          arguments: [Self.bootstrapReconciliationKey, reconciliation.storedValue]
+        )
+        return true
+      }
+
+      let runID = PrivateHeaderGeneration.RunID(
+        rawValue: "baseline-\(marker.generationID.rawValue)"
+      )
+      let targetIDs = marker.artifactsByTarget.keys.sorted()
+      let timestamp = date.timeIntervalSinceReferenceDate
+      try db.execute(
+        sql: """
+          INSERT INTO runs(
+              id, sourceIdentity, planFingerprint, targetIDs,
+              startedAt, endedAt, status
+          ) VALUES (?, ?, ?, ?, ?, NULL, ?)
+          """,
+        arguments: [
+          runID.rawValue,
+          sourceIdentity,
+          marker.planFingerprint,
+          try Self.encodeStrings(targetIDs),
+          timestamp,
+          PrivateHeaderGeneration.RunStatus.running.rawValue,
+        ]
+      )
+      try db.execute(
+        sql: "INSERT INTO runOrdering(runID) VALUES (?)",
+        arguments: [runID.rawValue]
+      )
+      for targetID in targetIDs {
+        let artifacts = marker.artifactsByTarget[targetID] ?? []
+        let encodedArtifacts = try Self.encodeArtifacts(artifacts)
+        let kind = targetID.split(separator: ":", maxSplits: 1).first.map(String.init) ?? ""
+        try db.execute(
+          sql: """
+            INSERT INTO runTargets(
+                runID, targetID, displayName, kind, status,
+                failureSummary, artifactSet, updatedAt
+            ) VALUES (?, ?, ?, ?, ?, NULL, ?, ?)
+            """,
+          arguments: [
+            runID.rawValue,
+            targetID,
+            targetID,
+            kind,
+            PrivateHeaderGeneration.RunTargetStatus.completed.rawValue,
+            encodedArtifacts,
+            timestamp,
+          ]
+        )
+      }
+      try db.execute(
+        sql: """
+          INSERT INTO publicationIntents(
+              generationID, runID, previousGenerationID, state,
+              planFingerprint, artifactChecksum, createdAt, completedAt
+          ) VALUES (?, ?, NULL, ?, ?, ?, ?, NULL)
+          """,
+        arguments: [
+          marker.generationID.rawValue,
+          runID.rawValue,
+          PrivateHeaderGeneration.PublicationState.pointerPublished.rawValue,
+          marker.planFingerprint,
+          marker.artifactChecksum,
+          timestamp,
+        ]
+      )
+      try db.execute(
+        sql: "INSERT INTO publicationOrdering(generationID) VALUES (?)",
+        arguments: [marker.generationID.rawValue]
+      )
+      try db.execute(
+        sql: "INSERT INTO metadata(key, value) VALUES (?, ?)",
+        arguments: [Self.bootstrapReconciliationKey, reconciliation.storedValue]
+      )
+      return true
+    }
+  }
+
+  package func pendingBootstrapReconciliation() throws -> BootstrapReconciliation?
+  {
+    try databaseQueue.read { db in
+      guard
+        let rawValue = try String.fetchOne(
+          db,
+          sql: "SELECT value FROM metadata WHERE key = ?",
+          arguments: [Self.bootstrapReconciliationKey]
+        )
+      else {
+        return nil
+      }
+      return try BootstrapReconciliation(storedValue: rawValue)
+    }
+  }
+
+  package func completeBootstrapReconciliation(
+    _ reconciliation: BootstrapReconciliation
+  ) throws {
+    try databaseQueue.write { db in
+      guard
+        let pending = try String.fetchOne(
+          db,
+          sql: "SELECT value FROM metadata WHERE key = ?",
+          arguments: [Self.bootstrapReconciliationKey]
+        )
+      else {
+        return
+      }
+      guard pending == reconciliation.storedValue else {
+        throw PrivateHeaderGeneration.StateError.corruptPublication(
+          "bootstrap reconciliation state changed from \(reconciliation.storedValue) to \(pending)"
+        )
+      }
+      try db.execute(
+        sql: "DELETE FROM metadata WHERE key = ?",
+        arguments: [Self.bootstrapReconciliationKey]
+      )
     }
   }
 
@@ -199,6 +376,7 @@ package actor GenerationStore {
 
   package func recordPublishedTargetAttempt(
     _ result: PrivateHeaderGeneration.TargetAttemptResult,
+    artifactDigests: [PrivateHeaderGeneration.ArtifactPath: String],
     in runID: PrivateHeaderGeneration.RunID
   ) throws {
     guard result.status == .completed else {
@@ -210,7 +388,12 @@ package actor GenerationStore {
     }
     try databaseQueue.write { db in
       try Self.updateRunTarget(db, result: result, in: runID)
-      try Self.upsertPublishedTarget(db, result: result, in: runID)
+      try Self.upsertPublishedTarget(
+        db,
+        result: result,
+        artifactDigests: artifactDigests,
+        in: runID
+      )
       try faultInjector(.afterRunTargetWrite)
     }
   }
@@ -639,6 +822,19 @@ package actor GenerationStore {
     }
   }
 
+  package func publishedTargetsByID()
+    throws -> [String: PrivateHeaderGeneration.TargetSnapshot]
+  {
+    try databaseQueue.read { db in
+      try Dictionary(
+        uniqueKeysWithValues: Row.fetchAll(db, sql: "SELECT * FROM targets").map { row in
+          let snapshot = try Self.targetSnapshot(row)
+          return (snapshot.targetID, snapshot)
+        }
+      )
+    }
+  }
+
   package func targetIDsCoveredByGeneration(
     _ generationID: PrivateHeaderGeneration.GenerationID
   ) throws -> Set<String> {
@@ -814,16 +1010,23 @@ extension GenerationStore {
   fileprivate static func upsertPublishedTarget(
     _ db: Database,
     result: PrivateHeaderGeneration.TargetAttemptResult,
+    artifactDigests: [PrivateHeaderGeneration.ArtifactPath: String],
     in runID: PrivateHeaderGeneration.RunID
   ) throws {
+    let encodedDigests = try encodeArtifactDigests(
+      artifactDigests,
+      artifacts: result.artifacts
+    )
     try db.execute(
       sql: """
-        INSERT INTO targets(targetID, lastSuccessfulRunID, status, artifactSet, updatedAt)
-        VALUES (?, ?, ?, ?, ?)
+        INSERT INTO targets(
+            targetID, lastSuccessfulRunID, status, artifactSet, artifactDigests, updatedAt
+        ) VALUES (?, ?, ?, ?, ?, ?)
         ON CONFLICT(targetID) DO UPDATE SET
             lastSuccessfulRunID = excluded.lastSuccessfulRunID,
             status = excluded.status,
             artifactSet = excluded.artifactSet,
+            artifactDigests = excluded.artifactDigests,
             updatedAt = excluded.updatedAt
         """,
       arguments: [
@@ -831,6 +1034,7 @@ extension GenerationStore {
         runID.rawValue,
         PrivateHeaderGeneration.RunTargetStatus.completed.rawValue,
         try encodeArtifacts(result.artifacts),
+        encodedDigests,
         result.completedAt.timeIntervalSinceReferenceDate,
       ]
     )
@@ -928,6 +1132,13 @@ extension GenerationStore {
           );
           INSERT INTO publicationOrdering(generationID)
               SELECT generationID FROM publicationIntents ORDER BY rowid;
+          """)
+    }
+    migrator.registerMigration("v4-published-artifact-digests") { db in
+      try db.execute(
+        sql: """
+          ALTER TABLE targets
+          ADD COLUMN artifactDigests TEXT NOT NULL DEFAULT '{}';
           """)
     }
     return migrator
@@ -1135,9 +1346,15 @@ extension GenerationStore {
       let updatedAt: Double = row["updatedAt"]
       try db.execute(
         sql: """
-          INSERT INTO targets(targetID, lastSuccessfulRunID, status, artifactSet, updatedAt)
-          VALUES (?, ?, ?, ?, ?)
+          INSERT INTO targets(
+              targetID, lastSuccessfulRunID, status, artifactSet, artifactDigests, updatedAt
+          ) VALUES (?, ?, ?, ?, '{}', ?)
           ON CONFLICT(targetID) DO UPDATE SET
+              artifactDigests = CASE
+                  WHEN targets.lastSuccessfulRunID = excluded.lastSuccessfulRunID
+                  THEN targets.artifactDigests
+                  ELSE excluded.artifactDigests
+              END,
               lastSuccessfulRunID = excluded.lastSuccessfulRunID,
               status = excluded.status,
               artifactSet = excluded.artifactSet,
@@ -1289,11 +1506,20 @@ extension GenerationStore {
         "unknown target status \(rawStatus)")
     }
     let artifactJSON: String = row["artifactSet"]
+    let artifacts = try decodeArtifacts(artifactJSON)
+    let digestJSON: String = row["artifactDigests"]
+    let artifactDigests = try decodeArtifactDigests(digestJSON)
+    guard artifactDigests.isEmpty || Set(artifactDigests.keys) == Set(artifacts) else {
+      throw PrivateHeaderGeneration.StateError.corruptPublication(
+        "published target artifact digests do not match its artifact set"
+      )
+    }
     return PrivateHeaderGeneration.TargetSnapshot(
       targetID: row["targetID"],
       lastSuccessfulRunID: try PrivateHeaderGeneration.RunID(row["lastSuccessfulRunID"]),
       status: status,
-      artifacts: try decodeArtifacts(artifactJSON),
+      artifacts: artifacts,
+      artifactDigests: artifactDigests,
       updatedAt: Date(timeIntervalSinceReferenceDate: row["updatedAt"])
     )
   }
@@ -1385,5 +1611,47 @@ extension GenerationStore {
     .ArtifactPath]
   {
     try decodeStrings(value).map { try PrivateHeaderGeneration.ArtifactPath($0) }
+  }
+
+  fileprivate static func encodeArtifactDigests(
+    _ values: [PrivateHeaderGeneration.ArtifactPath: String],
+    artifacts: [PrivateHeaderGeneration.ArtifactPath]
+  ) throws -> String {
+    guard Set(values.keys) == Set(artifacts), values.values.allSatisfy(isValidSHA256) else {
+      throw PrivateHeaderGeneration.StateError.corruptPublication(
+        "published target artifact digests do not match its artifact set"
+      )
+    }
+    let rawValues = Dictionary(uniqueKeysWithValues: values.map { ($0.key.rawValue, $0.value) })
+    return String(decoding: try JSONEncoder().encode(rawValues), as: UTF8.self)
+  }
+
+  fileprivate static func decodeArtifactDigests(
+    _ value: String
+  ) throws -> [PrivateHeaderGeneration.ArtifactPath: String] {
+    let rawValues = try JSONDecoder().decode([String: String].self, from: Data(value.utf8))
+    var result: [PrivateHeaderGeneration.ArtifactPath: String] = [:]
+    result.reserveCapacity(rawValues.count)
+    for (rawPath, digest) in rawValues {
+      guard isValidSHA256(digest) else {
+        throw PrivateHeaderGeneration.StateError.corruptPublication(
+          "published target has an invalid artifact digest"
+        )
+      }
+      let path = try PrivateHeaderGeneration.ArtifactPath(rawPath)
+      guard result[path] == nil else {
+        throw PrivateHeaderGeneration.StateError.corruptPublication(
+          "published target has duplicate artifact digest paths"
+        )
+      }
+      result[path] = digest
+    }
+    return result
+  }
+
+  fileprivate static func isValidSHA256(_ digest: String) -> Bool {
+    digest.utf8.count == 64 && digest.utf8.allSatisfy {
+      (48...57).contains($0) || (97...102).contains($0)
+    }
   }
 }

--- a/Sources/PrivateHeaderKitCore/PrivateHeaderGenerationStore.swift
+++ b/Sources/PrivateHeaderKitCore/PrivateHeaderGenerationStore.swift
@@ -145,10 +145,17 @@ package actor GenerationStore {
     }
   }
 
-  package func recordTargetAttempt(
+  package func prepareTargetPublication(
     _ result: PrivateHeaderGeneration.TargetAttemptResult,
     in runID: PrivateHeaderGeneration.RunID
   ) throws {
+    guard result.status == .completed else {
+      throw PrivateHeaderGeneration.StateError.invalidTransition(
+        entity: "target publication \(result.targetID)",
+        from: result.status.rawValue,
+        to: PrivateHeaderGeneration.RunTargetStatus.completed.rawValue
+      )
+    }
     try databaseQueue.write { db in
       let status = try String.fetchOne(
         db,
@@ -157,28 +164,53 @@ package actor GenerationStore {
       )
       guard status == PrivateHeaderGeneration.RunTargetStatus.running.rawValue else {
         throw PrivateHeaderGeneration.StateError.invalidTransition(
-          entity: "target attempt \(result.targetID)",
+          entity: "target publication \(result.targetID)",
           from: status ?? "missing",
-          to: result.status.rawValue
+          to: PrivateHeaderGeneration.RunTargetStatus.completed.rawValue
         )
       }
       try db.execute(
         sql: """
           UPDATE runTargets
-          SET displayName = ?, kind = ?, status = ?, failureSummary = ?, artifactSet = ?, updatedAt = ?
+          SET displayName = ?, kind = ?, artifactSet = ?, updatedAt = ?
           WHERE runID = ? AND targetID = ?
           """,
         arguments: [
           result.displayName,
           result.kind,
-          result.status.rawValue,
-          result.failureSummary,
           try Self.encodeArtifacts(result.artifacts),
           result.completedAt.timeIntervalSinceReferenceDate,
           runID.rawValue,
           result.targetID,
         ]
       )
+    }
+  }
+
+  package func recordTargetAttempt(
+    _ result: PrivateHeaderGeneration.TargetAttemptResult,
+    in runID: PrivateHeaderGeneration.RunID
+  ) throws {
+    try databaseQueue.write { db in
+      try Self.updateRunTarget(db, result: result, in: runID)
+      try faultInjector(.afterRunTargetWrite)
+    }
+  }
+
+  package func recordPublishedTargetAttempt(
+    _ result: PrivateHeaderGeneration.TargetAttemptResult,
+    in runID: PrivateHeaderGeneration.RunID
+  ) throws {
+    guard result.status == .completed else {
+      throw PrivateHeaderGeneration.StateError.invalidTransition(
+        entity: "published target attempt \(result.targetID)",
+        from: result.status.rawValue,
+        to: PrivateHeaderGeneration.RunTargetStatus.completed.rawValue
+      )
+    }
+    try databaseQueue.write { db in
+      try Self.updateRunTarget(db, result: result, in: runID)
+      try Self.upsertPublishedTarget(db, result: result, in: runID)
       try faultInjector(.afterRunTargetWrite)
     }
   }
@@ -594,6 +626,19 @@ package actor GenerationStore {
     }
   }
 
+  package func publishedArtifactsByTarget()
+    throws -> [String: [PrivateHeaderGeneration.ArtifactPath]]
+  {
+    try databaseQueue.read { db in
+      try Dictionary(
+        uniqueKeysWithValues: Row.fetchAll(db, sql: "SELECT * FROM targets").map { row in
+          let snapshot = try Self.targetSnapshot(row)
+          return (snapshot.targetID, snapshot.artifacts)
+        }
+      )
+    }
+  }
+
   package func recordRunLog(
     runID: PrivateHeaderGeneration.RunID,
     kind: String,
@@ -697,6 +742,67 @@ package actor GenerationStore {
 }
 
 extension GenerationStore {
+  fileprivate static func updateRunTarget(
+    _ db: Database,
+    result: PrivateHeaderGeneration.TargetAttemptResult,
+    in runID: PrivateHeaderGeneration.RunID
+  ) throws {
+    let status = try String.fetchOne(
+      db,
+      sql: "SELECT status FROM runTargets WHERE runID = ? AND targetID = ?",
+      arguments: [runID.rawValue, result.targetID]
+    )
+    guard status == PrivateHeaderGeneration.RunTargetStatus.running.rawValue else {
+      throw PrivateHeaderGeneration.StateError.invalidTransition(
+        entity: "target attempt \(result.targetID)",
+        from: status ?? "missing",
+        to: result.status.rawValue
+      )
+    }
+    try db.execute(
+      sql: """
+        UPDATE runTargets
+        SET displayName = ?, kind = ?, status = ?, failureSummary = ?, artifactSet = ?, updatedAt = ?
+        WHERE runID = ? AND targetID = ?
+        """,
+      arguments: [
+        result.displayName,
+        result.kind,
+        result.status.rawValue,
+        result.failureSummary,
+        try encodeArtifacts(result.artifacts),
+        result.completedAt.timeIntervalSinceReferenceDate,
+        runID.rawValue,
+        result.targetID,
+      ]
+    )
+  }
+
+  fileprivate static func upsertPublishedTarget(
+    _ db: Database,
+    result: PrivateHeaderGeneration.TargetAttemptResult,
+    in runID: PrivateHeaderGeneration.RunID
+  ) throws {
+    try db.execute(
+      sql: """
+        INSERT INTO targets(targetID, lastSuccessfulRunID, status, artifactSet, updatedAt)
+        VALUES (?, ?, ?, ?, ?)
+        ON CONFLICT(targetID) DO UPDATE SET
+            lastSuccessfulRunID = excluded.lastSuccessfulRunID,
+            status = excluded.status,
+            artifactSet = excluded.artifactSet,
+            updatedAt = excluded.updatedAt
+        """,
+      arguments: [
+        result.targetID,
+        runID.rawValue,
+        PrivateHeaderGeneration.RunTargetStatus.completed.rawValue,
+        try encodeArtifacts(result.artifacts),
+        result.completedAt.timeIntervalSinceReferenceDate,
+      ]
+    )
+  }
+
   fileprivate static func prepareDatabasePath(_ databaseURL: URL) throws {
     do {
       try ManagedFileSystem.ensureRealDirectory(databaseURL.deletingLastPathComponent())
@@ -932,7 +1038,16 @@ extension GenerationStore {
           sql: """
             UPDATE runTargets
             SET status = ?, failureSummary = COALESCE(failureSummary, ?), updatedAt = ?
-            WHERE runID = ? AND status IN (?, ?)
+            WHERE runID = ?
+              AND (
+                status = ?
+                OR (
+                  status = ?
+                  AND targetID NOT IN (
+                    SELECT targetID FROM targets WHERE lastSuccessfulRunID = ?
+                  )
+                )
+              )
             """,
           arguments: [
             PrivateHeaderGeneration.RunTargetStatus.failed.rawValue,
@@ -941,6 +1056,7 @@ extension GenerationStore {
             intent.runID.rawValue,
             PrivateHeaderGeneration.RunTargetStatus.running.rawValue,
             PrivateHeaderGeneration.RunTargetStatus.completed.rawValue,
+            intent.runID.rawValue,
           ]
         )
         try db.execute(

--- a/Sources/PrivateHeaderKitCore/PrivateHeaderGenerationStore.swift
+++ b/Sources/PrivateHeaderKitCore/PrivateHeaderGenerationStore.swift
@@ -639,6 +639,39 @@ package actor GenerationStore {
     }
   }
 
+  package func targetIDsCoveredByGeneration(
+    _ generationID: PrivateHeaderGeneration.GenerationID
+  ) throws -> Set<String> {
+    try databaseQueue.read { db in
+      guard
+        let generationSequence = try Int64.fetchOne(
+          db,
+          sql: """
+            SELECT runOrdering.sequence
+            FROM publicationIntents
+            JOIN runOrdering ON runOrdering.runID = publicationIntents.runID
+            WHERE publicationIntents.generationID = ?
+            """,
+          arguments: [generationID.rawValue]
+        )
+      else {
+        throw PrivateHeaderGeneration.StateError.missingPublicationIntent(generationID)
+      }
+      return Set(
+        try String.fetchAll(
+          db,
+          sql: """
+            SELECT targets.targetID
+            FROM targets
+            JOIN runOrdering ON runOrdering.runID = targets.lastSuccessfulRunID
+            WHERE runOrdering.sequence <= ?
+            """,
+          arguments: [generationSequence]
+        )
+      )
+    }
+  }
+
   package func recordRunLog(
     runID: PrivateHeaderGeneration.RunID,
     kind: String,

--- a/Sources/PrivateHeaderKitTooling/ProcessRunner.swift
+++ b/Sources/PrivateHeaderKitTooling/ProcessRunner.swift
@@ -321,6 +321,21 @@ public protocol CommandRunning: Sendable {
         env: [String: String]?,
         cwd: URL?
     ) async throws -> StreamingCommandResult
+    func runBuffered(
+        _ command: [String],
+        env: [String: String]?,
+        cwd: URL?
+    ) async throws -> StreamingCommandResult
+}
+
+public extension CommandRunning {
+    func runBuffered(
+        _ command: [String],
+        env: [String: String]? = nil,
+        cwd: URL? = nil
+    ) async throws -> StreamingCommandResult {
+        try await runStreaming(command, env: env, cwd: cwd)
+    }
 }
 
 public struct ProcessRunner: CommandRunning, Sendable {
@@ -548,6 +563,20 @@ public struct ProcessRunner: CommandRunning, Sendable {
         } onCancel: {
             outputWriter.cancel()
         }
+    }
+
+    public func runBuffered(
+        _ command: [String],
+        env: [String: String]? = nil,
+        cwd: URL? = nil
+    ) async throws -> StreamingCommandResult {
+        try await runStreaming(
+            command,
+            env: env,
+            cwd: cwd,
+            streamOutput: false,
+            passthrough: { _ in }
+        )
     }
 
     func runStreaming(

--- a/Tests/PrivateHeaderKitCLITests/PrivateHeaderKitCLITests.swift
+++ b/Tests/PrivateHeaderKitCLITests/PrivateHeaderKitCLITests.swift
@@ -643,6 +643,27 @@ struct PrivateHeaderKitCLIExecutionTests {
         #expect(await runner.streamingCommandSnapshot().count == 1)
     }
 
+    @Test func rawDumpUsesBufferedRunnerAndRetainsFailureTail() async throws {
+        let helperURL = URL(fileURLWithPath: "/tmp/privateheaderkit-raw-helper")
+        let invocation = PrivateHeaderGeneration.RawDumping.makeInvocation(
+            try PrivateHeaderGeneration.RawDumping.Request(
+                helperURLs: .init(host: helperURL, simulator: helperURL),
+                executionMode: .host,
+                inputPath: "/System/Library/Frameworks/AppKit.framework",
+                stagingOutputDirectory: URL(fileURLWithPath: "/tmp/privateheaderkit-stage")
+            )
+        )
+
+        let result = try await runPrivateHeaderKitRawDump(
+            invocation,
+            processRunner: BufferedRawDumpProbeRunner()
+        )
+
+        #expect(result.terminationStatus == 19)
+        #expect(!result.wasKilled)
+        #expect(result.failureSummary == "helper-warning\nfatal-tail")
+    }
+
     @Test func signalCoordinatorWaitsForOperationCleanupBeforeReturningSignalStatus() async {
         let cases: [(PrivateHeaderKitTerminationSignal, Int32)] = [
             (.interrupt, 130),
@@ -1654,6 +1675,53 @@ private func testPrivateHeaderKitHelperResolver(
             ? "test-tool-identity:host-and-simulator"
             : "test-tool-identity:host"
     )
+}
+
+private struct BufferedRawDumpProbeRunner: CommandRunning {
+    func runCapture(
+        _ command: [String],
+        env: [String: String]?,
+        cwd: URL?
+    ) async throws -> String {
+        throw ToolingError.message("unexpected runCapture command: \(command)")
+    }
+
+    func runCaptureChunks(
+        _ command: [String],
+        env: [String: String]?,
+        cwd: URL?,
+        consumeStandardOutput: @escaping CommandStandardOutputConsumer
+    ) async throws {
+        throw ToolingError.message("unexpected runCaptureChunks command: \(command)")
+    }
+
+    func runSimple(
+        _ command: [String],
+        env: [String: String]?,
+        cwd: URL?
+    ) async throws {
+        throw ToolingError.message("unexpected runSimple command: \(command)")
+    }
+
+    func runStreaming(
+        _ command: [String],
+        env: [String: String]?,
+        cwd: URL?
+    ) async throws -> StreamingCommandResult {
+        throw ToolingError.message("unexpected runStreaming command: \(command)")
+    }
+
+    func runBuffered(
+        _ command: [String],
+        env: [String: String]?,
+        cwd: URL?
+    ) async throws -> StreamingCommandResult {
+        StreamingCommandResult(
+            status: 19,
+            wasKilled: false,
+            lastLines: ["helper-warning", "fatal-tail"]
+        )
+    }
 }
 
 private actor MutatingCaptureRunner: CommandRunning {

--- a/Tests/PrivateHeaderKitCLITests/PrivateHeaderKitProgressRenderingTests.swift
+++ b/Tests/PrivateHeaderKitCLITests/PrivateHeaderKitProgressRenderingTests.swift
@@ -1,0 +1,238 @@
+import Foundation
+import PrivateHeaderKitCore
+import Testing
+
+@testable import PrivateHeaderKitCLI
+
+@Suite
+struct PrivateHeaderKitProgressRenderingTests {
+    @Test func nonTerminalOutputOmitsSuccessfulTargetsAndReportsOnlyFailures() {
+        let output = ProgressTextRecorder()
+        let failures = ProgressTextRecorder()
+        let renderer = PrivateHeaderKitProgressOutputLogger(
+            outputLogger: { output.append($0) },
+            failureLogger: { failures.append($0) },
+            artifactDirectory: URL(fileURLWithPath: "/tmp/generated-headers/source"),
+            inlineProgressEnabled: false,
+            startsTimer: false
+        )
+
+        renderer.report(.runStarted(runID: .init(rawValue: "run-001"), totalTargetCount: 2))
+        renderer.report(.targetStarted(index: 1, total: 2, displayName: "Foo"))
+        renderer.report(
+            .targetFinished(
+                index: 1,
+                total: 2,
+                displayName: "Foo",
+                status: .completed,
+                failureSummary: nil
+            )
+        )
+        renderer.report(.targetStarted(index: 2, total: 2, displayName: "Bar"))
+        renderer.report(
+            .targetFinished(
+                index: 2,
+                total: 2,
+                displayName: "Bar",
+                status: .failed,
+                failureSummary: "objc noise\nprivateheaderkit: error: missing image"
+            )
+        )
+
+        #expect(
+            output.values == [
+                "Generation run-001: 2 targets → /tmp/generated-headers/source"
+            ])
+        #expect(
+            failures.values == [
+                "[2/2] Bar failed",
+                "  privateheaderkit: error: missing image",
+            ])
+    }
+
+    @Test func terminalOutputCyclesDotsAndReusesTheSuccessfulTargetLine() {
+        let output = ProgressTextRecorder()
+        let failures = ProgressTextRecorder()
+        let inline = ProgressTextRecorder()
+        let renderer = PrivateHeaderKitProgressOutputLogger(
+            outputLogger: { output.append($0) },
+            failureLogger: { failures.append($0) },
+            artifactDirectory: URL(fileURLWithPath: "/tmp/generated-headers/source"),
+            inlineProgressEnabled: true,
+            inlineWriter: { inline.append($0) },
+            startsTimer: false
+        )
+
+        renderer.report(.targetStarted(index: 1, total: 2, displayName: "Foo"))
+        renderer.advanceIndicatorForTesting()
+        renderer.advanceIndicatorForTesting()
+        renderer.advanceIndicatorForTesting()
+        renderer.report(
+            .targetFinished(
+                index: 1,
+                total: 2,
+                displayName: "Foo",
+                status: .completed,
+                failureSummary: nil
+            )
+        )
+        renderer.report(.targetStarted(index: 2, total: 2, displayName: "Bar"))
+        renderer.report(
+            .targetFinished(
+                index: 2,
+                total: 2,
+                displayName: "Bar",
+                status: .failed,
+                failureSummary: "failed to dump"
+            )
+        )
+        renderer.report(
+            .runFinished(
+                .init(
+                    runID: .init(rawValue: "run-001"),
+                    status: .failed,
+                    targetCounts: .init(total: 2, completed: 1, failed: 1),
+                    artifactDirectory: URL(fileURLWithPath: "/tmp/generated-headers/source"),
+                    stateDatabaseURL: URL(fileURLWithPath: "/tmp/generation.sqlite")
+                )
+            )
+        )
+
+        let rendered = inline.values.joined()
+        #expect(rendered.contains("\r[1/2] Foo ."))
+        #expect(rendered.contains("\r[1/2] Foo .."))
+        #expect(rendered.contains("\r[1/2] Foo ..."))
+        #expect(rendered.contains("\r[1/2] Foo completed"))
+        #expect(rendered.contains("\r[2/2] Bar ."))
+        #expect(rendered.contains("\r[2/2] Bar failed\n"))
+        #expect(inline.values.count(where: { $0 == "\u{001B}[?25l" }) == 1)
+        #expect(inline.values.count(where: { $0 == "\u{001B}[?25h" }) == 1)
+        #expect(output.values.isEmpty)
+        #expect(failures.values == ["  failed to dump"])
+    }
+
+    @Test func runFinishedClearsTheLastSuccessfulTargetAndIgnoresLateTicks() {
+        let inline = ProgressTextRecorder()
+        let renderer = PrivateHeaderKitProgressOutputLogger(
+            outputLogger: { _ in },
+            failureLogger: { _ in },
+            artifactDirectory: URL(fileURLWithPath: "/tmp/generated-headers/source"),
+            inlineProgressEnabled: true,
+            inlineWriter: { inline.append($0) },
+            startsTimer: false,
+            inlineColumnCount: 80
+        )
+
+        renderer.report(.targetStarted(index: 1, total: 1, displayName: "Foo"))
+        renderer.report(
+            .targetFinished(
+                index: 1,
+                total: 1,
+                displayName: "Foo",
+                status: .completed,
+                failureSummary: nil
+            )
+        )
+        renderer.report(
+            .runFinished(
+                .init(
+                    runID: .init(rawValue: "run-001"),
+                    status: .completed,
+                    targetCounts: .init(total: 1, completed: 1),
+                    artifactDirectory: URL(fileURLWithPath: "/tmp/generated-headers/source"),
+                    stateDatabaseURL: URL(fileURLWithPath: "/tmp/generation.sqlite")
+                )
+            )
+        )
+        renderer.advanceIndicatorForTesting()
+
+        #expect(
+            inline.values == [
+                "\u{001B}[?25l",
+                "\r[1/1] Foo .",
+                "\r[1/1] Foo completed",
+                "\r                   \r",
+                "\u{001B}[?25h",
+            ])
+    }
+
+    @Test func runFinishedWithoutTargetResultStopsAnActiveIndicator() {
+        let inline = ProgressTextRecorder()
+        let renderer = PrivateHeaderKitProgressOutputLogger(
+            outputLogger: { _ in },
+            failureLogger: { _ in },
+            artifactDirectory: URL(fileURLWithPath: "/tmp/generated-headers/source"),
+            inlineProgressEnabled: true,
+            inlineWriter: { inline.append($0) },
+            startsTimer: false,
+            inlineColumnCount: 80
+        )
+
+        renderer.report(.targetStarted(index: 1, total: 1, displayName: "Foo"))
+        renderer.report(
+            .runFinished(
+                .init(
+                    runID: .init(rawValue: "run-001"),
+                    status: .failed,
+                    targetCounts: .init(total: 1, failed: 1),
+                    artifactDirectory: URL(fileURLWithPath: "/tmp/generated-headers/source"),
+                    stateDatabaseURL: URL(fileURLWithPath: "/tmp/generation.sqlite")
+                )
+            )
+        )
+        renderer.advanceIndicatorForTesting()
+
+        #expect(
+            inline.values == [
+                "\u{001B}[?25l",
+                "\r[1/1] Foo .",
+                "\r           \r",
+                "\u{001B}[?25h",
+            ])
+    }
+
+    @Test func terminalOutputTruncatesLongTargetsToTheTerminalWidth() {
+        let inline = ProgressTextRecorder()
+        let renderer = PrivateHeaderKitProgressOutputLogger(
+            outputLogger: { _ in },
+            failureLogger: { _ in },
+            artifactDirectory: URL(fileURLWithPath: "/tmp/generated-headers/source"),
+            inlineProgressEnabled: true,
+            inlineWriter: { inline.append($0) },
+            startsTimer: false,
+            inlineColumnCount: 32
+        )
+
+        renderer.report(
+            .targetStarted(
+                index: 24,
+                total: 6701,
+                displayName: "Frameworks/AppKit.framework/XPCServices/DefaultSyncService.xpc"
+            )
+        )
+
+        let line = inline.values.last.map { String($0.dropFirst()) }
+        #expect(line.map(privateHeaderKitTestTerminalWidth) == 32)
+        #expect(line?.contains("…") == true)
+        #expect(line?.contains("SyncService.xpc") == true)
+    }
+}
+
+private final class ProgressTextRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storage: [String] = []
+
+    var values: [String] {
+        lock.withLock { storage }
+    }
+
+    func append(_ value: String) {
+        lock.withLock { storage.append(value) }
+    }
+}
+
+private func privateHeaderKitTestTerminalWidth(_ text: String) -> Int {
+    text.unicodeScalars.reduce(into: 0) { width, scalar in
+        width += scalar.isASCII ? 1 : 2
+    }
+}

--- a/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationArtifactPublisherTests.swift
+++ b/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationArtifactPublisherTests.swift
@@ -991,6 +991,67 @@ struct PrivateHeaderGenerationArtifactPublisherTests {
     }
   }
 
+  @Test func retainedGenerationContentsAreAuthenticatedOnlyWhenUsed() throws {
+    let fixture = try PublisherFixture()
+    defer { fixture.cleanup() }
+    let oldID = PrivateHeaderGeneration.GenerationID(rawValue: "generation-old")
+    let old = try fixture.prepare(
+      generationID: oldID,
+      targetID: "framework:Foo",
+      relativePath: "Frameworks/Foo/Foo.h",
+      contents: "old"
+    )
+    try fixture.publish(old)
+    let currentID = PrivateHeaderGeneration.GenerationID(rawValue: "generation-current")
+    try fixture.publish(
+      fixture.prepare(
+        generationID: currentID,
+        targetID: "framework:Foo",
+        relativePath: "Frameworks/Foo/Foo.h",
+        contents: "current"
+      )
+    )
+    try Data("tampered".utf8).write(
+      to: old.finalDirectory.appendingPathComponent("Frameworks/Foo/Foo.h")
+    )
+
+    #expect(try fixture.publisher.inspect().currentGenerationID == currentID)
+    #expect(throws: ArtifactPublisher.PublisherError.self) {
+      try fixture.publisher.switchCurrent(to: oldID)
+    }
+    #expect(try fixture.publisher.inspect().currentGenerationID == currentID)
+
+    try fixture.publisher.discardGeneration(oldID)
+    #expect(!FileManager.default.fileExists(atPath: old.finalDirectory.path))
+  }
+
+  @Test func inspectStillRejectsRetainedGenerationInventoryChanges() throws {
+    let fixture = try PublisherFixture()
+    defer { fixture.cleanup() }
+    let old = try fixture.prepare(
+      generationID: .init(rawValue: "generation-old"),
+      targetID: "framework:Foo",
+      relativePath: "Frameworks/Foo/Foo.h",
+      contents: "old"
+    )
+    try fixture.publish(old)
+    try fixture.publish(
+      fixture.prepare(
+        generationID: .init(rawValue: "generation-current"),
+        targetID: "framework:Foo",
+        relativePath: "Frameworks/Foo/Foo.h",
+        contents: "current"
+      )
+    )
+    try Data("unexpected".utf8).write(
+      to: old.finalDirectory.appendingPathComponent("Frameworks/Foo/Unexpected.h")
+    )
+
+    #expect(throws: ArtifactPublisher.PublisherError.self) {
+      _ = try fixture.publisher.inspect()
+    }
+  }
+
   @Test func prepareGenerationRejectsUnexpectedPublishedTargetBytes() throws {
     let fixture = try PublisherFixture()
     defer { fixture.cleanup() }

--- a/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationArtifactPublisherTests.swift
+++ b/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationArtifactPublisherTests.swift
@@ -141,6 +141,99 @@ struct PrivateHeaderGenerationArtifactPublisherTests {
         encoding: .utf8) == "keep")
   }
 
+  @Test func replacingTheTargetSetDropsAbsentDraftOwners() throws {
+    let fixture = try PublisherFixture()
+    defer { fixture.cleanup() }
+    try fixture.publish(
+      fixture.prepare(
+        generationID: .init(rawValue: "generation-foo"),
+        targetID: "framework:Foo",
+        relativePath: "Frameworks/Foo/Foo.h",
+        contents: "foo"
+      )
+    )
+    var combinedDraft = try fixture.publisher.beginDraft(
+      generationID: .init(rawValue: "generation-combined"),
+      allowLegacyMigration: false
+    )
+    combinedDraft = try fixture.publisher.applyCompletedTarget(
+      targetID: "framework:Bar",
+      files: [
+        .init(rawValue: "Frameworks/Bar/Bar.h"): try fixture.sourceFile(contents: "bar")
+      ],
+      to: combinedDraft
+    )
+    try fixture.publish(
+      try fixture.publisher.prepareGeneration(
+        combinedDraft,
+        planFingerprint: "fingerprint"
+      )
+    )
+
+    let seededDraft = try fixture.publisher.beginDraft(
+      generationID: .init(rawValue: "generation-exact"),
+      allowLegacyMigration: false
+    )
+    let exactDraft = try fixture.publisher.replaceCompletedTargets(
+      [
+        "framework:Bar": [
+          .init(rawValue: "Frameworks/Bar/Bar.h"): try fixture.sourceFile(
+            contents: "bar-new"
+          )
+        ]
+      ],
+      in: seededDraft
+    )
+    let prepared = try fixture.publisher.prepareGeneration(
+      exactDraft,
+      planFingerprint: "fingerprint"
+    )
+
+    #expect(prepared.marker.artifactsByTarget.keys.sorted() == ["framework:Bar"])
+    #expect(!FileManager.default.fileExists(
+      atPath: prepared.draftDirectory.appendingPathComponent("Frameworks/Foo/Foo.h").path
+    ))
+  }
+
+  @Test func replacingTheTargetSetWithEmptySetDropsEveryDraftOwner() throws {
+    let fixture = try PublisherFixture()
+    defer { fixture.cleanup() }
+    let legacyUnknown = fixture.publisher.stableURL.appendingPathComponent("User/keep.txt")
+    try FileManager.default.createDirectory(
+      at: legacyUnknown.deletingLastPathComponent(),
+      withIntermediateDirectories: true
+    )
+    try Data("keep".utf8).write(to: legacyUnknown)
+    try fixture.publish(
+      fixture.prepare(
+        generationID: .init(rawValue: "generation-foo"),
+        targetID: "framework:Foo",
+        relativePath: "Frameworks/Foo/Foo.h",
+        contents: "foo",
+        allowLegacyMigration: true
+      )
+    )
+
+    let seededDraft = try fixture.publisher.beginDraft(
+      generationID: .init(rawValue: "generation-empty"),
+      allowLegacyMigration: false
+    )
+    let exactDraft = try fixture.publisher.replaceCompletedTargets([:], in: seededDraft)
+    let prepared = try fixture.publisher.prepareGeneration(
+      exactDraft,
+      planFingerprint: "fingerprint"
+    )
+
+    #expect(prepared.marker.artifactsByTarget.isEmpty)
+    #expect(!FileManager.default.fileExists(
+      atPath: prepared.draftDirectory.appendingPathComponent("Frameworks/Foo/Foo.h").path
+    ))
+    #expect(try String(
+      contentsOf: prepared.draftDirectory.appendingPathComponent("User/keep.txt"),
+      encoding: .utf8
+    ) == "keep")
+  }
+
   @Test func rawStagingRejectsHiddenUnsupportedAndSymlinkPayloads() throws {
     let fixture = try PublisherFixture()
     defer { fixture.cleanup() }

--- a/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationArtifactPublisherTests.swift
+++ b/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationArtifactPublisherTests.swift
@@ -735,12 +735,14 @@ struct PrivateHeaderGenerationArtifactPublisherTests {
       opaquePaths: []
     )
 
-    #expect(throws: ArtifactPublisher.PublisherError.artifactCollision(
-      firstPath: "Frameworks/Foo/Headers/A.h",
-      firstOwner: "framework:Foo",
-      secondPath: "Frameworks/Foo/Headers/a.h",
-      secondOwner: "framework:Foo"
-    )) {
+    #expect(
+      throws: ArtifactPublisher.PublisherError.artifactCollision(
+        firstPath: "Frameworks/Foo/Headers/A.h",
+        firstOwner: "framework:Foo",
+        secondPath: "Frameworks/Foo/Headers/a.h",
+        secondOwner: "framework:Foo"
+      )
+    ) {
       _ = try fixture.publisher.prepareGeneration(forged, planFingerprint: "fingerprint")
     }
   }
@@ -767,12 +769,14 @@ struct PrivateHeaderGenerationArtifactPublisherTests {
     marker["artifactChecksum"] = "intentionally-invalid"
     try JSONSerialization.data(withJSONObject: marker).write(to: markerURL)
 
-    #expect(throws: ArtifactPublisher.PublisherError.artifactCollision(
-      firstPath: "Frameworks/Foo/Headers/Foo.h",
-      firstOwner: "framework:Foo",
-      secondPath: "Frameworks/Foo/Headers/foo.h",
-      secondOwner: "framework:Bar"
-    )) {
+    #expect(
+      throws: ArtifactPublisher.PublisherError.artifactCollision(
+        firstPath: "Frameworks/Foo/Headers/Foo.h",
+        firstOwner: "framework:Foo",
+        secondPath: "Frameworks/Foo/Headers/foo.h",
+        secondOwner: "framework:Bar"
+      )
+    ) {
       _ = try fixture.publisher.inspect()
     }
   }
@@ -810,6 +814,52 @@ struct PrivateHeaderGenerationArtifactPublisherTests {
       try String(
         contentsOf: fixture.publisher.stableURL.appendingPathComponent("Frameworks/Foo/Foo.h"),
         encoding: .utf8) == "new")
+  }
+
+  @Test func prepareGenerationRemovesFinderMetadataFromManagedSnapshots() throws {
+    let fixture = try PublisherFixture()
+    defer { fixture.cleanup() }
+    var draft = try fixture.publisher.beginDraft(
+      generationID: .init(rawValue: "generation-finder-metadata"),
+      allowLegacyMigration: false
+    )
+    draft = try fixture.publisher.applyCompletedTarget(
+      targetID: "framework:Foo",
+      files: [
+        .init(rawValue: "Frameworks/Foo/Foo.h"): try fixture.sourceFile(contents: "header")
+      ],
+      to: draft
+    )
+    let rootMetadata = draft.directory.appendingPathComponent(".DS_Store")
+    let nestedMetadata = draft.directory.appendingPathComponent("Frameworks/Foo/.DS_Store")
+    try Data("finder".utf8).write(to: rootMetadata)
+    try Data("finder".utf8).write(to: nestedMetadata)
+
+    let prepared = try fixture.publisher.prepareGeneration(
+      draft,
+      planFingerprint: "fingerprint"
+    )
+
+    #expect(!FileManager.default.fileExists(atPath: rootMetadata.path))
+    #expect(!FileManager.default.fileExists(atPath: nestedMetadata.path))
+    #expect(
+      prepared.marker.artifactsByTarget["framework:Foo"] == [
+        .init(rawValue: "Frameworks/Foo/Foo.h")
+      ])
+  }
+
+  @Test func inventoryMismatchDescriptionIsBoundedAndShowsTheDifference() {
+    let expected = (0..<1_000).map { "Expected/\($0).h" }
+    let actual = (0..<1_000).map { "Actual/\($0).h" }
+    let description = ArtifactPublisher.PublisherError.inventoryMismatch(
+      expected: expected,
+      actual: actual
+    ).description
+
+    #expect(description.count < 500)
+    #expect(description.contains("missing Expected/0.h"))
+    #expect(description.contains("unexpected Actual/0.h"))
+    #expect(description.contains("and 995 more"))
   }
 }
 

--- a/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationArtifactPublisherTests.swift
+++ b/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationArtifactPublisherTests.swift
@@ -468,6 +468,36 @@ struct PrivateHeaderGenerationArtifactPublisherTests {
     )
   }
 
+  @Test func opaqueClaimsUseExactUTF8PathIdentity() throws {
+    let fixture = try PublisherFixture()
+    defer { fixture.cleanup() }
+    let composed = PrivateHeaderGeneration.ArtifactPath(
+      rawValue: "Frameworks/F\u{00E9}/Headers/Generated.h"
+    )
+    let decomposed = PrivateHeaderGeneration.ArtifactPath(
+      rawValue: "Frameworks/Fe\u{301}/Headers/Generated.h"
+    )
+    let unrelated = PrivateHeaderGeneration.ArtifactPath(
+      rawValue: "Frameworks/Bar/Headers/Generated.h"
+    )
+
+    #expect(
+      ArtifactPublisher.unclaimedOpaquePaths([decomposed], claimedBy: [composed])
+        == [decomposed]
+    )
+    #expect(
+      ArtifactPublisher.unclaimedOpaquePaths([decomposed], claimedBy: [decomposed]).isEmpty
+    )
+    #expect(throws: ArtifactPublisher.PublisherError.self) {
+      _ = try fixture.publisher.validateTargetReplacement(
+        targetID: "framework:Bar",
+        artifacts: [unrelated],
+        existingArtifactsByTarget: ["framework:Foo": [composed]],
+        opaquePaths: [decomposed]
+      )
+    }
+  }
+
   @Test func applyAllowsIdenticalSharedDirectoryComponents() throws {
     let fixture = try PublisherFixture()
     defer { fixture.cleanup() }
@@ -939,6 +969,51 @@ struct PrivateHeaderGenerationArtifactPublisherTests {
       prepared.marker.artifactsByTarget["framework:Foo"] == [
         .init(rawValue: "Frameworks/Foo/Foo.h")
       ])
+  }
+
+  @Test func inspectRejectsGenerationWhoseArtifactContentsChanged() throws {
+    let fixture = try PublisherFixture()
+    defer { fixture.cleanup() }
+    try fixture.publish(
+      try fixture.prepare(
+        generationID: .init(rawValue: "generation-content-authentication"),
+        targetID: "framework:Foo",
+        relativePath: "Frameworks/Foo/Foo.h",
+        contents: "original"
+      )
+    )
+    try Data("tampered".utf8).write(
+      to: fixture.publisher.stableURL.appendingPathComponent("Frameworks/Foo/Foo.h")
+    )
+
+    #expect(throws: ArtifactPublisher.PublisherError.self) {
+      _ = try fixture.publisher.inspect()
+    }
+  }
+
+  @Test func prepareGenerationRejectsUnexpectedPublishedTargetBytes() throws {
+    let fixture = try PublisherFixture()
+    defer { fixture.cleanup() }
+    var draft = try fixture.publisher.beginDraft(
+      generationID: .init(rawValue: "generation-expected-digest"),
+      allowLegacyMigration: false
+    )
+    let path = PrivateHeaderGeneration.ArtifactPath(rawValue: "Frameworks/Foo/Foo.h")
+    draft = try fixture.publisher.applyCompletedTarget(
+      targetID: "framework:Foo",
+      files: [path: try fixture.sourceFile(contents: "actual")],
+      to: draft
+    )
+
+    #expect(throws: ArtifactPublisher.PublisherError.self) {
+      _ = try fixture.publisher.prepareGeneration(
+        draft,
+        planFingerprint: "fingerprint",
+        expectedArtifactDigestsByTarget: [
+          "framework:Foo": [path: String(repeating: "0", count: 64)]
+        ]
+      )
+    }
   }
 
   @Test func inventoryMismatchDescriptionIsBoundedAndShowsTheDifference() {

--- a/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationArtifactReplacementTests.swift
+++ b/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationArtifactReplacementTests.swift
@@ -1,0 +1,148 @@
+import Foundation
+import Testing
+
+@testable import PrivateHeaderKitCore
+
+@Suite
+struct PrivateHeaderGenerationArtifactReplacementTests {
+  @Test func applyFailureRestoresTheEntirePreviousTarget() throws {
+    let fixture = try ReplacementFixture()
+    defer { fixture.cleanup() }
+    let replacement = try fixture.prepareReplacement()
+    let fileManager = FailingOnceRemovalFileManager(
+      failingPath: fixture.liveURL("Frameworks/Foo/Headers/Removed.h").path
+    )
+
+    #expect(throws: InjectedReplacementFailure.self) {
+      try fixture.store.applyReplacement(replacement, fileManager: fileManager)
+    }
+
+    #expect(try fixture.contents("Frameworks/Foo/Headers/Keep.h") == "old-keep")
+    #expect(try fixture.contents("Frameworks/Foo/Headers/Removed.h") == "old-removed")
+    #expect(!FileManager.default.fileExists(
+      atPath: fixture.liveURL("Frameworks/Foo/Headers/New.h").path
+    ))
+    try fixture.store.finalizeReplacement(replacement)
+  }
+
+  @Test func pendingReplacementCanRollbackAfterProcessRestart() throws {
+    let fixture = try ReplacementFixture()
+    defer { fixture.cleanup() }
+    let replacement = try fixture.prepareReplacement()
+    try fixture.store.applyReplacement(replacement)
+    #expect(try fixture.contents("Frameworks/Foo/Headers/Keep.h") == "new-keep")
+
+    let recovered = try #require(
+      PrivateHeaderGeneration.ArtifactStore.pendingReplacements(
+        in: fixture.replacementsRoot,
+        artifactRoot: fixture.liveRoot
+      ).only
+    )
+    try fixture.store.rollbackReplacement(recovered)
+    try fixture.store.finalizeReplacement(recovered)
+
+    #expect(try fixture.contents("Frameworks/Foo/Headers/Keep.h") == "old-keep")
+    #expect(try fixture.contents("Frameworks/Foo/Headers/Removed.h") == "old-removed")
+    #expect(!FileManager.default.fileExists(
+      atPath: fixture.liveURL("Frameworks/Foo/Headers/New.h").path
+    ))
+  }
+}
+
+private struct ReplacementFixture {
+  let root: URL
+  let liveRoot: URL
+  let stagingRoot: URL
+  let replacementsRoot: URL
+  let store: PrivateHeaderGeneration.ArtifactStore
+
+  init() throws {
+    root = FileManager.default.temporaryDirectory.appendingPathComponent(
+      "PrivateHeaderGenerationArtifactReplacementTests-\(UUID().uuidString)",
+      isDirectory: true
+    )
+    liveRoot = root.appendingPathComponent("live", isDirectory: true)
+    stagingRoot = root.appendingPathComponent("staging", isDirectory: true)
+    replacementsRoot = root.appendingPathComponent("replacements", isDirectory: true)
+    store = PrivateHeaderGeneration.ArtifactStore(artifactRoot: liveRoot)
+    try write("old-keep", to: liveURL("Frameworks/Foo/Headers/Keep.h"))
+    try write("old-removed", to: liveURL("Frameworks/Foo/Headers/Removed.h"))
+    try write("new-keep", to: stagingRoot.appendingPathComponent("output/Headers/Keep.h"))
+    try write("new", to: stagingRoot.appendingPathComponent("output/Headers/New.h"))
+  }
+
+  func prepareReplacement() throws -> PrivateHeaderGeneration.ArtifactStore.Replacement {
+    let artifactRoot = try PrivateHeaderGeneration.ArtifactPath("Frameworks/Foo")
+    let incoming = try [
+      PrivateHeaderGeneration.ArtifactPath("Frameworks/Foo/Headers/Keep.h"),
+      PrivateHeaderGeneration.ArtifactPath("Frameworks/Foo/Headers/New.h"),
+    ]
+    let removing = try [
+      PrivateHeaderGeneration.ArtifactPath("Frameworks/Foo/Headers/Keep.h"),
+      PrivateHeaderGeneration.ArtifactPath("Frameworks/Foo/Headers/Removed.h"),
+    ]
+    let plan = try store.prepareCommit(
+      stagingDirectory: stagingRoot,
+      stagedSourceDirectory: stagingRoot.appendingPathComponent("output", isDirectory: true),
+      artifactRoot: artifactRoot,
+      artifacts: incoming
+    )
+    return try store.prepareReplacement(
+      plan,
+      removing: removing,
+      runID: .init(rawValue: "run-replacement"),
+      targetID: "framework:Foo.framework",
+      at: replacementsRoot
+        .appendingPathComponent("run-replacement", isDirectory: true)
+        .appendingPathComponent("framework%3AFoo.framework", isDirectory: true)
+    )
+  }
+
+  func liveURL(_ relativePath: String) -> URL {
+    liveRoot.appendingPathComponent(relativePath, isDirectory: false)
+  }
+
+  func contents(_ relativePath: String) throws -> String {
+    try String(contentsOf: liveURL(relativePath), encoding: .utf8)
+  }
+
+  func cleanup() {
+    try? FileManager.default.removeItem(at: root)
+  }
+
+  private func write(_ contents: String, to url: URL) throws {
+    try FileManager.default.createDirectory(
+      at: url.deletingLastPathComponent(),
+      withIntermediateDirectories: true
+    )
+    try contents.write(to: url, atomically: true, encoding: .utf8)
+  }
+}
+
+private enum InjectedReplacementFailure: Error {
+  case stop
+}
+
+private final class FailingOnceRemovalFileManager: FileManager, @unchecked Sendable {
+  private let failingPath: String
+  private var hasFailed = false
+
+  init(failingPath: String) {
+    self.failingPath = failingPath
+    super.init()
+  }
+
+  override func removeItem(at URL: URL) throws {
+    if URL.path == failingPath, !hasFailed {
+      hasFailed = true
+      throw InjectedReplacementFailure.stop
+    }
+    try super.removeItem(at: URL)
+  }
+}
+
+private extension Array {
+  var only: Element? {
+    count == 1 ? self[0] : nil
+  }
+}

--- a/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationArtifactReplacementTests.swift
+++ b/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationArtifactReplacementTests.swift
@@ -47,6 +47,709 @@ struct PrivateHeaderGenerationArtifactReplacementTests {
       atPath: fixture.liveURL("Frameworks/Foo/Headers/New.h").path
     ))
   }
+
+  @Test func replacementRejectsUnsupportedManifestVersionWithoutMutation() throws {
+    let fixture = try ReplacementFixture()
+    defer { fixture.cleanup() }
+    _ = try fixture.prepareReplacement()
+    try fixture.rewriteManifest { manifest in
+      manifest["version"] = 99
+    }
+
+    #expect(throws: PrivateHeaderGeneration.ArtifactStoreError.self) {
+      _ = try PrivateHeaderGeneration.ArtifactStore.pendingReplacements(
+        in: fixture.replacementsRoot,
+        artifactRoot: fixture.liveRoot
+      )
+    }
+
+    #expect(try fixture.contents("Frameworks/Foo/Headers/Keep.h") == "old-keep")
+    #expect(try fixture.contents("Frameworks/Foo/Headers/Removed.h") == "old-removed")
+    #expect(FileManager.default.fileExists(atPath: fixture.transactionDirectory.path))
+  }
+
+  @Test func replacementRejectsIncompleteVersionOneManifestWithoutMutation() throws {
+    let fixture = try ReplacementFixture()
+    defer { fixture.cleanup() }
+    _ = try fixture.prepareReplacement()
+    try fixture.rewriteManifest { manifest in
+      manifest.removeValue(forKey: "incomingDigests")
+    }
+
+    #expect(throws: PrivateHeaderGeneration.ArtifactStoreError.self) {
+      _ = try PrivateHeaderGeneration.ArtifactStore.pendingReplacements(
+        in: fixture.replacementsRoot,
+        artifactRoot: fixture.liveRoot
+      )
+    }
+
+    #expect(try fixture.contents("Frameworks/Foo/Headers/Keep.h") == "old-keep")
+    #expect(try fixture.contents("Frameworks/Foo/Headers/Removed.h") == "old-removed")
+    #expect(FileManager.default.fileExists(atPath: fixture.transactionDirectory.path))
+  }
+
+  @Test func replacementSupportsFileToDirectoryTransition() throws {
+    let fixture = try ReplacementFixture(
+      existingFiles: ["Frameworks/Foo/Headers/Shape": "old"],
+      incomingFiles: ["Frameworks/Foo/Headers/Shape/New.h": "new"]
+    )
+    defer { fixture.cleanup() }
+    let replacement = try fixture.prepareReplacement()
+
+    try fixture.store.applyReplacement(replacement)
+
+    #expect(try fixture.contents("Frameworks/Foo/Headers/Shape/New.h") == "new")
+    try fixture.store.finalizeReplacement(replacement)
+  }
+
+  @Test func replacementSupportsDirectoryToFileTransition() throws {
+    let fixture = try ReplacementFixture(
+      existingFiles: ["Frameworks/Foo/Headers/Shape/Old.h": "old"],
+      incomingFiles: ["Frameworks/Foo/Headers/Shape": "new"]
+    )
+    defer { fixture.cleanup() }
+    let replacement = try fixture.prepareReplacement()
+
+    try fixture.store.applyReplacement(replacement)
+
+    #expect(try fixture.contents("Frameworks/Foo/Headers/Shape") == "new")
+    try fixture.store.finalizeReplacement(replacement)
+  }
+
+  @Test func shapeTransitionFailureRestoresThePreviousFile() throws {
+    let fixture = try ReplacementFixture(
+      existingFiles: ["Frameworks/Foo/Headers/Shape": "old"],
+      incomingFiles: ["Frameworks/Foo/Headers/Shape/New.h": "new"]
+    )
+    defer { fixture.cleanup() }
+    let replacement = try fixture.prepareReplacement()
+    let fileManager = FailingOnceDirectoryCreationFileManager(
+      failingPath: fixture.liveURL("Frameworks/Foo/Headers/Shape").path
+    )
+
+    #expect(throws: InjectedReplacementFailure.self) {
+      try fixture.store.applyReplacement(replacement, fileManager: fileManager)
+    }
+
+    #expect(try fixture.contents("Frameworks/Foo/Headers/Shape") == "old")
+    try fixture.store.finalizeReplacement(replacement)
+  }
+
+  @Test func directoryToFileFailurePreservesUnknownSiblingAndPreviousFile() throws {
+    let fixture = try ReplacementFixture(
+      existingFiles: ["Frameworks/Foo/Headers/Shape/Old.h": "old"],
+      incomingFiles: ["Frameworks/Foo/Headers/Shape": "new"]
+    )
+    defer { fixture.cleanup() }
+    try "keep".write(
+      to: fixture.liveURL("Frameworks/Foo/Headers/Shape/Keep.txt"),
+      atomically: true,
+      encoding: .utf8
+    )
+    let replacement = try fixture.prepareReplacement()
+
+    #expect(throws: PrivateHeaderGeneration.ArtifactStoreError.self) {
+      try fixture.store.applyReplacement(replacement)
+    }
+
+    #expect(try fixture.contents("Frameworks/Foo/Headers/Shape/Old.h") == "old")
+    #expect(try fixture.contents("Frameworks/Foo/Headers/Shape/Keep.txt") == "keep")
+    try fixture.store.finalizeReplacement(replacement)
+  }
+
+  @Test func shapeTransitionCanRollbackAfterProcessRestart() throws {
+    let fixture = try ReplacementFixture(
+      existingFiles: ["Frameworks/Foo/Headers/Shape": "old"],
+      incomingFiles: ["Frameworks/Foo/Headers/Shape/New.h": "new"]
+    )
+    defer { fixture.cleanup() }
+    let replacement = try fixture.prepareReplacement()
+    try fixture.store.applyReplacement(replacement)
+
+    let recovered = try #require(
+      PrivateHeaderGeneration.ArtifactStore.pendingReplacements(
+        in: fixture.replacementsRoot,
+        artifactRoot: fixture.liveRoot
+      ).only
+    )
+    try fixture.store.rollbackReplacement(recovered)
+    try fixture.store.finalizeReplacement(recovered)
+
+    #expect(try fixture.contents("Frameworks/Foo/Headers/Shape") == "old")
+  }
+
+  @Test func rollbackRestoresArtifactsOutsideTheNewArtifactRoot() throws {
+    let fixture = try ReplacementFixture(
+      existingFiles: ["Frameworks/Foo/Headers/Old.h": "old"],
+      incomingFiles: ["Frameworks/Foo.framework/Headers/New.h": "new"],
+      artifactRoot: "Frameworks/Foo.framework"
+    )
+    defer { fixture.cleanup() }
+    let replacement = try fixture.prepareReplacement()
+    try fixture.store.applyReplacement(replacement)
+
+    try fixture.store.rollbackReplacement(replacement)
+
+    #expect(try fixture.contents("Frameworks/Foo/Headers/Old.h") == "old")
+    #expect(!FileManager.default.fileExists(
+      atPath: fixture.liveURL("Frameworks/Foo.framework/Headers/New.h").path
+    ))
+    try fixture.store.finalizeReplacement(replacement)
+  }
+
+  @Test func rollbackRestoresOpaqueFileClaimedByIncomingArtifact() throws {
+    let path = "Frameworks/Foo/Headers/Claimed.h"
+    let fixture = try ReplacementFixture(
+      existingFiles: [path: "opaque"],
+      incomingFiles: [path: "generated"]
+    )
+    defer { fixture.cleanup() }
+    let replacement = try fixture.prepareReplacement(removing: [])
+    try fixture.store.applyReplacement(replacement)
+
+    try fixture.store.rollbackReplacement(replacement)
+    try fixture.store.rollbackReplacement(replacement)
+
+    #expect(try fixture.contents(path) == "opaque")
+    try fixture.store.finalizeReplacement(replacement)
+  }
+
+  @Test func recoveryRejectsArtifactRootReplacedBySymlink() throws {
+    let fixture = try ReplacementFixture()
+    defer { fixture.cleanup() }
+    let replacement = try fixture.prepareReplacement()
+    try fixture.store.applyReplacement(replacement)
+    let externalRoot = fixture.root.appendingPathComponent("external", isDirectory: true)
+    try FileManager.default.createDirectory(
+      at: externalRoot,
+      withIntermediateDirectories: false
+    )
+    let sentinel = externalRoot.appendingPathComponent("sentinel")
+    try "keep".write(to: sentinel, atomically: true, encoding: .utf8)
+    try FileManager.default.removeItem(at: fixture.liveRoot)
+    try FileManager.default.createSymbolicLink(
+      at: fixture.liveRoot,
+      withDestinationURL: externalRoot
+    )
+
+    let recovered = try #require(
+      PrivateHeaderGeneration.ArtifactStore.pendingReplacements(
+        in: fixture.replacementsRoot,
+        artifactRoot: fixture.liveRoot
+      ).only
+    )
+    #expect(throws: PrivateHeaderGeneration.ArtifactStoreError.self) {
+      try fixture.store.rollbackReplacement(recovered)
+    }
+    #expect(try String(contentsOf: sentinel, encoding: .utf8) == "keep")
+  }
+
+  @Test func missingBackupFailsBeforeRollbackChangesLiveOutput() throws {
+    let fixture = try ReplacementFixture()
+    defer { fixture.cleanup() }
+    let replacement = try fixture.prepareReplacement()
+    try fixture.store.applyReplacement(replacement)
+    try FileManager.default.removeItem(
+      at: fixture.backupURL("Frameworks/Foo/Headers/Keep.h")
+    )
+
+    #expect(throws: PrivateHeaderGeneration.ArtifactStoreError.self) {
+      try fixture.store.rollbackReplacement(replacement)
+    }
+
+    #expect(try fixture.contents("Frameworks/Foo/Headers/Keep.h") == "new-keep")
+    #expect(try fixture.contents("Frameworks/Foo/Headers/New.h") == "new")
+  }
+
+  @Test func finalizeDisarmsManifestBeforeRecursiveCleanup() throws {
+    let fixture = try ReplacementFixture()
+    defer { fixture.cleanup() }
+    let replacement = try fixture.prepareReplacement()
+    let fileManager = FailingOnceRemovalFileManager(
+      failingPath: fixture.transactionDirectory.path
+    )
+
+    #expect(throws: InjectedReplacementFailure.self) {
+      try fixture.store.finalizeReplacement(replacement, fileManager: fileManager)
+    }
+
+    #expect(try PrivateHeaderGeneration.ArtifactStore.pendingReplacements(
+      in: fixture.replacementsRoot,
+      artifactRoot: fixture.liveRoot
+    ).isEmpty)
+  }
+
+  @Test func rollbackPreservesUnknownDestinationCreatedAfterPreparation() throws {
+    let fixture = try ReplacementFixture()
+    defer { fixture.cleanup() }
+    let replacement = try fixture.prepareReplacement()
+    try "unknown".write(
+      to: fixture.liveURL("Frameworks/Foo/Headers/New.h"),
+      atomically: true,
+      encoding: .utf8
+    )
+
+    try fixture.store.rollbackReplacement(replacement)
+
+    #expect(try fixture.contents("Frameworks/Foo/Headers/New.h") == "unknown")
+    #expect(try fixture.contents("Frameworks/Foo/Headers/Keep.h") == "old-keep")
+    #expect(try fixture.contents("Frameworks/Foo/Headers/Removed.h") == "old-removed")
+    try fixture.store.finalizeReplacement(replacement)
+  }
+
+  @Test func applyRejectsUnknownDestinationCreatedAfterPreparation() throws {
+    let fixture = try ReplacementFixture()
+    defer { fixture.cleanup() }
+    let replacement = try fixture.prepareReplacement()
+    try "unknown".write(
+      to: fixture.liveURL("Frameworks/Foo/Headers/New.h"),
+      atomically: true,
+      encoding: .utf8
+    )
+
+    #expect(throws: PrivateHeaderGeneration.ArtifactStoreError.self) {
+      try fixture.store.applyReplacement(replacement)
+    }
+
+    #expect(try fixture.contents("Frameworks/Foo/Headers/New.h") == "unknown")
+    #expect(try fixture.contents("Frameworks/Foo/Headers/Keep.h") == "old-keep")
+    #expect(try fixture.contents("Frameworks/Foo/Headers/Removed.h") == "old-removed")
+    try fixture.store.finalizeReplacement(replacement)
+  }
+
+  @Test func applyRejectsOldOnlyFileCreatedAfterPreparation() throws {
+    let fixture = try ReplacementFixture()
+    defer { fixture.cleanup() }
+    let oldOnly = try PrivateHeaderGeneration.ArtifactPath(
+      "Frameworks/Foo/Headers/OldOnly.h"
+    )
+    _ = try fixture.prepareReplacement(removing: fixture.existingArtifacts + [oldOnly])
+    try "unknown".write(
+      to: fixture.liveURL(oldOnly.rawValue),
+      atomically: true,
+      encoding: .utf8
+    )
+    let replacement = try #require(
+      PrivateHeaderGeneration.ArtifactStore.pendingReplacements(
+        in: fixture.replacementsRoot,
+        artifactRoot: fixture.liveRoot
+      ).only
+    )
+
+    #expect(throws: PrivateHeaderGeneration.ArtifactStoreError.self) {
+      try fixture.store.applyReplacement(replacement)
+    }
+
+    #expect(try fixture.contents(oldOnly.rawValue) == "unknown")
+    #expect(try fixture.contents("Frameworks/Foo/Headers/Keep.h") == "old-keep")
+    #expect(try fixture.contents("Frameworks/Foo/Headers/Removed.h") == "old-removed")
+    #expect(!FileManager.default.fileExists(
+      atPath: fixture.liveURL("Frameworks/Foo/Headers/New.h").path
+    ))
+    try fixture.store.finalizeReplacement(replacement)
+  }
+
+  @Test func applyRejectsOldOnlyDirectoryCreatedAfterPreparation() throws {
+    let fixture = try ReplacementFixture()
+    defer { fixture.cleanup() }
+    let oldOnly = try PrivateHeaderGeneration.ArtifactPath(
+      "Frameworks/Foo/Headers/OldOnly.h"
+    )
+    let replacement = try fixture.prepareReplacement(
+      removing: fixture.existingArtifacts + [oldOnly]
+    )
+    try FileManager.default.createDirectory(
+      at: fixture.liveURL(oldOnly.rawValue),
+      withIntermediateDirectories: false
+    )
+
+    #expect(throws: PrivateHeaderGeneration.ArtifactStoreError.self) {
+      try fixture.store.applyReplacement(replacement)
+    }
+
+    var isDirectory: ObjCBool = false
+    #expect(FileManager.default.fileExists(
+      atPath: fixture.liveURL(oldOnly.rawValue).path,
+      isDirectory: &isDirectory
+    ))
+    #expect(isDirectory.boolValue)
+    #expect(try fixture.contents("Frameworks/Foo/Headers/Keep.h") == "old-keep")
+    #expect(try fixture.contents("Frameworks/Foo/Headers/Removed.h") == "old-removed")
+    #expect(!FileManager.default.fileExists(
+      atPath: fixture.liveURL("Frameworks/Foo/Headers/New.h").path
+    ))
+    try fixture.store.finalizeReplacement(replacement)
+  }
+
+  @Test func replacementSupportsCaseOnlyPathTransition() throws {
+    let fixture = try ReplacementFixture(
+      existingFiles: ["Frameworks/Foo/Headers/Case.h": "old"],
+      incomingFiles: ["Frameworks/Foo/Headers/case.h": "new"]
+    )
+    defer { fixture.cleanup() }
+    let replacement = try fixture.prepareReplacement()
+
+    try fixture.store.applyReplacement(replacement)
+    #expect(try fixture.contents("Frameworks/Foo/Headers/case.h") == "new")
+    try fixture.store.rollbackReplacement(replacement)
+
+    #expect(try fixture.contents("Frameworks/Foo/Headers/Case.h") == "old")
+    try fixture.store.finalizeReplacement(replacement)
+  }
+
+  @Test func rollbackBeforeApplyPreservesAnExistingEmptyDirectory() throws {
+    let fixture = try ReplacementFixture(
+      existingFiles: ["Frameworks/Foo/Headers/Old.h": "old"],
+      incomingFiles: ["Frameworks/Foo/Headers/NewDir/New.h": "new"]
+    )
+    defer { fixture.cleanup() }
+    let replacement = try fixture.prepareReplacement()
+    let createdDirectory = fixture.liveURL("Frameworks/Foo/Headers/NewDir")
+    try FileManager.default.createDirectory(
+      at: createdDirectory,
+      withIntermediateDirectories: true
+    )
+
+    try fixture.store.rollbackReplacement(replacement)
+
+    #expect(FileManager.default.fileExists(atPath: createdDirectory.path))
+    #expect(try fixture.contents("Frameworks/Foo/Headers/Old.h") == "old")
+    try fixture.store.finalizeReplacement(replacement)
+  }
+
+  @Test func replacementSupportsCaseAliasedFileToDirectoryTransition() throws {
+    let fixture = try ReplacementFixture(
+      existingFiles: ["Frameworks/Foo/Headers/Shape": "old"],
+      incomingFiles: ["Frameworks/Foo/headers/shape/New.h": "new"]
+    )
+    defer { fixture.cleanup() }
+    let replacement = try fixture.prepareReplacement()
+
+    try fixture.store.applyReplacement(replacement)
+    #expect(try fixture.contents("Frameworks/Foo/headers/shape/New.h") == "new")
+    try fixture.store.rollbackReplacement(replacement)
+
+    #expect(try fixture.contents("Frameworks/Foo/Headers/Shape") == "old")
+    try fixture.store.finalizeReplacement(replacement)
+  }
+
+  @Test func applyRejectsAChangedBackedUpLiveFileWithoutMutatingOutput() throws {
+    let fixture = try ReplacementFixture()
+    defer { fixture.cleanup() }
+    let replacement = try fixture.prepareReplacement()
+    try "user-edit".write(
+      to: fixture.liveURL("Frameworks/Foo/Headers/Keep.h"),
+      atomically: true,
+      encoding: .utf8
+    )
+
+    #expect(throws: PrivateHeaderGeneration.ArtifactStoreError.self) {
+      try fixture.store.applyReplacement(replacement)
+    }
+    try fixture.store.rollbackReplacement(replacement)
+
+    #expect(try fixture.contents("Frameworks/Foo/Headers/Keep.h") == "user-edit")
+    #expect(try fixture.contents("Frameworks/Foo/Headers/Removed.h") == "old-removed")
+    #expect(!FileManager.default.fileExists(
+      atPath: fixture.liveURL("Frameworks/Foo/Headers/New.h").path
+    ))
+    try fixture.store.finalizeReplacement(replacement)
+  }
+
+  @Test func rollbackRejectsAChangedInstalledFileBeforeMutatingOtherArtifacts() throws {
+    let fixture = try ReplacementFixture()
+    defer { fixture.cleanup() }
+    let replacement = try fixture.prepareReplacement()
+    try fixture.store.applyReplacement(replacement)
+    try "user-edit".write(
+      to: fixture.liveURL("Frameworks/Foo/Headers/New.h"),
+      atomically: true,
+      encoding: .utf8
+    )
+
+    #expect(throws: PrivateHeaderGeneration.ArtifactStoreError.self) {
+      try fixture.store.rollbackReplacement(replacement)
+    }
+
+    #expect(try fixture.contents("Frameworks/Foo/Headers/Keep.h") == "new-keep")
+    #expect(try fixture.contents("Frameworks/Foo/Headers/New.h") == "user-edit")
+    #expect(!FileManager.default.fileExists(
+      atPath: fixture.liveURL("Frameworks/Foo/Headers/Removed.h").path
+    ))
+  }
+
+  @Test func rollbackRejectsATamperedBackupBeforeMutatingLiveOutput() throws {
+    let fixture = try ReplacementFixture()
+    defer { fixture.cleanup() }
+    let replacement = try fixture.prepareReplacement()
+    try fixture.store.applyReplacement(replacement)
+    try "tampered".write(
+      to: fixture.backupURL("Frameworks/Foo/Headers/Keep.h"),
+      atomically: true,
+      encoding: .utf8
+    )
+
+    #expect(throws: PrivateHeaderGeneration.ArtifactStoreError.self) {
+      try fixture.store.rollbackReplacement(replacement)
+    }
+
+    #expect(try fixture.contents("Frameworks/Foo/Headers/Keep.h") == "new-keep")
+    #expect(try fixture.contents("Frameworks/Foo/Headers/New.h") == "new")
+  }
+
+  @Test func rollbackRejectsALateSymlinkBeforeDeletingEarlierIncomingFiles() throws {
+    let fixture = try ReplacementFixture()
+    defer { fixture.cleanup() }
+    let replacement = try fixture.prepareReplacement()
+    try fixture.store.applyReplacement(replacement)
+    let external = fixture.root.appendingPathComponent("external")
+    try "external".write(to: external, atomically: true, encoding: .utf8)
+    try FileManager.default.removeItem(
+      at: fixture.liveURL("Frameworks/Foo/Headers/New.h")
+    )
+    try FileManager.default.createSymbolicLink(
+      at: fixture.liveURL("Frameworks/Foo/Headers/New.h"),
+      withDestinationURL: external
+    )
+
+    #expect(throws: PrivateHeaderGeneration.ArtifactStoreError.self) {
+      try fixture.store.rollbackReplacement(replacement)
+    }
+
+    #expect(try fixture.contents("Frameworks/Foo/Headers/Keep.h") == "new-keep")
+    #expect(
+      try FileManager.default.destinationOfSymbolicLink(
+        atPath: fixture.liveURL("Frameworks/Foo/Headers/New.h").path
+      ) == external.path
+    )
+  }
+
+  @Test func rollbackRejectsUnknownSiblingBeforeRemovingInstalledShapeContents() throws {
+    let fixture = try ReplacementFixture(
+      existingFiles: ["Frameworks/Foo/Headers/Shape": "old"],
+      incomingFiles: ["Frameworks/Foo/Headers/Shape/New.h": "new"]
+    )
+    defer { fixture.cleanup() }
+    let replacement = try fixture.prepareReplacement()
+    try fixture.store.applyReplacement(replacement)
+    try "unknown".write(
+      to: fixture.liveURL("Frameworks/Foo/Headers/Shape/Keep.txt"),
+      atomically: true,
+      encoding: .utf8
+    )
+
+    #expect(throws: PrivateHeaderGeneration.ArtifactStoreError.self) {
+      try fixture.store.rollbackReplacement(replacement)
+    }
+
+    #expect(try fixture.contents("Frameworks/Foo/Headers/Shape/New.h") == "new")
+    #expect(try fixture.contents("Frameworks/Foo/Headers/Shape/Keep.txt") == "unknown")
+  }
+
+  @Test func applyRejectsArtifactRootReplacedByAnotherDirectory() throws {
+    let fixture = try ReplacementFixture()
+    defer { fixture.cleanup() }
+    let replacement = try fixture.prepareReplacement()
+    let originalRoot = fixture.root.appendingPathComponent("live-original", isDirectory: true)
+    try FileManager.default.moveItem(at: fixture.liveRoot, to: originalRoot)
+    try FileManager.default.createDirectory(
+      at: fixture.liveRoot,
+      withIntermediateDirectories: false
+    )
+    let sentinel = fixture.liveRoot.appendingPathComponent("sentinel")
+    try "keep".write(to: sentinel, atomically: true, encoding: .utf8)
+
+    #expect(throws: PrivateHeaderGeneration.ArtifactStoreError.self) {
+      try fixture.store.applyReplacement(replacement)
+    }
+
+    #expect(try String(contentsOf: sentinel, encoding: .utf8) == "keep")
+    #expect(
+      try String(
+        contentsOf: originalRoot.appendingPathComponent("Frameworks/Foo/Headers/Keep.h"),
+        encoding: .utf8
+      ) == "old-keep"
+    )
+  }
+
+  @Test func rollbackRejectsArtifactRootReplacedByAnotherDirectory() throws {
+    let fixture = try ReplacementFixture()
+    defer { fixture.cleanup() }
+    let replacement = try fixture.prepareReplacement()
+    try fixture.store.applyReplacement(replacement)
+    let appliedRoot = fixture.root.appendingPathComponent("live-applied", isDirectory: true)
+    try FileManager.default.moveItem(at: fixture.liveRoot, to: appliedRoot)
+    try FileManager.default.createDirectory(
+      at: fixture.liveRoot,
+      withIntermediateDirectories: false
+    )
+    let sentinel = fixture.liveRoot.appendingPathComponent("sentinel")
+    try "keep".write(to: sentinel, atomically: true, encoding: .utf8)
+
+    #expect(throws: PrivateHeaderGeneration.ArtifactStoreError.self) {
+      try fixture.store.rollbackReplacement(replacement)
+    }
+
+    #expect(try String(contentsOf: sentinel, encoding: .utf8) == "keep")
+    #expect(
+      try String(
+        contentsOf: appliedRoot.appendingPathComponent("Frameworks/Foo/Headers/Keep.h"),
+        encoding: .utf8
+      ) == "new-keep"
+    )
+  }
+
+  @Test func unstartedReplacementCanBeDiscardedAfterRootAndStagingChanges() throws {
+    let fixture = try ReplacementFixture()
+    defer { fixture.cleanup() }
+    _ = try fixture.prepareReplacement()
+    try FileManager.default.removeItem(at: fixture.liveRoot)
+    try FileManager.default.createDirectory(
+      at: fixture.liveRoot,
+      withIntermediateDirectories: false
+    )
+    let sentinel = fixture.liveRoot.appendingPathComponent("sentinel")
+    try "keep".write(to: sentinel, atomically: true, encoding: .utf8)
+    try FileManager.default.removeItem(
+      at: fixture.transactionDirectory.appendingPathComponent("incoming", isDirectory: true)
+    )
+
+    let recovered = try #require(
+      PrivateHeaderGeneration.ArtifactStore.pendingReplacements(
+        in: fixture.replacementsRoot,
+        artifactRoot: fixture.liveRoot
+      ).only
+    )
+    try fixture.store.rollbackReplacement(recovered)
+    try fixture.store.finalizeReplacement(recovered)
+
+    #expect(try String(contentsOf: sentinel, encoding: .utf8) == "keep")
+  }
+
+  @Test func rollbackResumesAfterOneBackupWasAlreadyRestored() throws {
+    let fixture = try ReplacementFixture()
+    defer { fixture.cleanup() }
+    let replacement = try fixture.prepareReplacement()
+    try fixture.store.applyReplacement(replacement)
+    try FileManager.default.removeItem(
+      at: fixture.liveURL("Frameworks/Foo/Headers/Keep.h")
+    )
+    try FileManager.default.removeItem(
+      at: fixture.liveURL("Frameworks/Foo/Headers/New.h")
+    )
+    try FileManager.default.copyItem(
+      at: fixture.backupURL("Frameworks/Foo/Headers/Keep.h"),
+      to: fixture.liveURL("Frameworks/Foo/Headers/Keep.h")
+    )
+
+    try fixture.store.rollbackReplacement(replacement)
+
+    #expect(try fixture.contents("Frameworks/Foo/Headers/Keep.h") == "old-keep")
+    #expect(try fixture.contents("Frameworks/Foo/Headers/Removed.h") == "old-removed")
+    #expect(!FileManager.default.fileExists(
+      atPath: fixture.liveURL("Frameworks/Foo/Headers/New.h").path
+    ))
+    try fixture.store.finalizeReplacement(replacement)
+  }
+
+  @Test func rollbackRestoresAnUnchangedArtifactWithMatchingIncomingDigest() throws {
+    let path = "Frameworks/Foo/Headers/Keep.h"
+    let fixture = try ReplacementFixture(
+      existingFiles: [path: "same"],
+      incomingFiles: [path: "same"]
+    )
+    defer { fixture.cleanup() }
+    let replacement = try fixture.prepareReplacement()
+    try fixture.store.applyReplacement(replacement)
+    let recovered = try #require(
+      PrivateHeaderGeneration.ArtifactStore.pendingReplacements(
+        in: fixture.replacementsRoot,
+        artifactRoot: fixture.liveRoot
+      ).only
+    )
+
+    try fixture.store.rollbackReplacement(recovered)
+
+    #expect(try fixture.contents(path) == "same")
+    try fixture.store.finalizeReplacement(recovered)
+  }
+
+  @Test func rollbackRejectsTamperedDurableRestoreWithoutMutatingLiveOutput() throws {
+    let fixture = try ReplacementFixture()
+    defer { fixture.cleanup() }
+    let replacement = try fixture.prepareReplacement()
+    try fixture.store.applyReplacement(replacement)
+    let partialRestore = fixture.transactionDirectory.appendingPathComponent(
+      "restore/Frameworks/Foo/Headers/Keep.h"
+    )
+    try FileManager.default.createDirectory(
+      at: partialRestore.deletingLastPathComponent(),
+      withIntermediateDirectories: true
+    )
+    try "partial".write(to: partialRestore, atomically: true, encoding: .utf8)
+
+    #expect(throws: PrivateHeaderGeneration.ArtifactStoreError.self) {
+      try fixture.store.rollbackReplacement(replacement)
+    }
+
+    #expect(try fixture.contents("Frameworks/Foo/Headers/Keep.h") == "new-keep")
+    #expect(try fixture.contents("Frameworks/Foo/Headers/New.h") == "new")
+    #expect(!FileManager.default.fileExists(
+      atPath: fixture.liveURL("Frameworks/Foo/Headers/Removed.h").path
+    ))
+  }
+
+  @Test func restorePayloadCopyFailureLeavesLiveOutputUntouchedAndUnarmed() throws {
+    let fixture = try ReplacementFixture()
+    defer { fixture.cleanup() }
+    let fileManager = FailingOnceRestoreCopyFileManager()
+
+    #expect(throws: InjectedReplacementFailure.self) {
+      _ = try fixture.prepareReplacement(fileManager: fileManager)
+    }
+
+    #expect(try fixture.contents("Frameworks/Foo/Headers/Keep.h") == "old-keep")
+    #expect(try fixture.contents("Frameworks/Foo/Headers/Removed.h") == "old-removed")
+    #expect(!FileManager.default.fileExists(
+      atPath: fixture.liveURL("Frameworks/Foo/Headers/New.h").path
+    ))
+    #expect(!FileManager.default.fileExists(atPath: fixture.transactionDirectory.path))
+  }
+
+  @Test func replacementRejectsCrossVolumeTransactionBeforeMutatingLiveOutput() throws {
+    let fixture = try ReplacementFixture()
+    defer { fixture.cleanup() }
+    let fileManager = DifferentTransactionDeviceFileManager()
+
+    #expect(throws: PrivateHeaderGeneration.ArtifactStoreError.self) {
+      _ = try fixture.prepareReplacement(fileManager: fileManager)
+    }
+
+    #expect(try fixture.contents("Frameworks/Foo/Headers/Keep.h") == "old-keep")
+    #expect(try fixture.contents("Frameworks/Foo/Headers/Removed.h") == "old-removed")
+    #expect(!FileManager.default.fileExists(
+      atPath: fixture.liveURL("Frameworks/Foo/Headers/New.h").path
+    ))
+    #expect(!FileManager.default.fileExists(atPath: fixture.transactionDirectory.path))
+  }
+
+  @Test func replacementRejectsMissingExclusiveRenameBeforeMutatingLiveOutput() throws {
+    let fixture = try ReplacementFixture()
+    defer { fixture.cleanup() }
+
+    #expect(throws: InjectedReplacementFailure.self) {
+      _ = try fixture.prepareReplacement(exclusiveRename: { _, _ in
+        throw InjectedReplacementFailure.stop
+      })
+    }
+
+    #expect(try fixture.contents("Frameworks/Foo/Headers/Keep.h") == "old-keep")
+    #expect(try fixture.contents("Frameworks/Foo/Headers/Removed.h") == "old-removed")
+    #expect(!FileManager.default.fileExists(
+      atPath: fixture.liveURL("Frameworks/Foo/Headers/New.h").path
+    ))
+    #expect(!FileManager.default.fileExists(atPath: fixture.transactionDirectory.path))
+  }
 }
 
 private struct ReplacementFixture {
@@ -55,8 +758,27 @@ private struct ReplacementFixture {
   let stagingRoot: URL
   let replacementsRoot: URL
   let store: PrivateHeaderGeneration.ArtifactStore
+  let existingArtifacts: [PrivateHeaderGeneration.ArtifactPath]
+  let incomingArtifacts: [PrivateHeaderGeneration.ArtifactPath]
+  let artifactRoot: PrivateHeaderGeneration.ArtifactPath
 
-  init() throws {
+  var transactionDirectory: URL {
+    replacementsRoot
+      .appendingPathComponent("run-replacement", isDirectory: true)
+      .appendingPathComponent("framework%3AFoo.framework", isDirectory: true)
+  }
+
+  init(
+    existingFiles: [String: String] = [
+      "Frameworks/Foo/Headers/Keep.h": "old-keep",
+      "Frameworks/Foo/Headers/Removed.h": "old-removed",
+    ],
+    incomingFiles: [String: String] = [
+      "Frameworks/Foo/Headers/Keep.h": "new-keep",
+      "Frameworks/Foo/Headers/New.h": "new",
+    ],
+    artifactRoot: String = "Frameworks/Foo"
+  ) throws {
     root = FileManager.default.temporaryDirectory.appendingPathComponent(
       "PrivateHeaderGenerationArtifactReplacementTests-\(UUID().uuidString)",
       isDirectory: true
@@ -65,37 +787,56 @@ private struct ReplacementFixture {
     stagingRoot = root.appendingPathComponent("staging", isDirectory: true)
     replacementsRoot = root.appendingPathComponent("replacements", isDirectory: true)
     store = PrivateHeaderGeneration.ArtifactStore(artifactRoot: liveRoot)
-    try write("old-keep", to: liveURL("Frameworks/Foo/Headers/Keep.h"))
-    try write("old-removed", to: liveURL("Frameworks/Foo/Headers/Removed.h"))
-    try write("new-keep", to: stagingRoot.appendingPathComponent("output/Headers/Keep.h"))
-    try write("new", to: stagingRoot.appendingPathComponent("output/Headers/New.h"))
+    existingArtifacts = try existingFiles.keys.map {
+      try PrivateHeaderGeneration.ArtifactPath($0)
+    }
+    incomingArtifacts = try incomingFiles.keys.map {
+      try PrivateHeaderGeneration.ArtifactPath($0)
+    }
+    self.artifactRoot = try PrivateHeaderGeneration.ArtifactPath(artifactRoot)
+    for (path, contents) in existingFiles {
+      try write(contents, to: liveURL(path))
+    }
+    for (path, contents) in incomingFiles {
+      let relativePath = try #require(path.removingPrefix("\(artifactRoot)/"))
+      try write(contents, to: stagingRoot.appendingPathComponent("output/\(relativePath)"))
+    }
   }
 
-  func prepareReplacement() throws -> PrivateHeaderGeneration.ArtifactStore.Replacement {
-    let artifactRoot = try PrivateHeaderGeneration.ArtifactPath("Frameworks/Foo")
-    let incoming = try [
-      PrivateHeaderGeneration.ArtifactPath("Frameworks/Foo/Headers/Keep.h"),
-      PrivateHeaderGeneration.ArtifactPath("Frameworks/Foo/Headers/New.h"),
-    ]
-    let removing = try [
-      PrivateHeaderGeneration.ArtifactPath("Frameworks/Foo/Headers/Keep.h"),
-      PrivateHeaderGeneration.ArtifactPath("Frameworks/Foo/Headers/Removed.h"),
-    ]
-    let plan = try store.prepareCommit(
+  func prepareReplacement(
+    removing: [PrivateHeaderGeneration.ArtifactPath]? = nil,
+    fileManager: FileManager = .default,
+    exclusiveRename: (URL, URL) throws -> Void = ManagedFileSystem.atomicRenameExclusively
+  ) throws -> PrivateHeaderGeneration.ArtifactStore.Replacement {
+    return try store.prepareReplacement(
       stagingDirectory: stagingRoot,
       stagedSourceDirectory: stagingRoot.appendingPathComponent("output", isDirectory: true),
       artifactRoot: artifactRoot,
-      artifacts: incoming
-    )
-    return try store.prepareReplacement(
-      plan,
-      removing: removing,
+      artifacts: incomingArtifacts,
+      removing: removing ?? existingArtifacts,
       runID: .init(rawValue: "run-replacement"),
       targetID: "framework:Foo.framework",
-      at: replacementsRoot
-        .appendingPathComponent("run-replacement", isDirectory: true)
-        .appendingPathComponent("framework%3AFoo.framework", isDirectory: true)
+      at: transactionDirectory,
+      fileManager: fileManager,
+      exclusiveRename: exclusiveRename
     )
+  }
+
+  func backupURL(_ relativePath: String) -> URL {
+    transactionDirectory
+      .appendingPathComponent("backup", isDirectory: true)
+      .appendingPathComponent(relativePath)
+  }
+
+  func rewriteManifest(_ mutation: (inout [String: Any]) -> Void) throws {
+    let manifestURL = transactionDirectory.appendingPathComponent("manifest.json")
+    var manifest = try #require(
+      try JSONSerialization.jsonObject(with: Data(contentsOf: manifestURL))
+        as? [String: Any]
+    )
+    mutation(&manifest)
+    try JSONSerialization.data(withJSONObject: manifest, options: [.sortedKeys])
+      .write(to: manifestURL, options: .atomic)
   }
 
   func liveURL(_ relativePath: String) -> URL {
@@ -138,6 +879,67 @@ private final class FailingOnceRemovalFileManager: FileManager, @unchecked Senda
       throw InjectedReplacementFailure.stop
     }
     try super.removeItem(at: URL)
+  }
+}
+
+private final class FailingOnceDirectoryCreationFileManager: FileManager, @unchecked Sendable {
+  private let failingPath: String
+  private var hasFailed = false
+
+  init(failingPath: String) {
+    self.failingPath = failingPath
+    super.init()
+  }
+
+  override func createDirectory(
+    at url: URL,
+    withIntermediateDirectories createIntermediates: Bool,
+    attributes: [FileAttributeKey: Any]? = nil
+  ) throws {
+    if url.path == failingPath, !hasFailed {
+      hasFailed = true
+      throw InjectedReplacementFailure.stop
+    }
+    try super.createDirectory(
+      at: url,
+      withIntermediateDirectories: createIntermediates,
+      attributes: attributes
+    )
+  }
+}
+
+private final class FailingOnceRestoreCopyFileManager: FileManager, @unchecked Sendable {
+  private var hasFailed = false
+
+  override func copyItem(at sourceURL: URL, to destinationURL: URL) throws {
+    if destinationURL.path.contains("/restore/"), !hasFailed {
+      hasFailed = true
+      try super.createDirectory(
+        at: destinationURL.deletingLastPathComponent(),
+        withIntermediateDirectories: true
+      )
+      try "partial".write(to: destinationURL, atomically: true, encoding: .utf8)
+      throw InjectedReplacementFailure.stop
+    }
+    try super.copyItem(at: sourceURL, to: destinationURL)
+  }
+}
+
+private final class DifferentTransactionDeviceFileManager: FileManager, @unchecked Sendable {
+  override func attributesOfItem(atPath path: String) throws -> [FileAttributeKey: Any] {
+    var attributes = try super.attributesOfItem(atPath: path)
+    if path.contains("/incoming") || path.contains("/restore") {
+      let current = (attributes[.systemNumber] as? NSNumber)?.uint64Value ?? 0
+      attributes[.systemNumber] = NSNumber(value: current &+ 1)
+    }
+    return attributes
+  }
+}
+
+private extension String {
+  func removingPrefix(_ prefix: String) -> String? {
+    guard hasPrefix(prefix) else { return nil }
+    return String(dropFirst(prefix.count))
   }
 }
 

--- a/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationExecutorTests.swift
+++ b/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationExecutorTests.swift
@@ -118,7 +118,8 @@ struct PrivateHeaderGenerationExecutorTests {
     #expect(!FileManager.default.fileExists(atPath: fixture.outputBase.path))
   }
 
-  @Test func preparedPlanCanChangeOnlyInteractiveResumeBehaviorWithoutReloadingCohort() async throws {
+  @Test func preparedPlanCanChangeOnlyInteractiveResumeBehaviorWithoutReloadingCohort() async throws
+  {
     let fixture = try ExecutorFixture()
     defer { fixture.cleanup() }
     try fixture.createFramework("Foo.framework")
@@ -251,15 +252,136 @@ struct PrivateHeaderGenerationExecutorTests {
     #expect(result.generatedTargets.map(\.identifier) == ["framework:Foo.framework"])
     #expect(result.targetCounts.completed == 1)
     #expect(result.warnings.isEmpty)
+    #expect(result.artifactDirectory == fixture.liveURL)
+    #expect(try fixture.readLiveHeader() == "first")
     #expect(try fixture.readStableHeader() == "first")
     let publisher = try fixture.publisher()
     let publication = try publisher.inspect()
     #expect(publication.currentGenerationID == .init(rawValue: "generation-001"))
-    let store = try GenerationStore(databaseURL: result.stateDatabaseURL, toolCompatibilityIdentity: "test")
+    let store = try GenerationStore(
+      databaseURL: result.stateDatabaseURL, toolCompatibilityIdentity: "test")
     #expect(try await store.runSnapshot(result.runID).status == .completed)
     #expect(
       try await store.targetSnapshot(targetID: "framework:Foo.framework")?.lastSuccessfulRunID
         == result.runID)
+  }
+
+  @Test func completedTargetIsVisibleWhenItsFinishedEventIsReported() async throws {
+    let fixture = try ExecutorFixture()
+    defer { fixture.cleanup() }
+    try fixture.createFramework("Foo.framework")
+    try fixture.createFramework("Bar.framework")
+    let observation = LiveArtifactObservation()
+
+    _ = try await fixture.executor(
+      runner: RecordingRunner(contents: "generated"),
+      runID: "run-visible",
+      generationID: "generation-visible"
+    ).run(
+      plan: try fixture.plan(
+        .identifiers(["framework:Foo.framework", "framework:Bar.framework"])
+      ),
+      progressReporter: { event in
+        if case .targetFinished(_, _, "Foo", .completed, _) = event {
+          observation.observe(fixture.liveHeaderURL(framework: "Foo"))
+        }
+      }
+    )
+
+    #expect(observation.contents == "generated")
+    #expect(observation.errorDescription == nil)
+  }
+
+  @Test func laterInfrastructureFailureKeepsCompletedTargetVisibleAndResumeSkipsIt()
+    async throws
+  {
+    let fixture = try ExecutorFixture()
+    defer { fixture.cleanup() }
+    try fixture.createFramework("Foo.framework")
+    try fixture.createFramework("Bar.framework")
+    let plan = try fixture.plan(
+      .identifiers(["framework:Foo.framework", "framework:Bar.framework"]),
+      resumeBehavior: .resume
+    )
+
+    do {
+      _ = try await fixture.executor(
+        runner: RecordingRunner(
+          contents: "first-run",
+          hiddenPayloadFramework: "Bar.framework"
+        ),
+        runID: "run-partial",
+        generationID: "generation-partial"
+      ).run(plan: plan)
+      Issue.record("invalid second target unexpectedly completed")
+    } catch let PrivateHeaderGeneration.GenerationError.infrastructureFailed(failure) {
+      #expect(failure.summary.targetCounts.completed == 1)
+      #expect(failure.summary.targetCounts.failed == 1)
+      #expect(failure.summary.targetFailures.map(\.displayName) == ["Bar"])
+    }
+
+    #expect(try fixture.readLiveHeader(framework: "Foo") == "first-run")
+    #expect(!FileManager.default.fileExists(atPath: fixture.liveHeaderURL(framework: "Bar").path))
+    let firstStore = try GenerationStore(
+      databaseURL: fixture.databaseURL,
+      toolCompatibilityIdentity: "test"
+    )
+    #expect(
+      try await firstStore.targetSnapshot(targetID: "framework:Foo.framework")?
+        .lastSuccessfulRunID == .init(rawValue: "run-partial")
+    )
+
+    let resumedRunner = RecordingRunner(contents: "resumed")
+    let result = try await fixture.executor(
+      runner: resumedRunner,
+      runID: "run-resumed",
+      generationID: "generation-resumed"
+    ).run(plan: plan)
+
+    #expect(await resumedRunner.invocationCount == 1)
+    #expect(await resumedRunner.invocations.first?.inputPath.hasSuffix("/Bar.framework") == true)
+    #expect(result.targetCounts.skipped == 1)
+    #expect(result.targetCounts.completed == 1)
+    #expect(try fixture.readLiveHeader(framework: "Foo") == "first-run")
+    #expect(try fixture.readLiveHeader(framework: "Bar") == "resumed")
+    #expect(try fixture.readStableHeader(framework: "Foo") == "first-run")
+    #expect(try fixture.readStableHeader(framework: "Bar") == "resumed")
+  }
+
+  @Test func resumeRemovesAttemptedOrphansAfterCrashBetweenLiveCopyAndDatabaseCommit()
+    async throws
+  {
+    let fixture = try ExecutorFixture()
+    defer { fixture.cleanup() }
+    try fixture.createFramework("Foo.framework")
+    let plan = try fixture.plan(.query("Foo"), resumeBehavior: .resume)
+
+    await #expect(throws: InjectedFault.self) {
+      _ = try await fixture.executor(
+        runner: RecordingRunner(contents: "first", additionalHeaderName: "Stale.h"),
+        runID: "run-crashed",
+        generationID: "generation-crashed",
+        storeFaultInjector: { point in
+          if point == .afterRunTargetWrite { throw InjectedFault.stop }
+        }
+      ).run(plan: plan)
+    }
+    let staleHeader = fixture.liveURL.appendingPathComponent(
+      "Frameworks/Foo/Headers/Stale.h"
+    )
+    #expect(FileManager.default.fileExists(atPath: staleHeader.path))
+    try FileManager.default.removeItem(at: fixture.liveHeaderURL())
+
+    let resumedRunner = RecordingRunner(contents: "second")
+    _ = try await fixture.executor(
+      runner: resumedRunner,
+      runID: "run-recovered",
+      generationID: "generation-recovered"
+    ).run(plan: plan)
+
+    #expect(await resumedRunner.invocationCount == 1)
+    #expect(try fixture.readLiveHeader() == "second")
+    #expect(!FileManager.default.fileExists(atPath: staleHeader.path))
   }
 
   @Test func compatibleResumeSkipsCurrentCompletedTarget() async throws {
@@ -313,14 +435,16 @@ struct PrivateHeaderGenerationExecutorTests {
       #expect(failure.summary.runID == .init(rawValue: "run-002"))
       #expect(failure.summary.status == .partial)
       #expect(failure.summary.targetCounts.partial == 1)
-      #expect(failure.summary.artifactDirectory == fixture.stableURL)
+      #expect(failure.summary.artifactDirectory == fixture.liveURL)
       #expect(failure.summary.stateDatabaseURL == fixture.databaseURL)
       #expect(failure.failedTargetIDs == ["framework:Foo.framework"])
     }
 
     #expect(try fixture.publisher().inspect().currentGenerationID == oldCurrent)
+    #expect(try fixture.readLiveHeader() == "old")
     #expect(try fixture.readStableHeader() == "old")
-    let store = try GenerationStore(databaseURL: fixture.databaseURL, toolCompatibilityIdentity: "test")
+    let store = try GenerationStore(
+      databaseURL: fixture.databaseURL, toolCompatibilityIdentity: "test")
     #expect(try await store.runSnapshot(.init(rawValue: "run-002")).status == .partial)
     #expect(
       try await store.targetSnapshot(targetID: "framework:Foo.framework")?.lastSuccessfulRunID
@@ -343,7 +467,8 @@ struct PrivateHeaderGenerationExecutorTests {
 
     #expect(try fixture.publisher().inspect().currentGenerationID == nil)
     #expect(!FileManager.default.fileExists(atPath: fixture.stableURL.path))
-    let store = try GenerationStore(databaseURL: fixture.databaseURL, toolCompatibilityIdentity: "test")
+    let store = try GenerationStore(
+      databaseURL: fixture.databaseURL, toolCompatibilityIdentity: "test")
     #expect(try await store.runSnapshot(.init(rawValue: "run-failed")).status == .failed)
   }
 
@@ -378,9 +503,12 @@ struct PrivateHeaderGenerationExecutorTests {
     }
 
     #expect(await runner.invocationCount == 2)
+    #expect(try fixture.readLiveHeader(framework: "Foo") == "generated")
+    #expect(!FileManager.default.fileExists(atPath: fixture.liveHeaderURL(framework: "Bar").path))
     #expect(try fixture.readStableHeader(framework: "Foo") == "generated")
     #expect(!FileManager.default.fileExists(atPath: fixture.stableHeaderURL(framework: "Bar").path))
-    let store = try GenerationStore(databaseURL: fixture.databaseURL, toolCompatibilityIdentity: "test")
+    let store = try GenerationStore(
+      databaseURL: fixture.databaseURL, toolCompatibilityIdentity: "test")
     let run = try await store.runSnapshot(.init(rawValue: "run-cancelled"))
     #expect(run.status == .interrupted)
     let statuses = Dictionary(uniqueKeysWithValues: run.targets.map { ($0.targetID, $0.status) })
@@ -394,7 +522,7 @@ struct PrivateHeaderGenerationExecutorTests {
     #expect(summary.status == .interrupted)
     #expect(summary.targetCounts.completed == 1)
     #expect(summary.targetCounts.interrupted == 1)
-    #expect(summary.artifactDirectory == fixture.stableURL)
+    #expect(summary.artifactDirectory == fixture.liveURL)
     #expect(summary.stateDatabaseURL == fixture.databaseURL)
   }
 
@@ -429,11 +557,12 @@ struct PrivateHeaderGenerationExecutorTests {
     let interruption = try #require(capturedInterruption)
     #expect(interruption.summary.status == .interrupted)
     #expect(interruption.summary.targetCounts.completed == 1)
-    #expect(interruption.summary.artifactDirectory == fixture.stableURL)
+    #expect(interruption.summary.artifactDirectory == fixture.liveURL)
 
     #expect(await runner.invocationCount == 1)
     #expect(try fixture.readStableHeader() == "generated")
-    let store = try GenerationStore(databaseURL: fixture.databaseURL, toolCompatibilityIdentity: "test")
+    let store = try GenerationStore(
+      databaseURL: fixture.databaseURL, toolCompatibilityIdentity: "test")
     #expect(try await store.runSnapshot(.init(rawValue: "run-interrupted")).status == .interrupted)
     #expect(
       try await store.publicationIntent(generationID: .init(rawValue: "generation-interrupted"))?
@@ -565,7 +694,8 @@ struct PrivateHeaderGenerationExecutorTests {
 
     #expect(await secondRunner.invocationCount == 0)
     #expect(try fixture.readStableHeader() == "recoverable")
-    let store = try GenerationStore(databaseURL: result.stateDatabaseURL, toolCompatibilityIdentity: "test")
+    let store = try GenerationStore(
+      databaseURL: result.stateDatabaseURL, toolCompatibilityIdentity: "test")
     #expect(try await store.runSnapshot(.init(rawValue: "run-001")).status == .completed)
     #expect(
       try await store.publicationIntent(generationID: .init(rawValue: "generation-001"))?.state
@@ -605,23 +735,26 @@ struct PrivateHeaderGenerationExecutorTests {
       generationID: "generation-002"
     ).run(plan: plan)
 
-    let shouldRerun = faultPoint == .afterPrepared || faultPoint == .afterGenerationMove
-    #expect(await secondRunner.invocationCount == (shouldRerun ? 1 : 0))
+    let firstSnapshotWasAborted =
+      faultPoint == .afterPrepared || faultPoint == .afterGenerationMove
+    #expect(await secondRunner.invocationCount == 0)
     let expectedGeneration = PrivateHeaderGeneration.GenerationID(
-      rawValue: shouldRerun ? "generation-002" : "generation-001"
+      rawValue: firstSnapshotWasAborted ? "generation-002" : "generation-001"
     )
     let publication = try fixture.publisher().inspect()
     #expect(publication.currentGenerationID == expectedGeneration)
-    #expect(try fixture.readStableHeader() == (shouldRerun ? "second-attempt" : "first-attempt"))
-    let store = try GenerationStore(databaseURL: fixture.databaseURL, toolCompatibilityIdentity: "test")
+    #expect(try fixture.readLiveHeader() == "first-attempt")
+    #expect(try fixture.readStableHeader() == "first-attempt")
+    let store = try GenerationStore(
+      databaseURL: fixture.databaseURL, toolCompatibilityIdentity: "test")
     let firstIntent = try #require(
       try await store.publicationIntent(generationID: .init(rawValue: "generation-001"))
     )
-    #expect(firstIntent.state == (shouldRerun ? .aborted : .committed))
+    #expect(firstIntent.state == (firstSnapshotWasAborted ? .aborted : .committed))
     #expect(
       try await store.runSnapshot(.init(rawValue: "run-001")).status
-        == (shouldRerun ? .interrupted : .completed))
-    if shouldRerun {
+        == (firstSnapshotWasAborted ? .interrupted : .completed))
+    if firstSnapshotWasAborted {
       #expect(!publication.validGenerationIDs.contains(.init(rawValue: "generation-001")))
       #expect(
         try await store.publicationIntent(generationID: .init(rawValue: "generation-002"))?.state
@@ -633,7 +766,7 @@ struct PrivateHeaderGenerationExecutorTests {
     PrivateHeaderGeneration.PublicationFaultPoint.afterPrepared,
     .afterGenerationMove,
   ])
-  func abortedPublicationWithSameArtifactPathsRerunsInsteadOfReusingOldContent(
+  func abortedFinalSnapshotKeepsPublishedTargetAndResumeDoesNotRerun(
     _ faultPoint: PrivateHeaderGeneration.PublicationFaultPoint
   ) async throws {
     let fixture = try ExecutorFixture()
@@ -663,8 +796,9 @@ struct PrivateHeaderGenerationExecutorTests {
       generationID: "generation-resumed"
     ).run(plan: try fixture.plan(.query("Foo"), resumeBehavior: .resume))
 
-    #expect(await resumedRunner.invocationCount == 1)
-    #expect(try fixture.readStableHeader() == "resumed-content")
+    #expect(await resumedRunner.invocationCount == 0)
+    #expect(try fixture.readLiveHeader() == "unpublished-content")
+    #expect(try fixture.readStableHeader() == "unpublished-content")
     #expect(
       try fixture.publisher().inspect().currentGenerationID
         == .init(rawValue: "generation-resumed")
@@ -675,7 +809,7 @@ struct PrivateHeaderGenerationExecutorTests {
     )
     #expect(
       try await store.targetSnapshot(targetID: "framework:Foo.framework")?.lastSuccessfulRunID
-        == .init(rawValue: "run-resumed")
+        == .init(rawValue: "run-unpublished")
     )
   }
 
@@ -711,17 +845,20 @@ struct PrivateHeaderGenerationExecutorTests {
       Issue.record("missing prepared generation unexpectedly moved and committed")
     } catch let PrivateHeaderGeneration.GenerationError.infrastructureFailed(failure) {
       #expect(failure.summary.status == .failed)
-      #expect(failure.summary.targetCounts.failed == 1)
+      #expect(failure.summary.targetCounts.completed == 1)
+      #expect(failure.summary.targetCounts.failed == 0)
       #expect(failure.message.contains("rename"))
     }
 
     #expect(mutation.message == nil)
     #expect(try fixture.publisher().inspect().currentGenerationID == previousGenerationID)
+    #expect(try fixture.readLiveHeader() == "new")
     #expect(try fixture.readStableHeader() == "old")
-    let store = try GenerationStore(databaseURL: fixture.databaseURL, toolCompatibilityIdentity: "test")
+    let store = try GenerationStore(
+      databaseURL: fixture.databaseURL, toolCompatibilityIdentity: "test")
     let run = try await store.runSnapshot(.init(rawValue: "run-002"))
     #expect(run.status == .failed)
-    #expect(run.targets.first?.status == .failed)
+    #expect(run.targets.first?.status == .completed)
     #expect(
       try await store.publicationIntent(generationID: .init(rawValue: "generation-002"))?.state
         == .aborted)
@@ -828,7 +965,8 @@ struct PrivateHeaderGenerationExecutorTests {
     }
 
     #expect(try fixture.publisher().inspect().currentGenerationID == nil)
-    let store = try GenerationStore(databaseURL: fixture.databaseURL, toolCompatibilityIdentity: "test")
+    let store = try GenerationStore(
+      databaseURL: fixture.databaseURL, toolCompatibilityIdentity: "test")
     #expect(try await store.runSnapshot(.init(rawValue: "run-hidden")).status == .failed)
   }
 
@@ -992,6 +1130,30 @@ private final class FileMutationRecorder: @unchecked Sendable {
   }
 }
 
+private final class LiveArtifactObservation: @unchecked Sendable {
+  private let lock = NSLock()
+  private var storedContents: String?
+  private var storedErrorDescription: String?
+
+  var contents: String? {
+    lock.withLock { storedContents }
+  }
+
+  var errorDescription: String? {
+    lock.withLock { storedErrorDescription }
+  }
+
+  func observe(_ url: URL) {
+    lock.withLock {
+      do {
+        storedContents = try String(contentsOf: url, encoding: .utf8)
+      } catch {
+        storedErrorDescription = String(describing: error)
+      }
+    }
+  }
+}
+
 private func captureInterruption(
   operation: @escaping @Sendable () async throws -> PrivateHeaderGeneration.Result
 ) async -> PrivateHeaderGeneration.RunInterruption? {
@@ -1015,6 +1177,8 @@ private actor RecordingRunner {
   let result: PrivateHeaderGeneration.RawDumping.Result
   let thrownError: (any Error & Sendable)?
   let writesHiddenPayload: Bool
+  let hiddenPayloadFramework: String?
+  let additionalHeaderName: String?
   let cancelsForFramework: String?
   let afterRun: @Sendable () -> Void
 
@@ -1023,6 +1187,8 @@ private actor RecordingRunner {
     result: PrivateHeaderGeneration.RawDumping.Result = .init(terminationStatus: 0),
     thrownError: (any Error & Sendable)? = nil,
     writesHiddenPayload: Bool = false,
+    hiddenPayloadFramework: String? = nil,
+    additionalHeaderName: String? = nil,
     cancelsForFramework: String? = nil,
     afterRun: @escaping @Sendable () -> Void = {}
   ) {
@@ -1030,6 +1196,8 @@ private actor RecordingRunner {
     self.result = result
     self.thrownError = thrownError
     self.writesHiddenPayload = writesHiddenPayload
+    self.hiddenPayloadFramework = hiddenPayloadFramework
+    self.additionalHeaderName = additionalHeaderName
     self.cancelsForFramework = cancelsForFramework
     self.afterRun = afterRun
   }
@@ -1048,7 +1216,12 @@ private actor RecordingRunner {
       let output = outputDirectory(for: invocation)
       try FileManager.default.createDirectory(at: output, withIntermediateDirectories: true)
       try Data(contents.utf8).write(to: output.appendingPathComponent("Generated.h"))
-      if writesHiddenPayload {
+      if let additionalHeaderName {
+        try Data(contents.utf8).write(to: output.appendingPathComponent(additionalHeaderName))
+      }
+      if writesHiddenPayload
+        || hiddenPayloadFramework.map({ invocation.inputPath.hasSuffix("/\($0)") }) == true
+      {
         try Data("hidden".utf8).write(
           to: invocation.stagingOutputDirectory.appendingPathComponent(".unexpected")
         )
@@ -1077,9 +1250,8 @@ private actor RecordingRunner {
 
 private actor RecordingInventoryRunner {
   private var data: Data
-  private(set) var invocations: [
-    PrivateHeaderGeneration.RawDumping.SharedCacheInventoryInvocation
-  ] = []
+  private(set) var invocations:
+    [PrivateHeaderGeneration.RawDumping.SharedCacheInventoryInvocation] = []
 
   init(data: Data) {
     self.data = data
@@ -1099,8 +1271,8 @@ private actor RecordingInventoryRunner {
   }
 }
 
-private extension PrivateHeaderGeneration.GenerationExecutor {
-  func run(
+extension PrivateHeaderGeneration.GenerationExecutor {
+  fileprivate func run(
     plan: PrivateHeaderGeneration.Plan,
     progressReporter: ProgressReporter? = nil
   ) async throws -> PrivateHeaderGeneration.Result {
@@ -1137,6 +1309,12 @@ private struct ExecutorFixture {
 
   var sourceLabel: String { source.storageIdentifier }
   var stableURL: URL { outputBase.appendingPathComponent(sourceLabel, isDirectory: false) }
+  var liveURL: URL {
+    outputBase.appendingPathComponent(
+      "generated-headers/\(sourceLabel)",
+      isDirectory: true
+    )
+  }
   var stateDirectory: URL {
     outputBase.appendingPathComponent(".state/\(sourceLabel)", isDirectory: true)
   }
@@ -1189,9 +1367,10 @@ private struct ExecutorFixture {
 
   func executor(
     runner: RecordingRunner,
-    inventoryRunner: @escaping PrivateHeaderGeneration.GenerationExecutor.SharedCacheInventoryRunner = { _ in
-      throw ExecutorFixtureError.unexpectedSharedCacheInventory
-    },
+    inventoryRunner:
+      @escaping PrivateHeaderGeneration.GenerationExecutor.SharedCacheInventoryRunner = { _ in
+        throw ExecutorFixtureError.unexpectedSharedCacheInventory
+      },
     runID: String,
     generationID: String,
     storeFaultInjector: @escaping GenerationStore.FaultInjector = { _ in },
@@ -1217,8 +1396,16 @@ private struct ExecutorFixture {
     stableURL.appendingPathComponent("Frameworks/\(framework)/Headers/Generated.h")
   }
 
+  func liveHeaderURL(framework: String = "Foo") -> URL {
+    liveURL.appendingPathComponent("Frameworks/\(framework)/Headers/Generated.h")
+  }
+
   func readStableHeader(framework: String = "Foo") throws -> String {
     try String(contentsOf: stableHeaderURL(framework: framework), encoding: .utf8)
+  }
+
+  func readLiveHeader(framework: String = "Foo") throws -> String {
+    try String(contentsOf: liveHeaderURL(framework: framework), encoding: .utf8)
   }
 }
 

--- a/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationExecutorTests.swift
+++ b/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationExecutorTests.swift
@@ -388,6 +388,77 @@ struct PrivateHeaderGenerationExecutorTests {
     #expect(!FileManager.default.fileExists(atPath: staleHeader.path))
   }
 
+  @Test func recoveryDoesNotRestoreArtifactRemovedByNewerTargetPublication() async throws {
+    let fixture = try ExecutorFixture()
+    defer { fixture.cleanup() }
+    try fixture.createFramework("Foo.framework")
+    _ = try await fixture.executor(
+      runner: RecordingRunner(contents: "old", additionalHeaderName: "Removed.h"),
+      runID: "run-old",
+      generationID: "generation-old"
+    ).run(plan: try fixture.plan(.query("Foo"), resumeBehavior: .fresh))
+
+    await #expect(throws: InjectedFault.self) {
+      _ = try await fixture.executor(
+        runner: RecordingRunner(contents: "new"),
+        runID: "run-new",
+        generationID: "generation-new",
+        publicationFaultInjector: { point in
+          if point == .afterPrepared { throw InjectedFault.stop }
+        }
+      ).run(plan: try fixture.plan(.query("Foo"), resumeBehavior: .fresh))
+    }
+    let removedHeader = fixture.liveURL.appendingPathComponent(
+      "Frameworks/Foo/Headers/Removed.h"
+    )
+    #expect(try fixture.readLiveHeader() == "new")
+    #expect(!FileManager.default.fileExists(atPath: removedHeader.path))
+
+    let resumedRunner = RecordingRunner(contents: "unexpected")
+    _ = try await fixture.executor(
+      runner: resumedRunner,
+      runID: "run-resumed",
+      generationID: "generation-resumed"
+    ).run(plan: try fixture.plan(.query("Foo"), resumeBehavior: .resume))
+
+    #expect(await resumedRunner.invocationCount == 0)
+    #expect(try fixture.readLiveHeader() == "new")
+    #expect(!FileManager.default.fileExists(atPath: removedHeader.path))
+  }
+
+  @Test func recoveryRerunsNewerTargetInsteadOfHydratingOlderBytes() async throws {
+    let fixture = try ExecutorFixture()
+    defer { fixture.cleanup() }
+    try fixture.createFramework("Foo.framework")
+    _ = try await fixture.executor(
+      runner: RecordingRunner(contents: "old"),
+      runID: "run-old",
+      generationID: "generation-old"
+    ).run(plan: try fixture.plan(.query("Foo"), resumeBehavior: .fresh))
+
+    await #expect(throws: InjectedFault.self) {
+      _ = try await fixture.executor(
+        runner: RecordingRunner(contents: "new"),
+        runID: "run-new",
+        generationID: "generation-new",
+        publicationFaultInjector: { point in
+          if point == .afterPrepared { throw InjectedFault.stop }
+        }
+      ).run(plan: try fixture.plan(.query("Foo"), resumeBehavior: .fresh))
+    }
+    try FileManager.default.removeItem(at: fixture.liveHeaderURL())
+
+    let resumedRunner = RecordingRunner(contents: "recovered")
+    _ = try await fixture.executor(
+      runner: resumedRunner,
+      runID: "run-resumed",
+      generationID: "generation-resumed"
+    ).run(plan: try fixture.plan(.query("Foo"), resumeBehavior: .resume))
+
+    #expect(await resumedRunner.invocationCount == 1)
+    #expect(try fixture.readLiveHeader() == "recovered")
+  }
+
   @Test func compatibleResumeSkipsCurrentCompletedTarget() async throws {
     let fixture = try ExecutorFixture()
     defer { fixture.cleanup() }

--- a/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationExecutorTests.swift
+++ b/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationExecutorTests.swift
@@ -426,6 +426,55 @@ struct PrivateHeaderGenerationExecutorTests {
     #expect(!FileManager.default.fileExists(atPath: removedHeader.path))
   }
 
+  @Test func recoveryPreservesCaseOnlyNewerTargetPublication() async throws {
+    let fixture = try ExecutorFixture()
+    defer { fixture.cleanup() }
+    try fixture.createFramework("Foo.framework")
+    _ = try await fixture.executor(
+      runner: RecordingRunner(contents: "old"),
+      runID: "run-old",
+      generationID: "generation-old"
+    ).run(plan: try fixture.plan(.query("Foo"), resumeBehavior: .fresh))
+    let volumeValues = try fixture.liveURL.resourceValues(
+      forKeys: [.volumeSupportsCaseSensitiveNamesKey]
+    )
+    guard volumeValues.volumeSupportsCaseSensitiveNames == false else { return }
+
+    await #expect(throws: InjectedFault.self) {
+      _ = try await fixture.executor(
+        runner: RecordingRunner(contents: "new", primaryHeaderName: "generated.h"),
+        runID: "run-new",
+        generationID: "generation-new",
+        publicationFaultInjector: { point in
+          if point == .afterPrepared { throw InjectedFault.stop }
+        }
+      ).run(plan: try fixture.plan(.query("Foo"), resumeBehavior: .fresh))
+    }
+    let lowercasedLiveHeader = fixture.liveURL.appendingPathComponent(
+      "Frameworks/Foo/Headers/generated.h"
+    )
+    #expect(try String(contentsOf: lowercasedLiveHeader, encoding: .utf8) == "new")
+
+    let resumedRunner = RecordingRunner(contents: "unexpected")
+    _ = try await fixture.executor(
+      runner: resumedRunner,
+      runID: "run-resumed",
+      generationID: "generation-resumed"
+    ).run(plan: try fixture.plan(.query("Foo"), resumeBehavior: .resume))
+
+    let lowercasedStableHeader = fixture.stableURL.appendingPathComponent(
+      "Frameworks/Foo/Headers/generated.h"
+    )
+    #expect(await resumedRunner.invocationCount == 0)
+    #expect(try String(contentsOf: lowercasedLiveHeader, encoding: .utf8) == "new")
+    #expect(try String(contentsOf: lowercasedStableHeader, encoding: .utf8) == "new")
+    #expect(
+      try fixture.publisher().inspect().currentMarker?
+        .artifactsByTarget["framework:Foo.framework"]?.map(\.rawValue)
+        == ["Frameworks/Foo/Headers/generated.h"]
+    )
+  }
+
   @Test func recoveryRerunsNewerTargetInsteadOfHydratingOlderBytes() async throws {
     let fixture = try ExecutorFixture()
     defer { fixture.cleanup() }
@@ -459,6 +508,40 @@ struct PrivateHeaderGenerationExecutorTests {
     #expect(try fixture.readLiveHeader() == "recovered")
   }
 
+  @Test func recoveryRerunsNewerTargetWhoseLiveContentsChanged() async throws {
+    let fixture = try ExecutorFixture()
+    defer { fixture.cleanup() }
+    try fixture.createFramework("Foo.framework")
+    _ = try await fixture.executor(
+      runner: RecordingRunner(contents: "old"),
+      runID: "run-old",
+      generationID: "generation-old"
+    ).run(plan: try fixture.plan(.query("Foo"), resumeBehavior: .fresh))
+
+    await #expect(throws: InjectedFault.self) {
+      _ = try await fixture.executor(
+        runner: RecordingRunner(contents: "new"),
+        runID: "run-new",
+        generationID: "generation-new",
+        publicationFaultInjector: { point in
+          if point == .afterPrepared { throw InjectedFault.stop }
+        }
+      ).run(plan: try fixture.plan(.query("Foo"), resumeBehavior: .fresh))
+    }
+    try Data("tampered".utf8).write(to: fixture.liveHeaderURL())
+
+    let resumedRunner = RecordingRunner(contents: "recovered")
+    _ = try await fixture.executor(
+      runner: resumedRunner,
+      runID: "run-resumed",
+      generationID: "generation-resumed"
+    ).run(plan: try fixture.plan(.query("Foo"), resumeBehavior: .resume))
+
+    #expect(await resumedRunner.invocationCount == 1)
+    #expect(try fixture.readLiveHeader() == "recovered")
+    #expect(try fixture.readStableHeader() == "recovered")
+  }
+
   @Test func snapshotRebuildDropsPublishedTargetThatIsMissingFromLiveOutput() async throws {
     let fixture = try ExecutorFixture()
     defer { fixture.cleanup() }
@@ -472,7 +555,7 @@ struct PrivateHeaderGenerationExecutorTests {
 
     await #expect(throws: InjectedFault.self) {
       _ = try await fixture.executor(
-        runner: RecordingRunner(contents: "new"),
+        runner: RecordingRunner(contents: "new", additionalHeaderName: "Still.h"),
         runID: "run-new",
         generationID: "generation-new",
         publicationFaultInjector: { point in
@@ -490,14 +573,38 @@ struct PrivateHeaderGenerationExecutorTests {
 
     let marker = try #require(fixture.publisher().inspect().currentMarker)
     #expect(marker.artifactsByTarget.keys.sorted() == ["framework:Bar.framework"])
+    #expect(!FileManager.default.fileExists(
+      atPath: fixture.liveURL.appendingPathComponent(
+        "Frameworks/Foo/Headers/Still.h"
+      ).path
+    ))
+    try FileManager.default.createDirectory(
+      at: fixture.liveHeaderURL(framework: "Foo").deletingLastPathComponent(),
+      withIntermediateDirectories: true
+    )
+    try "untrusted".write(
+      to: fixture.liveHeaderURL(framework: "Foo"),
+      atomically: true,
+      encoding: .utf8
+    )
     let recoveredRunner = RecordingRunner(contents: "recovered")
     _ = try await fixture.executor(
       runner: recoveredRunner,
       runID: "run-recovered",
       generationID: "generation-recovered"
-    ).run(plan: try fixture.plan(.query("Foo"), resumeBehavior: .fresh))
+    ).run(
+      plan: try fixture.plan(
+        .identifiers(["framework:Foo.framework", "framework:Bar.framework"]),
+        resumeBehavior: .resume
+      )
+    )
     #expect(await recoveredRunner.invocationCount == 1)
+    #expect(
+      await recoveredRunner.invocations.first?.inputPath.hasSuffix("/Foo.framework") == true
+    )
     #expect(try fixture.readLiveHeader(framework: "Foo") == "recovered")
+    #expect(try fixture.readStableHeader(framework: "Foo") == "recovered")
+    #expect(try fixture.readStableHeader(framework: "Bar") == "bar")
   }
 
   @Test func compatibleResumeSkipsCurrentCompletedTarget() async throws {
@@ -522,6 +629,154 @@ struct PrivateHeaderGenerationExecutorTests {
     #expect(result.generatedTargets.isEmpty)
     #expect(result.targetCounts.skipped == 1)
     #expect(try fixture.readStableHeader() == "first")
+  }
+
+  @Test func compatibleResumeRestoresModifiedCurrentArtifactBeforeSkipping() async throws {
+    let fixture = try ExecutorFixture()
+    defer { fixture.cleanup() }
+    try fixture.createFramework("Foo.framework")
+    let plan = try fixture.plan(.query("Foo"))
+    _ = try await fixture.executor(
+      runner: RecordingRunner(contents: "first"),
+      runID: "run-first",
+      generationID: "generation-first"
+    ).run(plan: plan)
+    try "tampered".write(
+      to: fixture.liveHeaderURL(),
+      atomically: true,
+      encoding: .utf8
+    )
+    let runner = RecordingRunner(contents: "unexpected")
+
+    let result = try await fixture.executor(
+      runner: runner,
+      runID: "run-resumed",
+      generationID: "generation-resumed"
+    ).run(plan: plan)
+
+    #expect(await runner.invocationCount == 0)
+    #expect(result.targetCounts.skipped == 1)
+    #expect(try fixture.readLiveHeader() == "first")
+    #expect(try fixture.readStableHeader() == "first")
+  }
+
+  @Test func nextSnapshotUsesCanonicalBytesForCoveredTargetAfterLiveMutation() async throws {
+    let fixture = try ExecutorFixture()
+    defer { fixture.cleanup() }
+    try fixture.createFramework("Foo.framework")
+    try fixture.createFramework("Bar.framework")
+    _ = try await fixture.executor(
+      runner: RecordingRunner(contents: "first"),
+      runID: "run-first",
+      generationID: "generation-first"
+    ).run(plan: try fixture.plan(.query("Foo")))
+    let mutation = FileMutationRecorder()
+    let fooLiveHeader = fixture.liveHeaderURL(framework: "Foo")
+    let barRunner = RecordingRunner(contents: "bar") {
+      mutation.run {
+        try "tampered".write(to: fooLiveHeader, atomically: true, encoding: .utf8)
+      }
+    }
+
+    _ = try await fixture.executor(
+      runner: barRunner,
+      runID: "run-bar",
+      generationID: "generation-bar"
+    ).run(plan: try fixture.plan(.query("Bar"), resumeBehavior: .fresh))
+
+    #expect(mutation.message == nil)
+    #expect(await barRunner.invocationCount == 1)
+    #expect(try fixture.readLiveHeader(framework: "Foo") == "first")
+    #expect(try fixture.readStableHeader(framework: "Foo") == "first")
+    #expect(try fixture.readLiveHeader(framework: "Bar") == "bar")
+    #expect(try fixture.readStableHeader(framework: "Bar") == "bar")
+  }
+
+  @Test func finalSnapshotRejectsGeneratedStagingChangedAfterLivePublication() async throws {
+    let fixture = try ExecutorFixture()
+    defer { fixture.cleanup() }
+    try fixture.createFramework("Foo.framework")
+    try fixture.createFramework("Bar.framework")
+    let mutation = FileMutationRecorder()
+    let fooStagedHeader = fixture.stagedHeaderURL(runID: "run-generated", framework: "Foo")
+    let barStagedHeader = fixture.stagedHeaderURL(runID: "run-generated", framework: "Bar")
+    let runner = RecordingRunner(contents: "generated") {
+      guard FileManager.default.fileExists(atPath: barStagedHeader.path) else { return }
+      mutation.run {
+        try "tampered".write(to: fooStagedHeader, atomically: true, encoding: .utf8)
+      }
+    }
+
+    do {
+      _ = try await fixture.executor(
+        runner: runner,
+        runID: "run-generated",
+        generationID: "generation-generated"
+      ).run(plan: try fixture.plan(.query("Foo,Bar"), resumeBehavior: .fresh))
+      Issue.record("changed generated staging unexpectedly became an immutable generation")
+    } catch let PrivateHeaderGeneration.GenerationError.infrastructureFailed(failure) {
+      #expect(failure.summary.targetCounts.completed == 2)
+      #expect(failure.message.contains("artifact contents do not match published target"))
+    }
+
+    #expect(mutation.message == nil)
+    #expect(await runner.invocationCount == 2)
+    #expect(try fixture.readLiveHeader(framework: "Foo") == "generated")
+    #expect(try fixture.readLiveHeader(framework: "Bar") == "generated")
+    #expect(try fixture.publisher().inspect().currentGenerationID == nil)
+  }
+
+  @Test func finalSnapshotFailsBeforeRetiringNewerLiveOutputChangedDuringRun() async throws {
+    let fixture = try ExecutorFixture()
+    defer { fixture.cleanup() }
+    try fixture.createFramework("Foo.framework")
+    try fixture.createFramework("Bar.framework")
+    _ = try await fixture.executor(
+      runner: RecordingRunner(contents: "old"),
+      runID: "run-old",
+      generationID: "generation-old"
+    ).run(plan: try fixture.plan(.query("Foo"), resumeBehavior: .fresh))
+    await #expect(throws: InjectedFault.self) {
+      _ = try await fixture.executor(
+        runner: RecordingRunner(contents: "new"),
+        runID: "run-new",
+        generationID: "generation-new",
+        publicationFaultInjector: { point in
+          if point == .afterPrepared { throw InjectedFault.stop }
+        }
+      ).run(plan: try fixture.plan(.query("Foo"), resumeBehavior: .fresh))
+    }
+    let previousGenerationID = try #require(fixture.publisher().inspect().currentGenerationID)
+    let mutation = FileMutationRecorder()
+    let runner = RecordingRunner(contents: "bar") {
+      mutation.run {
+        try "tampered".write(
+          to: fixture.liveHeaderURL(framework: "Foo"),
+          atomically: true,
+          encoding: .utf8
+        )
+      }
+    }
+
+    do {
+      _ = try await fixture.executor(
+        runner: runner,
+        runID: "run-resumed",
+        generationID: "generation-resumed"
+      ).run(plan: try fixture.plan(.query("Foo,Bar"), resumeBehavior: .resume))
+      Issue.record("changed newer live output unexpectedly became an immutable generation")
+    } catch let PrivateHeaderGeneration.GenerationError.infrastructureFailed(failure) {
+      #expect(failure.summary.targetCounts.completed == 1)
+      #expect(failure.summary.targetCounts.skipped == 1)
+      #expect(failure.message.contains("published target contents changed during generation"))
+    }
+
+    #expect(mutation.message == nil)
+    #expect(await runner.invocationCount == 1)
+    #expect(try fixture.readLiveHeader(framework: "Foo") == "tampered")
+    #expect(try fixture.readLiveHeader(framework: "Bar") == "bar")
+    #expect(try fixture.readStableHeader(framework: "Foo") == "old")
+    #expect(try fixture.publisher().inspect().currentGenerationID == previousGenerationID)
   }
 
   @Test func failedAndPartialAttemptsPreserveLastSuccessfulGeneration() async throws {
@@ -929,6 +1184,65 @@ struct PrivateHeaderGenerationExecutorTests {
     )
   }
 
+  @Test func resumeDropsOpaqueOwnershipAlreadyClaimedByAPublishedTarget() async throws {
+    let fixture = try ExecutorFixture()
+    defer { fixture.cleanup() }
+    try fixture.createFramework("Foo.framework")
+    try fixture.createFramework("Bar.framework")
+    try fixture.createFramework("Baz.framework")
+    let legacyFooHeader = fixture.stableHeaderURL(framework: "Foo")
+    try FileManager.default.createDirectory(
+      at: legacyFooHeader.deletingLastPathComponent(),
+      withIntermediateDirectories: true
+    )
+    try "legacy".write(to: legacyFooHeader, atomically: true, encoding: .utf8)
+
+    _ = try await fixture.executor(
+      runner: RecordingRunner(contents: "bar"),
+      runID: "run-seed",
+      generationID: "generation-seed"
+    ).run(plan: try fixture.plan(.query("Bar"), resumeBehavior: .fresh))
+
+    await #expect(throws: InjectedFault.self) {
+      _ = try await fixture.executor(
+        runner: RecordingRunner(contents: "foo"),
+        runID: "run-claim",
+        generationID: "generation-claim",
+        publicationFaultInjector: { point in
+          if point == .afterPrepared { throw InjectedFault.stop }
+        }
+      ).run(plan: try fixture.plan(.query("Foo"), resumeBehavior: .fresh))
+    }
+
+    try FileManager.default.removeItem(at: fixture.liveHeaderURL(framework: "Foo"))
+
+    let resumedRunner = RecordingRunner(contents: "baz")
+    _ = try await fixture.executor(
+      runner: resumedRunner,
+      runID: "run-resumed",
+      generationID: "generation-resumed"
+    ).run(plan: try fixture.plan(.query("Baz"), resumeBehavior: .fresh))
+
+    #expect(await resumedRunner.invocationCount == 1)
+    #expect(try fixture.readLiveHeader(framework: "Baz") == "baz")
+    #expect(!FileManager.default.fileExists(atPath: fixture.liveHeaderURL(framework: "Foo").path))
+    #expect(
+      try fixture.publisher().inspect().currentMarker?.opaquePaths.contains(
+        PrivateHeaderGeneration.ArtifactPath(rawValue: "Frameworks/Foo/Headers/Generated.h")
+      ) == false
+    )
+
+    let fooRunner = RecordingRunner(contents: "regenerated-foo")
+    _ = try await fixture.executor(
+      runner: fooRunner,
+      runID: "run-foo",
+      generationID: "generation-foo"
+    ).run(plan: try fixture.plan(.query("Foo,Baz"), resumeBehavior: .resume))
+
+    #expect(await fooRunner.invocationCount == 1)
+    #expect(try fixture.readLiveHeader(framework: "Foo") == "regenerated-foo")
+  }
+
   @Test func generationMoveFailureAbortsAsFailedAndPreservesPreviousCurrent() async throws {
     let fixture = try ExecutorFixture()
     defer { fixture.cleanup() }
@@ -963,7 +1277,7 @@ struct PrivateHeaderGenerationExecutorTests {
       #expect(failure.summary.status == .failed)
       #expect(failure.summary.targetCounts.completed == 1)
       #expect(failure.summary.targetCounts.failed == 0)
-      #expect(failure.message.contains("rename"))
+      #expect(failure.message.contains("missing marker"))
     }
 
     #expect(mutation.message == nil)
@@ -977,7 +1291,409 @@ struct PrivateHeaderGenerationExecutorTests {
     #expect(run.targets.first?.status == .completed)
     #expect(
       try await store.publicationIntent(generationID: .init(rawValue: "generation-002"))?.state
-        == .aborted)
+      == .aborted)
+  }
+
+  @Test func changedPreparedGenerationNeverReachesLiveOrManagedOutput() async throws {
+    let fixture = try ExecutorFixture()
+    defer { fixture.cleanup() }
+    try fixture.createFramework("Foo.framework")
+    _ = try await fixture.executor(
+      runner: RecordingRunner(contents: "old"),
+      runID: "run-001",
+      generationID: "generation-001"
+    ).run(plan: try fixture.plan(.query("Foo")))
+    let previousGenerationID = try #require(fixture.publisher().inspect().currentGenerationID)
+    let mutation = FileMutationRecorder()
+    let draftHeader = fixture.outputBase
+      .appendingPathComponent(".privateheaderkit/\(fixture.sourceLabel)/staging", isDirectory: true)
+      .appendingPathComponent("generation-002.draft", isDirectory: true)
+      .appendingPathComponent("Frameworks/Foo/Headers/Generated.h")
+
+    do {
+      _ = try await fixture.executor(
+        runner: RecordingRunner(contents: "new"),
+        runID: "run-002",
+        generationID: "generation-002",
+        publicationFaultInjector: { point in
+          guard point == .afterPrepared else { return }
+          mutation.run {
+            try "tampered".write(to: draftHeader, atomically: true, encoding: .utf8)
+          }
+        }
+      ).run(plan: try fixture.plan(.query("Foo"), resumeBehavior: .fresh))
+      Issue.record("changed prepared generation unexpectedly committed")
+    } catch let PrivateHeaderGeneration.GenerationError.infrastructureFailed(failure) {
+      #expect(failure.summary.status == .failed)
+      #expect(failure.summary.targetCounts.completed == 1)
+      #expect(failure.message.contains("artifact content digest does not match marker"))
+    }
+
+    #expect(mutation.message == nil)
+    let failedPublication = try fixture.publisher().inspect()
+    #expect(failedPublication.currentGenerationID == previousGenerationID)
+    #expect(!failedPublication.validGenerationIDs.contains(.init(rawValue: "generation-002")))
+    #expect(try fixture.readLiveHeader() == "new")
+    #expect(try fixture.readStableHeader() == "old")
+
+    let retryRunner = RecordingRunner(contents: "should-not-run")
+    _ = try await fixture.executor(
+      runner: retryRunner,
+      runID: "run-003",
+      generationID: "generation-003"
+    ).run(plan: try fixture.plan(.query("Foo"), resumeBehavior: .resume))
+
+    #expect(await retryRunner.invocationCount == 0)
+    #expect(try fixture.readLiveHeader() == "new")
+    #expect(try fixture.readStableHeader() == "new")
+  }
+
+  @Test func staleAttemptCleanupPreservesArtifactsOwnedByAnotherTarget() async throws {
+    let fixture = try ExecutorFixture()
+    defer { fixture.cleanup() }
+    try fixture.createFramework("Foo.framework")
+    try fixture.createFramework("Bar.framework")
+    let legacyOpaqueArtifact = fixture.stableURL.appendingPathComponent("User/keep.txt")
+    try FileManager.default.createDirectory(
+      at: legacyOpaqueArtifact.deletingLastPathComponent(),
+      withIntermediateDirectories: true
+    )
+    try "opaque".write(to: legacyOpaqueArtifact, atomically: true, encoding: .utf8)
+    _ = try await fixture.executor(
+      runner: RecordingRunner(contents: "bar"),
+      runID: "run-bar",
+      generationID: "generation-bar"
+    ).run(plan: try fixture.plan(.query("Bar"), resumeBehavior: .fresh))
+
+    let store = try GenerationStore(
+      databaseURL: fixture.databaseURL,
+      toolCompatibilityIdentity: "test"
+    )
+    let staleRunID = PrivateHeaderGeneration.RunID(rawValue: "run-stale-foo")
+    let staleDate = Date(timeIntervalSinceReferenceDate: 90)
+    _ = try await store.beginRun(
+      id: staleRunID,
+      plan: .init(
+        sourceIdentity: fixture.source.storageIdentifier,
+        fingerprint: "stale-attempt",
+        targetIDs: ["framework:Foo.framework"],
+        toolCompatibilityIdentity: "test"
+      ),
+      at: staleDate
+    )
+    try await store.beginTargetAttempt(
+      targetID: "framework:Foo.framework",
+      displayName: "Foo.framework",
+      kind: "framework",
+      in: staleRunID,
+      at: staleDate
+    )
+    try await store.recordTargetAttempt(
+      .init(
+        targetID: "framework:Foo.framework",
+        displayName: "Foo.framework",
+        kind: "framework",
+        status: .partial,
+        artifacts: [
+          .init(rawValue: "Frameworks/Bar/Headers/Generated.h"),
+          .init(rawValue: "User/keep.txt"),
+        ],
+        failureSummary: "stale partial output",
+        completedAt: staleDate
+      ),
+      in: staleRunID
+    )
+    _ = try await store.finishRunWithoutPublication(staleRunID, at: staleDate)
+
+    await #expect(throws: InjectedFault.self) {
+      _ = try await fixture.executor(
+        runner: RecordingRunner(contents: "foo"),
+        runID: "run-foo",
+        generationID: "generation-foo",
+        publicationFaultInjector: { point in
+          if point == .afterPrepared { throw InjectedFault.stop }
+        }
+      ).run(plan: try fixture.plan(.query("Foo"), resumeBehavior: .fresh))
+    }
+
+    #expect(try fixture.readLiveHeader(framework: "Bar") == "bar")
+    #expect(try fixture.readStableHeader(framework: "Bar") == "bar")
+    #expect(try fixture.readLiveHeader(framework: "Foo") == "foo")
+    #expect(
+      try String(
+        contentsOf: fixture.liveURL.appendingPathComponent("User/keep.txt"),
+        encoding: .utf8
+      ) == "opaque"
+    )
+    #expect(
+      try String(
+        contentsOf: fixture.stableURL.appendingPathComponent("User/keep.txt"),
+        encoding: .utf8
+      ) == "opaque"
+    )
+  }
+
+  @Test func freshRunRebuildsStateWhenManagedGenerationOutlivesDatabase() async throws {
+    let fixture = try ExecutorFixture()
+    defer { fixture.cleanup() }
+    try fixture.createFramework("Foo.framework")
+    _ = try await fixture.executor(
+      runner: RecordingRunner(contents: "first", additionalHeaderName: "Removed.h"),
+      runID: "run-first",
+      generationID: "generation-first"
+    ).run(plan: try fixture.plan(.query("Foo")))
+    try fixture.removeDatabaseFiles()
+    let runner = RecordingRunner(contents: "regenerated")
+    let executor = fixture.executor(
+      runner: runner,
+      runID: "run-regenerated",
+      generationID: "generation-regenerated"
+    )
+    let preparedPlan = try await executor.prepare(
+      fixture.plan(.query("Foo"), resumeBehavior: .fresh)
+    )
+
+    #expect(try await executor.availableResumeSummary(for: preparedPlan) == nil)
+    #expect(!FileManager.default.fileExists(atPath: fixture.databaseURL.path))
+    let result = try await executor.run(preparedPlan)
+
+    #expect(await runner.invocationCount == 1)
+    #expect(result.targetCounts.completed == 1)
+    #expect(try fixture.readLiveHeader() == "regenerated")
+    #expect(try fixture.readStableHeader() == "regenerated")
+    #expect(!FileManager.default.fileExists(
+      atPath: fixture.liveURL.appendingPathComponent(
+        "Frameworks/Foo/Headers/Removed.h"
+      ).path
+    ))
+  }
+
+  @Test func freshDatabaseBootstrapSurvivesFailedPublicationAndRetries() async throws {
+    let fixture = try ExecutorFixture()
+    defer { fixture.cleanup() }
+    try fixture.createFramework("Foo.framework")
+    _ = try await fixture.executor(
+      runner: RecordingRunner(contents: "first"),
+      runID: "run-first",
+      generationID: "generation-first"
+    ).run(plan: try fixture.plan(.query("Foo")))
+    try fixture.removeDatabaseFiles()
+
+    await #expect(throws: InjectedFault.self) {
+      _ = try await fixture.executor(
+        runner: RecordingRunner(contents: "unpublished"),
+        runID: "run-faulted",
+        generationID: "generation-faulted",
+        publicationFaultInjector: { point in
+          if point == .afterPrepared { throw InjectedFault.stop }
+        }
+      ).run(plan: try fixture.plan(.query("Foo"), resumeBehavior: .fresh))
+    }
+
+    let runner = RecordingRunner(contents: "recovered")
+    let result = try await fixture.executor(
+      runner: runner,
+      runID: "run-recovered",
+      generationID: "generation-recovered"
+    ).run(plan: try fixture.plan(.query("Foo"), resumeBehavior: .fresh))
+
+    #expect(await runner.invocationCount == 1)
+    #expect(result.targetCounts.completed == 1)
+    #expect(try fixture.readLiveHeader() == "recovered")
+    #expect(try fixture.readStableHeader() == "recovered")
+  }
+
+  @Test func freshDatabaseBootstrapCompletesMissingStablePointer() async throws {
+    let fixture = try ExecutorFixture()
+    defer { fixture.cleanup() }
+    try fixture.createFramework("Foo.framework")
+    await #expect(throws: InjectedFault.self) {
+      _ = try await fixture.executor(
+        runner: RecordingRunner(contents: "first"),
+        runID: "run-first",
+        generationID: "generation-first",
+        publicationFaultInjector: { point in
+          if point == .afterCurrentPointerSwitch { throw InjectedFault.stop }
+        }
+      ).run(plan: try fixture.plan(.query("Foo"), resumeBehavior: .fresh))
+    }
+    #expect(try fixture.publisher().inspect().stablePathState == .absent)
+    try fixture.removeDatabaseFiles()
+
+    let runner = RecordingRunner(contents: "regenerated")
+    _ = try await fixture.executor(
+      runner: runner,
+      runID: "run-regenerated",
+      generationID: "generation-regenerated"
+    ).run(plan: try fixture.plan(.query("Foo"), resumeBehavior: .fresh))
+
+    #expect(await runner.invocationCount == 1)
+    #expect(try fixture.publisher().inspect().stablePathState == .managed)
+    #expect(try fixture.readLiveHeader() == "regenerated")
+    #expect(try fixture.readStableHeader() == "regenerated")
+  }
+
+  @Test func freshDatabaseBootstrapKeepsReplacementPublishedByCurrentGeneration() async throws {
+    let fixture = try ExecutorFixture()
+    defer { fixture.cleanup() }
+    try fixture.createFramework("Foo.framework")
+    try fixture.createFramework("Bar.framework")
+    _ = try await fixture.executor(
+      runner: RecordingRunner(contents: "new"),
+      runID: "run-new",
+      generationID: "generation-new"
+    ).run(plan: try fixture.plan(.query("Foo"), resumeBehavior: .fresh))
+
+    try "old".write(
+      to: fixture.liveHeaderURL(framework: "Foo"),
+      atomically: true,
+      encoding: .utf8
+    )
+    let artifact = try PrivateHeaderGeneration.ArtifactPath(
+      "Frameworks/Foo/Headers/Generated.h"
+    )
+    let replacementInput = fixture.stateDirectory.appendingPathComponent(
+      "replacement-input",
+      isDirectory: true
+    )
+    let stagedSource = replacementInput.appendingPathComponent("output", isDirectory: true)
+    let stagedHeader = stagedSource.appendingPathComponent("Headers/Generated.h")
+    try FileManager.default.createDirectory(
+      at: stagedHeader.deletingLastPathComponent(),
+      withIntermediateDirectories: true
+    )
+    try "new".write(to: stagedHeader, atomically: true, encoding: .utf8)
+    let replacementStore = PrivateHeaderGeneration.ArtifactStore(
+      artifactRoot: fixture.liveURL
+    )
+    let replacementDirectory = fixture.stateDirectory
+      .appendingPathComponent("replacements/run-new", isDirectory: true)
+      .appendingPathComponent("framework%3AFoo.framework", isDirectory: true)
+    let replacement = try replacementStore.prepareReplacement(
+      stagingDirectory: replacementInput,
+      stagedSourceDirectory: stagedSource,
+      artifactRoot: try PrivateHeaderGeneration.ArtifactPath("Frameworks/Foo"),
+      artifacts: [artifact],
+      removing: [artifact],
+      runID: .init(rawValue: "run-new"),
+      targetID: "framework:Foo.framework",
+      at: replacementDirectory
+    )
+    try replacementStore.applyReplacement(replacement)
+    #expect(try fixture.readLiveHeader(framework: "Foo") == "new")
+    try fixture.removeDatabaseFiles()
+
+    let runner = RecordingRunner(contents: "bar")
+    _ = try await fixture.executor(
+      runner: runner,
+      runID: "run-bar",
+      generationID: "generation-bar"
+    ).run(plan: try fixture.plan(.query("Bar"), resumeBehavior: .fresh))
+
+    #expect(await runner.invocationCount == 1)
+    #expect(try fixture.readLiveHeader(framework: "Foo") == "new")
+    #expect(try fixture.readStableHeader(framework: "Foo") == "new")
+    #expect(try fixture.readStableHeader(framework: "Bar") == "bar")
+    #expect(!FileManager.default.fileExists(atPath: replacementDirectory.path))
+  }
+
+  @Test func freshDatabaseBootstrapRejectsUnauthenticatedSamePathLiveBytes() async throws {
+    let fixture = try ExecutorFixture()
+    defer { fixture.cleanup() }
+    try fixture.createFramework("Foo.framework")
+    _ = try await fixture.executor(
+      runner: RecordingRunner(contents: "stable"),
+      runID: "run-stable",
+      generationID: "generation-stable"
+    ).run(plan: try fixture.plan(.query("Foo"), resumeBehavior: .fresh))
+    await #expect(throws: InjectedFault.self) {
+      _ = try await fixture.executor(
+        runner: RecordingRunner(contents: "incremental"),
+        runID: "run-incremental",
+        generationID: "generation-incremental",
+        publicationFaultInjector: { point in
+          if point == .afterPrepared { throw InjectedFault.stop }
+        }
+      ).run(plan: try fixture.plan(.query("Foo"), resumeBehavior: .fresh))
+    }
+    try fixture.removeDatabaseFiles()
+    let runner = RecordingRunner(contents: "must-not-run")
+
+    await #expect(throws: PrivateHeaderGeneration.ArtifactStoreError.self) {
+      _ = try await fixture.executor(
+        runner: runner,
+        runID: "run-retry",
+        generationID: "generation-retry"
+      ).run(plan: try fixture.plan(.query("Foo"), resumeBehavior: .fresh))
+    }
+
+    #expect(await runner.invocationCount == 0)
+    #expect(try fixture.readLiveHeader() == "incremental")
+    #expect(try fixture.readStableHeader() == "stable")
+
+    let summaryRunner = RecordingRunner(contents: "must-not-run")
+    let summaryExecutor = fixture.executor(
+      runner: summaryRunner,
+      runID: "run-summary",
+      generationID: "generation-summary"
+    )
+    let summaryPlan = try await summaryExecutor.prepare(
+      fixture.plan(.query("Foo"), resumeBehavior: .resume)
+    )
+    await #expect(throws: PrivateHeaderGeneration.ArtifactStoreError.self) {
+      _ = try await summaryExecutor.availableResumeSummary(for: summaryPlan)
+    }
+    #expect(await summaryRunner.invocationCount == 0)
+    #expect(try fixture.readLiveHeader() == "incremental")
+
+    let secondRetryRunner = RecordingRunner(contents: "must-not-run")
+    await #expect(throws: PrivateHeaderGeneration.ArtifactStoreError.self) {
+      _ = try await fixture.executor(
+        runner: secondRetryRunner,
+        runID: "run-second-retry",
+        generationID: "generation-second-retry"
+      ).run(plan: try fixture.plan(.query("Foo"), resumeBehavior: .fresh))
+    }
+    #expect(await secondRetryRunner.invocationCount == 0)
+    #expect(try fixture.readLiveHeader() == "incremental")
+  }
+
+  @Test func freshDatabaseBootstrapPreservesUnauthenticatedAdditionalLiveFile() async throws {
+    let fixture = try ExecutorFixture()
+    defer { fixture.cleanup() }
+    try fixture.createFramework("Foo.framework")
+    _ = try await fixture.executor(
+      runner: RecordingRunner(contents: "stable"),
+      runID: "run-stable",
+      generationID: "generation-stable"
+    ).run(plan: try fixture.plan(.query("Foo"), resumeBehavior: .fresh))
+    await #expect(throws: InjectedFault.self) {
+      _ = try await fixture.executor(
+        runner: RecordingRunner(contents: "stable", additionalHeaderName: "Additional.h"),
+        runID: "run-incremental",
+        generationID: "generation-incremental",
+        publicationFaultInjector: { point in
+          if point == .afterPrepared { throw InjectedFault.stop }
+        }
+      ).run(plan: try fixture.plan(.query("Foo"), resumeBehavior: .fresh))
+    }
+    try fixture.removeDatabaseFiles()
+    let additionalHeader = fixture.liveURL.appendingPathComponent(
+      "Frameworks/Foo/Headers/Additional.h"
+    )
+    let runner = RecordingRunner(contents: "must-not-run")
+
+    await #expect(throws: PrivateHeaderGeneration.StateError.self) {
+      _ = try await fixture.executor(
+        runner: runner,
+        runID: "run-retry",
+        generationID: "generation-retry"
+      ).run(plan: try fixture.plan(.query("Foo"), resumeBehavior: .fresh))
+    }
+
+    #expect(await runner.invocationCount == 0)
+    #expect(FileManager.default.fileExists(atPath: additionalHeader.path))
+    #expect(try String(contentsOf: additionalHeader, encoding: .utf8) == "stable")
   }
 
   @Test func legacyJSONGateRunsBeforeDatabaseCreationOnEveryRetry() async throws {
@@ -1107,6 +1823,78 @@ struct PrivateHeaderGenerationExecutorTests {
     )
   }
 
+  @Test(arguments: [
+    "Frameworks/Foo/headers/Generated.h",
+    "Frameworks/Foo/Headers",
+  ])
+  func freshLegacyCollisionFailsBeforePublishingTargetOwnership(
+    _ legacyPath: String
+  ) async throws {
+    let fixture = try ExecutorFixture()
+    defer { fixture.cleanup() }
+    try fixture.createFramework("Foo.framework")
+    let legacyArtifact = fixture.stableURL.appendingPathComponent(legacyPath)
+    try FileManager.default.createDirectory(
+      at: legacyArtifact.deletingLastPathComponent(),
+      withIntermediateDirectories: true
+    )
+    try "legacy".write(to: legacyArtifact, atomically: true, encoding: .utf8)
+    let runner = RecordingRunner(contents: "generated")
+
+    await #expect(throws: PrivateHeaderGeneration.GenerationError.self) {
+      _ = try await fixture.executor(
+        runner: runner,
+        runID: "run-legacy-collision",
+        generationID: "generation-legacy-collision"
+      ).run(plan: try fixture.plan(.query("Foo"), resumeBehavior: .fresh))
+    }
+
+    #expect(await runner.invocationCount == 1)
+    #expect(!FileManager.default.fileExists(atPath: fixture.liveHeaderURL().path))
+    #expect(try String(contentsOf: legacyArtifact, encoding: .utf8) == "legacy")
+    let store = try GenerationStore(
+      databaseURL: fixture.databaseURL,
+      toolCompatibilityIdentity: "test"
+    )
+    #expect(try await store.publishedArtifactsByTarget().isEmpty)
+  }
+
+  @Test(arguments: [
+    ".privateheaderkit-generation.json/opaque.txt",
+    ".PRIVATEHEADERKIT-GENERATION.JSON",
+  ])
+  func freshLegacyReservedMarkerCollisionFailsBeforeRunningTarget(
+    _ legacyPath: String
+  ) async throws {
+    let fixture = try ExecutorFixture()
+    defer { fixture.cleanup() }
+    try fixture.createFramework("Foo.framework")
+    let legacyArtifact = fixture.stableURL.appendingPathComponent(legacyPath)
+    try FileManager.default.createDirectory(
+      at: legacyArtifact.deletingLastPathComponent(),
+      withIntermediateDirectories: true
+    )
+    try "legacy".write(to: legacyArtifact, atomically: true, encoding: .utf8)
+    let runner = RecordingRunner(contents: "generated")
+
+    await #expect(throws: PrivateHeaderGeneration.GenerationError.self) {
+      _ = try await fixture.executor(
+        runner: runner,
+        runID: "run-reserved-marker",
+        generationID: "generation-reserved-marker"
+      ).run(plan: try fixture.plan(.query("Foo"), resumeBehavior: .fresh))
+    }
+
+    #expect(await runner.invocationCount == 0)
+    #expect(!FileManager.default.fileExists(atPath: fixture.liveHeaderURL().path))
+    #expect(try String(contentsOf: legacyArtifact, encoding: .utf8) == "legacy")
+    let store = try GenerationStore(
+      databaseURL: fixture.databaseURL,
+      toolCompatibilityIdentity: "test"
+    )
+    #expect(try await store.publishedArtifactsByTarget().isEmpty)
+  }
+
   @Test func startupRecoveryRemovesCrashedStateStagingPayload() async throws {
     let fixture = try ExecutorFixture()
     defer { fixture.cleanup() }
@@ -1162,16 +1950,17 @@ struct PrivateHeaderGenerationExecutorTests {
       runner: RecordingRunner(contents: "first"),
       runID: "run-001",
       generationID: "generation-001"
-    ).run(plan: try fixture.plan(.query("Foo")))
+    ).run(plan: try fixture.plan(.query("Foo"), outputBase: alias))
     let secondRunner = RecordingRunner(contents: "second")
 
     let result = try await fixture.executor(
       runner: secondRunner,
       runID: "run-002",
       generationID: "generation-002"
-    ).run(plan: try fixture.plan(.query("Foo"), outputBase: alias))
+    ).run(plan: try fixture.plan(.query("Foo")))
 
     #expect(await secondRunner.invocationCount == 0)
+    #expect(result.artifactDirectory == fixture.liveURL)
     #expect(result.stateDatabaseURL == fixture.databaseURL)
     #expect(try fixture.readStableHeader() == "first")
   }
@@ -1358,6 +2147,7 @@ private actor RecordingRunner {
   let thrownError: (any Error & Sendable)?
   let writesHiddenPayload: Bool
   let hiddenPayloadFramework: String?
+  let primaryHeaderName: String
   let additionalHeaderName: String?
   let cancelsForFramework: String?
   let afterRun: @Sendable () -> Void
@@ -1368,6 +2158,7 @@ private actor RecordingRunner {
     thrownError: (any Error & Sendable)? = nil,
     writesHiddenPayload: Bool = false,
     hiddenPayloadFramework: String? = nil,
+    primaryHeaderName: String = "Generated.h",
     additionalHeaderName: String? = nil,
     cancelsForFramework: String? = nil,
     afterRun: @escaping @Sendable () -> Void = {}
@@ -1377,6 +2168,7 @@ private actor RecordingRunner {
     self.thrownError = thrownError
     self.writesHiddenPayload = writesHiddenPayload
     self.hiddenPayloadFramework = hiddenPayloadFramework
+    self.primaryHeaderName = primaryHeaderName
     self.additionalHeaderName = additionalHeaderName
     self.cancelsForFramework = cancelsForFramework
     self.afterRun = afterRun
@@ -1395,7 +2187,7 @@ private actor RecordingRunner {
     if let contents {
       let output = outputDirectory(for: invocation)
       try FileManager.default.createDirectory(at: output, withIntermediateDirectories: true)
-      try Data(contents.utf8).write(to: output.appendingPathComponent("Generated.h"))
+      try Data(contents.utf8).write(to: output.appendingPathComponent(primaryHeaderName))
       if let additionalHeaderName {
         try Data(contents.utf8).write(to: output.appendingPathComponent(additionalHeaderName))
       }
@@ -1500,8 +2292,26 @@ private struct ExecutorFixture {
   }
   var databaseURL: URL { stateDirectory.appendingPathComponent("generation.sqlite") }
 
+  func stagedHeaderURL(runID: String, framework: String) -> URL {
+    stateDirectory
+      .appendingPathComponent("staging/\(runID)", isDirectory: true)
+      .appendingPathComponent("framework%3A\(framework).framework", isDirectory: true)
+      .appendingPathComponent(
+        "System/Library/Frameworks/\(framework).framework/Headers/Generated.h"
+      )
+  }
+
   func cleanup() {
     try? FileManager.default.removeItem(at: root)
+  }
+
+  func removeDatabaseFiles() throws {
+    for suffix in ["", "-shm", "-wal"] {
+      let url = URL(fileURLWithPath: databaseURL.path + suffix)
+      if FileManager.default.fileExists(atPath: url.path) {
+        try FileManager.default.removeItem(at: url)
+      }
+    }
   }
 
   func createFramework(_ name: String) throws {

--- a/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationExecutorTests.swift
+++ b/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationExecutorTests.swift
@@ -348,36 +348,40 @@ struct PrivateHeaderGenerationExecutorTests {
     #expect(try fixture.readStableHeader(framework: "Bar") == "resumed")
   }
 
-  @Test func resumeRemovesAttemptedOrphansAfterCrashBetweenLiveCopyAndDatabaseCommit()
+  @Test func databaseCommitFailureRestoresPreviousTargetAndResumeReplacesItCleanly()
     async throws
   {
     let fixture = try ExecutorFixture()
     defer { fixture.cleanup() }
     try fixture.createFramework("Foo.framework")
-    let plan = try fixture.plan(.query("Foo"), resumeBehavior: .resume)
+    _ = try await fixture.executor(
+      runner: RecordingRunner(contents: "old"),
+      runID: "run-old",
+      generationID: "generation-old"
+    ).run(plan: try fixture.plan(.query("Foo"), resumeBehavior: .fresh))
 
     await #expect(throws: InjectedFault.self) {
       _ = try await fixture.executor(
-        runner: RecordingRunner(contents: "first", additionalHeaderName: "Stale.h"),
+        runner: RecordingRunner(contents: "uncommitted", additionalHeaderName: "Stale.h"),
         runID: "run-crashed",
         generationID: "generation-crashed",
         storeFaultInjector: { point in
           if point == .afterRunTargetWrite { throw InjectedFault.stop }
         }
-      ).run(plan: plan)
+      ).run(plan: try fixture.plan(.query("Foo"), resumeBehavior: .fresh))
     }
     let staleHeader = fixture.liveURL.appendingPathComponent(
       "Frameworks/Foo/Headers/Stale.h"
     )
-    #expect(FileManager.default.fileExists(atPath: staleHeader.path))
-    try FileManager.default.removeItem(at: fixture.liveHeaderURL())
+    #expect(try fixture.readLiveHeader() == "old")
+    #expect(!FileManager.default.fileExists(atPath: staleHeader.path))
 
     let resumedRunner = RecordingRunner(contents: "second")
     _ = try await fixture.executor(
       runner: resumedRunner,
       runID: "run-recovered",
       generationID: "generation-recovered"
-    ).run(plan: plan)
+    ).run(plan: try fixture.plan(.query("Foo"), resumeBehavior: .resume))
 
     #expect(await resumedRunner.invocationCount == 1)
     #expect(try fixture.readLiveHeader() == "second")
@@ -925,6 +929,70 @@ struct PrivateHeaderGenerationExecutorTests {
     }
 
     #expect(!FileManager.default.fileExists(atPath: fixture.databaseURL.path))
+    #expect(!FileManager.default.fileExists(atPath: fixture.liveURL.path))
+  }
+
+  @Test func freshLegacyMigrationPublishesOpaqueArtifactInLiveOutput() async throws {
+    let fixture = try ExecutorFixture()
+    defer { fixture.cleanup() }
+    try fixture.createFramework("Foo.framework")
+    let legacyArtifact = fixture.stableURL.appendingPathComponent("Notes/custom.txt")
+    try FileManager.default.createDirectory(
+      at: legacyArtifact.deletingLastPathComponent(),
+      withIntermediateDirectories: true
+    )
+    try "opaque".write(to: legacyArtifact, atomically: true, encoding: .utf8)
+
+    let result = try await fixture.executor(
+      runner: RecordingRunner(contents: "generated"),
+      runID: "run-legacy",
+      generationID: "generation-legacy"
+    ).run(plan: try fixture.plan(.query("Foo"), resumeBehavior: .fresh))
+
+    let liveArtifact = fixture.liveURL.appendingPathComponent("Notes/custom.txt")
+    #expect(result.artifactDirectory == fixture.liveURL)
+    #expect(try String(contentsOf: liveArtifact, encoding: .utf8) == "opaque")
+    #expect(try String(contentsOf: fixture.stableURL.appendingPathComponent("Notes/custom.txt"), encoding: .utf8) == "opaque")
+    let publisher = try ArtifactPublisher(
+      artifactBaseDirectory: fixture.outputBase,
+      sourceLabel: fixture.sourceLabel
+    )
+    #expect(
+      try publisher.inspect().currentMarker?.opaquePaths
+        == [PrivateHeaderGeneration.ArtifactPath(rawValue: "Notes/custom.txt")]
+    )
+  }
+
+  @Test func freshLegacyMigrationKeepsGeneratedClaimOverOpaquePath() async throws {
+    let fixture = try ExecutorFixture()
+    defer { fixture.cleanup() }
+    try fixture.createFramework("Foo.framework")
+    let claimedArtifact = fixture.stableURL.appendingPathComponent(
+      "Frameworks/Foo/Headers/Generated.h"
+    )
+    try FileManager.default.createDirectory(
+      at: claimedArtifact.deletingLastPathComponent(),
+      withIntermediateDirectories: true
+    )
+    try "legacy".write(to: claimedArtifact, atomically: true, encoding: .utf8)
+
+    _ = try await fixture.executor(
+      runner: RecordingRunner(contents: "generated"),
+      runID: "run-claim",
+      generationID: "generation-claim"
+    ).run(plan: try fixture.plan(.query("Foo"), resumeBehavior: .fresh))
+
+    #expect(try fixture.readLiveHeader() == "generated")
+    let publisher = try ArtifactPublisher(
+      artifactBaseDirectory: fixture.outputBase,
+      sourceLabel: fixture.sourceLabel
+    )
+    let marker = try #require(publisher.inspect().currentMarker)
+    #expect(marker.opaquePaths.isEmpty)
+    #expect(
+      marker.artifactsByTarget["framework:Foo.framework"]
+        == [PrivateHeaderGeneration.ArtifactPath(rawValue: "Frameworks/Foo/Headers/Generated.h")]
+    )
   }
 
   @Test func startupRecoveryRemovesCrashedStateStagingPayload() async throws {

--- a/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationExecutorTests.swift
+++ b/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationExecutorTests.swift
@@ -1468,6 +1468,56 @@ struct PrivateHeaderGenerationExecutorTests {
     ))
   }
 
+  @Test func resumeSummaryRebuildsStateWhenManagedGenerationOutlivesDatabase() async throws {
+    let fixture = try ExecutorFixture()
+    defer { fixture.cleanup() }
+    try fixture.createFramework("Foo.framework")
+    let plan = try fixture.plan(.query("Foo"))
+    _ = try await fixture.executor(
+      runner: RecordingRunner(contents: "first"),
+      runID: "run-first",
+      generationID: "generation-first"
+    ).run(plan: plan)
+    try fixture.removeDatabaseFiles()
+    let runner = RecordingRunner(contents: "unexpected")
+    let executor = fixture.executor(
+      runner: runner,
+      runID: "run-summary",
+      generationID: "generation-summary"
+    )
+    let preparedPlan = try await executor.prepare(plan)
+
+    #expect(try await executor.availableResumeSummary(for: preparedPlan) == nil)
+    #expect(await runner.invocationCount == 0)
+    #expect(FileManager.default.fileExists(atPath: fixture.databaseURL.path))
+    #expect(try fixture.readLiveHeader() == "first")
+    #expect(try fixture.readStableHeader() == "first")
+  }
+
+  @Test func resumeRunRebuildsStateWhenManagedGenerationOutlivesDatabase() async throws {
+    let fixture = try ExecutorFixture()
+    defer { fixture.cleanup() }
+    try fixture.createFramework("Foo.framework")
+    _ = try await fixture.executor(
+      runner: RecordingRunner(contents: "first"),
+      runID: "run-first",
+      generationID: "generation-first"
+    ).run(plan: try fixture.plan(.query("Foo")))
+    try fixture.removeDatabaseFiles()
+    let runner = RecordingRunner(contents: "unexpected")
+
+    let result = try await fixture.executor(
+      runner: runner,
+      runID: "run-resumed",
+      generationID: "generation-resumed"
+    ).run(plan: try fixture.plan(.query("Foo"), resumeBehavior: .resume))
+
+    #expect(await runner.invocationCount == 0)
+    #expect(result.targetCounts.skipped == 1)
+    #expect(try fixture.readLiveHeader() == "first")
+    #expect(try fixture.readStableHeader() == "first")
+  }
+
   @Test func freshDatabaseBootstrapSurvivesFailedPublicationAndRetries() async throws {
     let fixture = try ExecutorFixture()
     defer { fixture.cleanup() }

--- a/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationExecutorTests.swift
+++ b/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationExecutorTests.swift
@@ -459,6 +459,47 @@ struct PrivateHeaderGenerationExecutorTests {
     #expect(try fixture.readLiveHeader() == "recovered")
   }
 
+  @Test func snapshotRebuildDropsPublishedTargetThatIsMissingFromLiveOutput() async throws {
+    let fixture = try ExecutorFixture()
+    defer { fixture.cleanup() }
+    try fixture.createFramework("Foo.framework")
+    try fixture.createFramework("Bar.framework")
+    _ = try await fixture.executor(
+      runner: RecordingRunner(contents: "old", additionalHeaderName: "Removed.h"),
+      runID: "run-old",
+      generationID: "generation-old"
+    ).run(plan: try fixture.plan(.query("Foo"), resumeBehavior: .fresh))
+
+    await #expect(throws: InjectedFault.self) {
+      _ = try await fixture.executor(
+        runner: RecordingRunner(contents: "new"),
+        runID: "run-new",
+        generationID: "generation-new",
+        publicationFaultInjector: { point in
+          if point == .afterPrepared { throw InjectedFault.stop }
+        }
+      ).run(plan: try fixture.plan(.query("Foo"), resumeBehavior: .fresh))
+    }
+    try FileManager.default.removeItem(at: fixture.liveHeaderURL(framework: "Foo"))
+
+    _ = try await fixture.executor(
+      runner: RecordingRunner(contents: "bar"),
+      runID: "run-bar",
+      generationID: "generation-bar"
+    ).run(plan: try fixture.plan(.query("Bar"), resumeBehavior: .fresh))
+
+    let marker = try #require(fixture.publisher().inspect().currentMarker)
+    #expect(marker.artifactsByTarget.keys.sorted() == ["framework:Bar.framework"])
+    let recoveredRunner = RecordingRunner(contents: "recovered")
+    _ = try await fixture.executor(
+      runner: recoveredRunner,
+      runID: "run-recovered",
+      generationID: "generation-recovered"
+    ).run(plan: try fixture.plan(.query("Foo"), resumeBehavior: .fresh))
+    #expect(await recoveredRunner.invocationCount == 1)
+    #expect(try fixture.readLiveHeader(framework: "Foo") == "recovered")
+  }
+
   @Test func compatibleResumeSkipsCurrentCompletedTarget() async throws {
     let fixture = try ExecutorFixture()
     defer { fixture.cleanup() }

--- a/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationStoreTests.swift
+++ b/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationStoreTests.swift
@@ -128,6 +128,39 @@ struct PrivateHeaderGenerationStoreTests {
     )
   }
 
+  @Test func publishedTargetAttemptBecomesImmediatelyResumable() async throws {
+    let fixture = try StoreFixture()
+    defer { fixture.cleanup() }
+    let runID = PrivateHeaderGeneration.RunID(rawValue: "run-incremental")
+    _ = try await fixture.store.beginRun(
+      id: runID,
+      plan: fixture.plan(targetIDs: ["framework:Foo"]),
+      at: fixture.date
+    )
+    try await fixture.store.beginTargetAttempt(
+      targetID: "framework:Foo",
+      displayName: "Foo",
+      kind: "framework",
+      in: runID,
+      at: fixture.date
+    )
+    let completed = fixture.completedTarget("framework:Foo")
+
+    try await fixture.store.prepareTargetPublication(completed, in: runID)
+    try await fixture.store.recordPublishedTargetAttempt(completed, in: runID)
+
+    #expect(try await fixture.store.runSnapshot(runID).status == .running)
+    #expect(try await fixture.store.runSnapshot(runID).targets.first?.status == .completed)
+    #expect(
+      try await fixture.store.targetSnapshot(targetID: "framework:Foo")?.lastSuccessfulRunID
+        == runID
+    )
+    #expect(
+      try await fixture.store.publishedArtifactsByTarget()["framework:Foo"]
+        == completed.artifacts
+    )
+  }
+
   @Test func committedIntentRejectsMismatchedCurrentMarker() async throws {
     let fixture = try StoreFixture()
     defer { fixture.cleanup() }
@@ -459,7 +492,9 @@ struct PrivateHeaderGenerationStoreTests {
     }
   }
 
-  @Test func completedAttemptRequiresTransactionalPublicationOwnershipToResumeAsComplete() async throws {
+  @Test func completedAttemptRequiresTransactionalPublicationOwnershipToResumeAsComplete()
+    async throws
+  {
     let fixture = try StoreFixture()
     defer { fixture.cleanup() }
     let first = try await fixture.prepareCompletedPublication()
@@ -676,7 +711,8 @@ private final class StoreFixture: @unchecked Sendable {
   init(fault: @escaping GenerationStore.FaultInjector = { _ in }) throws {
     root = try temporaryDirectory()
     databaseURL = root.appendingPathComponent("generation.sqlite")
-    store = try GenerationStore(databaseURL: databaseURL, toolCompatibilityIdentity: "test", faultInjector: fault)
+    store = try GenerationStore(
+      databaseURL: databaseURL, toolCompatibilityIdentity: "test", faultInjector: fault)
   }
 
   func cleanup() {

--- a/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationStoreTests.swift
+++ b/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationStoreTests.swift
@@ -27,6 +27,7 @@ struct PrivateHeaderGenerationStoreTests {
         "v1-generation-state",
         "v2-run-logs-and-indexes",
         "v3-causal-ordering",
+        "v4-published-artifact-digests",
       ])
     let columns = try await queue.read { db in
       try db.columns(in: "runLogs").map(\.name)
@@ -147,7 +148,14 @@ struct PrivateHeaderGenerationStoreTests {
     let completed = fixture.completedTarget("framework:Foo")
 
     try await fixture.store.prepareTargetPublication(completed, in: runID)
-    try await fixture.store.recordPublishedTargetAttempt(completed, in: runID)
+    try await fixture.store.recordPublishedTargetAttempt(
+      completed,
+      artifactDigests: [
+        PrivateHeaderGeneration.ArtifactPath(rawValue: "Frameworks/Foo/Foo.h"):
+          String(repeating: "0", count: 64)
+      ],
+      in: runID
+    )
 
     #expect(try await fixture.store.runSnapshot(runID).status == .running)
     #expect(try await fixture.store.runSnapshot(runID).targets.first?.status == .completed)

--- a/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationTests.swift
+++ b/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationTests.swift
@@ -72,7 +72,8 @@ struct PrivateHeaderGenerationTests {
     )
 
     #expect(
-      plan.artifactDirectory.path == "/tmp/PrivateHeaderKit/macos-v1-16.0-b1-25~41000")
+      plan.artifactDirectory.path
+        == "/tmp/PrivateHeaderKit/generated-headers/macos-v1-16.0-b1-25~41000")
     #expect(
       plan.stateDirectory.path == "/tmp/PrivateHeaderKit/.state/macos-v1-16.0-b1-25~41000")
     #expect(

--- a/Tests/PrivateHeaderKitToolingTestHelper/main.swift
+++ b/Tests/PrivateHeaderKitToolingTestHelper/main.swift
@@ -41,6 +41,12 @@ private struct PrivateHeaderKitToolingTestHelper {
                 try writeLargeStandardErrorFailure(byteCount: byteCount)
             case "chunked-output":
                 try writeChunkedOutput()
+            case "buffered-output":
+#if os(macOS)
+                try await runBufferedOutputCheck()
+#else
+                throw HelperError.invalidCommand(command)
+#endif
             case "process-group":
 #if os(macOS)
                 let arguments = Array(CommandLine.arguments.dropFirst(2))
@@ -136,6 +142,26 @@ private struct PrivateHeaderKitToolingTestHelper {
     }
 
 #if os(macOS)
+    private static func runBufferedOutputCheck() async throws {
+        let result = try await ProcessRunner().runBuffered(
+            [
+                "/bin/zsh", "-lc",
+                "print -r -- buffered-stdout; print -u2 -- buffered-stderr; exit 19",
+            ],
+            env: nil,
+            cwd: nil
+        )
+        guard result.status == 19,
+              !result.wasKilled,
+              result.lastLines == ["buffered-stdout", "buffered-stderr"]
+        else {
+            throw ToolingError.message(
+                "status=\(result.status) killed=\(result.wasKilled) lines=\(result.lastLines)"
+            )
+        }
+        print("buffered-ok")
+    }
+
     private static func writeCurrentProcessIdentity(to descriptor: Int32) throws {
         var info = proc_bsdinfo()
         let expectedSize = Int32(MemoryLayout<proc_bsdinfo>.size)

--- a/Tests/PrivateHeaderKitToolingTests/StreamingProcessRunnerTests.swift
+++ b/Tests/PrivateHeaderKitToolingTests/StreamingProcessRunnerTests.swift
@@ -527,6 +527,18 @@ struct StreamingProcessRunnerTests {
         #expect(forwarded.contains("tail-line"))
     }
 
+    @Test func bufferedRunnerRetainsCombinedTailWithoutForwardingOutput() async throws {
+        let helper = try testHelperExecutableURL()
+
+        let output = try await ProcessRunner().runCapture(
+            [helper.path, "buffered-output"],
+            env: nil,
+            cwd: nil
+        )
+
+        #expect(output == "buffered-ok\n")
+    }
+
     @Test func helperUsesNullDeviceWhenParentStdinIsClosed() async throws {
         let helper = try testHelperExecutableURL()
         let output = try await ProcessRunner().runCapture(


### PR DESCRIPTION
## Purpose

Make long-running debug dumps observable and durable: completed targets should appear in the generated header tree immediately, successful work should survive later failures, and the terminal should show concise human-facing progress instead of helper diagnostics and per-target success logs.

## Root cause

The generation transaction had moved publication to an all-target final snapshot, so no stable output was visible during a long run and an infrastructure failure could discard earlier completed work. The typed CLI migration also restored newline-based progress rendering, while raw helper stdout and stderr were still passed directly through to the terminal.

## Changes

- Publish each completed target atomically under `generated-headers/<source-id>` and persist its artifact ownership and content digests before reporting completion.
- Add durable replacement journals, rollback and restart recovery, shape and case-transition handling, database-loss reconciliation, and authenticated immutable snapshot rebuilding.
- Rebuild an empty state database from the managed current generation for normal and resume flows, not only explicit fresh runs.
- Authenticate current generation contents while avoiding repeated full-content hashing of retained generations.
- Preserve completed output across later target or finalization failures and resume without rerunning authenticated targets.
- Restore one-line TTY progress animation, omit successful target lines, retain only failed targets, and buffer a bounded helper diagnostic tail for failures.
- Ignore Finder metadata in managed inventories and document the Darwin/macOS host requirement, live output layout, and resume behavior.

## Testing

- `swift test` (including 188 PrivateHeaderKitCore tests and 58 CLI tests)
- iOS Simulator compile for `PrivateHeaderKitCore`
- iOS Simulator compile for `PrivateHeaderKitCoreTests`
- `swift run -c debug privateheaderkit --help`
- Real macOS debug smoke for `AppTrackingTransparency` (2 targets, 11 generated files)
- Branch-wide Codex review in two rounds, with no actionable findings in the final round
