### PR TITLE
Improve installer PATH guidance

### DIFF
--- a/Sources/PrivateHeaderKitInstall/InstallPathGuidance.swift
+++ b/Sources/PrivateHeaderKitInstall/InstallPathGuidance.swift
@@ -1,0 +1,217 @@
+import Foundation
+
+#if canImport(Darwin)
+import Darwin
+#endif
+
+struct InstallPathGuidance {
+    private enum LoginProfile {
+        case existing(URL, appendable: Bool)
+        case creatable(URL)
+        case unavailable
+
+        var url: URL? {
+            switch self {
+            case .existing(let url, _), .creatable(let url):
+                url
+            case .unavailable:
+                nil
+            }
+        }
+
+        var isAppendable: Bool {
+            switch self {
+            case .existing(_, appendable: let appendable):
+                appendable
+            case .creatable:
+                true
+            case .unavailable:
+                false
+            }
+        }
+    }
+
+    let commandDirectory: URL
+    let environment: [String: String]
+    let fileManager: FileManager
+
+    func messages() -> [String] {
+        guard !commandDirectoryIsOnPATH else { return [] }
+
+        let directoryPath = commandDirectory.path
+        guard !directoryPath.contains(":"), !directoryPath.contains(where: \.isNewline) else {
+            return [
+                "",
+                "PrivateHeaderKit is installed, but its command directory cannot be represented safely in PATH.",
+                "",
+                "Next steps:",
+                "  Run the command using the path printed above, or reinstall to a directory without ':' or newlines.",
+            ]
+        }
+
+        guard let loginShell = loginShell() else {
+            return [
+                "",
+                "PrivateHeaderKit is installed, but its command directory is not on your PATH.",
+                "",
+                "Next steps:",
+                "  Add this directory to your login shell's PATH:",
+                "    \(directoryPath)",
+                "",
+                "Then run:",
+                "  privateheaderkit",
+            ]
+        }
+
+        let exportLine = "export PATH=\(shellQuote(directoryPath)):\"$PATH\""
+        var result = [
+            "",
+            "PrivateHeaderKit is installed, but its command directory is not on your PATH.",
+            "",
+            "Next steps:",
+        ]
+
+        if case .existing(let profileURL, _) = loginShell.profile,
+           profileContains(exportLine, at: profileURL)
+        {
+            result.append("  \(profileURL.path) already contains the PATH entry.")
+            result.append("  Open a new terminal, or use PrivateHeaderKit in this shell:")
+        } else if loginShell.profile.isAppendable,
+                  let profileURL = loginShell.profile.url
+        {
+            let appendCommand = "printf '\\n%s\\n' \(shellQuote(exportLine)) >> \(shellQuote(profileURL.path))"
+            result.append("  Add PrivateHeaderKit to future \(loginShell.name) sessions:")
+            result.append("    \(appendCommand)")
+            result.append("")
+            result.append("  Use PrivateHeaderKit in this shell:")
+        } else {
+            result.append("  Add the command directory to a writable \(loginShell.name) login profile.")
+            result.append("")
+            result.append("  Use PrivateHeaderKit in this shell:")
+        }
+
+        result.append("    \(exportLine)")
+        result.append("")
+        result.append("Then run:")
+        result.append("  privateheaderkit")
+        return result
+    }
+
+    private var commandDirectoryIsOnPATH: Bool {
+        guard let path = environment["PATH"] else { return false }
+        let installedPath = commandDirectory.standardizedFileURL.path
+        return path.split(separator: ":", omittingEmptySubsequences: false).contains { entry in
+            canonicalPATHEntry(String(entry)) == installedPath
+        }
+    }
+
+    private func canonicalPATHEntry(_ entry: String) -> String {
+        let url: URL
+        if entry.isEmpty {
+            url = URL(
+                fileURLWithPath: fileManager.currentDirectoryPath,
+                isDirectory: true
+            )
+        } else {
+            url = URL(fileURLWithPath: entry, isDirectory: true)
+        }
+        let standardized = url.standardizedFileURL
+        guard fileManager.fileExists(atPath: standardized.path) else {
+            return standardized.path
+        }
+        return standardized.resolvingSymlinksInPath().standardizedFileURL.path
+    }
+
+    private func loginShell() -> (name: String, profile: LoginProfile)? {
+        guard let shellPath = nonEmpty(environment["SHELL"]),
+              let home = nonEmpty(environment["HOME"])
+        else {
+            return nil
+        }
+
+        let shellName = (shellPath as NSString).lastPathComponent
+        switch shellName {
+        case "zsh":
+            let profileRoot = nonEmpty(environment["ZDOTDIR"]) ?? home
+            let profileURL = URL(fileURLWithPath: profileRoot, isDirectory: true)
+                .appendingPathComponent(".zprofile", isDirectory: false)
+            return (shellName, classifyProfile(profileURL))
+        case "bash":
+            let homeURL = URL(fileURLWithPath: home, isDirectory: true)
+            let candidates = [".bash_profile", ".bash_login", ".profile"].map {
+                homeURL.appendingPathComponent($0, isDirectory: false)
+            }
+            if let existingProfile = candidates.first(where: isReadableRegularFile) {
+                return (shellName, classifyProfile(existingProfile))
+            }
+            if candidates.allSatisfy(isAbsent) {
+                return (shellName, classifyProfile(candidates[0]))
+            }
+            return (shellName, .unavailable)
+        default:
+            return nil
+        }
+    }
+
+    private func profileContains(_ line: String, at url: URL) -> Bool {
+        guard let data = fileManager.contents(atPath: url.path),
+              let contents = String(data: data, encoding: .utf8)
+        else {
+            return false
+        }
+        return contents.split(whereSeparator: \.isNewline).contains { $0 == line }
+    }
+
+    private func isReadableRegularFile(_ url: URL) -> Bool {
+        let resolvedURL = url.resolvingSymlinksInPath().standardizedFileURL
+        guard let attributes = try? fileManager.attributesOfItem(atPath: resolvedURL.path),
+              attributes[.type] as? FileAttributeType == .typeRegular
+        else {
+            return false
+        }
+        return fileManager.isReadableFile(atPath: resolvedURL.path)
+    }
+
+    private func classifyProfile(_ url: URL) -> LoginProfile {
+        if isReadableRegularFile(url) {
+            let resolvedURL = url.resolvingSymlinksInPath().standardizedFileURL
+            return .existing(
+                url,
+                appendable: fileManager.isWritableFile(atPath: resolvedURL.path)
+            )
+        }
+        if isAbsent(url), isWritableDirectory(url.deletingLastPathComponent()) {
+            return .creatable(url)
+        }
+        return .unavailable
+    }
+
+    private func isWritableDirectory(_ url: URL) -> Bool {
+        let resolvedURL = url.resolvingSymlinksInPath().standardizedFileURL
+        guard let attributes = try? fileManager.attributesOfItem(atPath: resolvedURL.path),
+              attributes[.type] as? FileAttributeType == .typeDirectory
+        else {
+            return false
+        }
+        return fileManager.isWritableFile(atPath: resolvedURL.path)
+    }
+
+    private func isAbsent(_ url: URL) -> Bool {
+        #if canImport(Darwin)
+        var metadata = stat()
+        let result = url.path.withCString { Darwin.lstat($0, &metadata) }
+        return result != 0 && errno == ENOENT
+        #else
+        return !fileManager.fileExists(atPath: url.path)
+        #endif
+    }
+
+    private func shellQuote(_ value: String) -> String {
+        "'\(value.replacingOccurrences(of: "'", with: "'\\''"))'"
+    }
+
+    private func nonEmpty(_ value: String?) -> String? {
+        guard let value, !value.isEmpty else { return nil }
+        return value
+    }
+}

--- a/Sources/PrivateHeaderKitInstall/PrivateHeaderKitInstallMain.swift
+++ b/Sources/PrivateHeaderKitInstall/PrivateHeaderKitInstallMain.swift
@@ -201,7 +201,7 @@ func runInstall(
         faultInjector: faultInjector,
         outputLogger: outputLogger
     )
-    try await installer.withInstallLock {
+    let result = try await installer.withInstallLock {
         let cohort: ReleaseCohort
         if let releaseDirectory = options.releaseDirectory {
             cohort = try ReleaseCohort.read(
@@ -239,8 +239,13 @@ func runInstall(
                 simulatorHelperTriple: simulatorHelperTriple
             )
         }
-        _ = try await installer.installLocked(cohort)
+        return try await installer.installLocked(cohort)
     }
+    InstallPathGuidance(
+        commandDirectory: result.publicCommandURL.deletingLastPathComponent(),
+        environment: environment,
+        fileManager: fileManager
+    ).messages().forEach(outputLogger)
 }
 
 func createReleaseManifest(

--- a/Tests/PrivateHeaderKitInstallTests/InstallPathGuidanceTests.swift
+++ b/Tests/PrivateHeaderKitInstallTests/InstallPathGuidanceTests.swift
@@ -1,0 +1,310 @@
+#if os(macOS)
+import Foundation
+import Testing
+
+@testable import PrivateHeaderKitInstall
+import PrivateHeaderKitTestSupport
+
+@Suite
+struct InstallPathGuidanceTests {
+    @Test func omitsGuidanceWhenTheCommandDirectoryIsAlreadyOnPATH() throws {
+        let directories = try makeTemporaryTestDirectories()
+        let commandDirectory = directories.root.appendingPathComponent(
+            "Private Header Bin",
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(
+            at: commandDirectory,
+            withIntermediateDirectories: true
+        )
+
+        let messages = guidance(
+            commandDirectory: commandDirectory,
+            environment: ["PATH": "/usr/bin:\(commandDirectory.path):/bin"]
+        )
+
+        #expect(messages.isEmpty)
+    }
+
+    @Test func recognizesAnExistingSymlinkedPATHEntry() throws {
+        let directories = try makeTemporaryTestDirectories()
+        let commandDirectory = directories.root.appendingPathComponent("real-bin", isDirectory: true)
+        let alias = directories.root.appendingPathComponent("bin-alias", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: commandDirectory,
+            withIntermediateDirectories: true
+        )
+        try FileManager.default.createSymbolicLink(at: alias, withDestinationURL: commandDirectory)
+
+        let messages = guidance(
+            commandDirectory: commandDirectory,
+            environment: ["PATH": "/usr/bin:\(alias.path):/bin"]
+        )
+
+        #expect(messages.isEmpty)
+    }
+
+    @Test func zshGuidanceUsesZProfileAndQuotesLiteralPathsWithoutMutatingIt() throws {
+        let directories = try makeTemporaryTestDirectories()
+        let commandDirectory = directories.root.appendingPathComponent(
+            "Private Header's Bin",
+            isDirectory: true
+        )
+        let profile = directories.root.appendingPathComponent(".zprofile")
+        let originalProfile = "export EXISTING=value\n"
+        try Data(originalProfile.utf8).write(to: profile)
+
+        let messages = guidance(
+            commandDirectory: commandDirectory,
+            environment: [
+                "HOME": directories.root.path,
+                "PATH": "/usr/bin:/bin",
+                "SHELL": "/bin/zsh",
+            ]
+        )
+
+        let exportLine = try #require(
+            messages.first(where: { $0.hasPrefix("    export PATH=") })
+        ).trimmingCharacters(in: .whitespaces)
+        #expect(messages.contains("Next steps:"))
+        #expect(messages.contains(where: { $0.contains(profile.path) }))
+        #expect(exportLine.contains("'\\''"))
+        #expect(try String(contentsOf: profile, encoding: .utf8) == originalProfile)
+        #expect(try firstPATHEntry(afterRunning: exportLine) == commandDirectory.path)
+    }
+
+    @Test func zshGuidanceDoesNotAppendToAMalformedProfile() throws {
+        let directories = try makeTemporaryTestDirectories()
+        let profile = directories.root.appendingPathComponent(".zprofile")
+        try FileManager.default.createDirectory(at: profile, withIntermediateDirectories: true)
+
+        let messages = guidance(
+            commandDirectory: directories.root.appendingPathComponent("bin", isDirectory: true),
+            environment: [
+                "HOME": directories.root.path,
+                "PATH": "/usr/bin:/bin",
+                "SHELL": "/bin/zsh",
+            ]
+        )
+
+        #expect(messages.contains(where: { $0.contains("writable zsh login profile") }))
+        #expect(!messages.contains(where: { $0.contains("printf '") }))
+        #expect(messages.contains(where: { $0.hasPrefix("    export PATH=") }))
+    }
+
+    @Test func zshGuidanceDoesNotAppendToAReadOnlyProfile() throws {
+        let directories = try makeTemporaryTestDirectories()
+        let profile = directories.root.appendingPathComponent(".zprofile")
+        try Data("export EXISTING=value\n".utf8).write(to: profile)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o444],
+            ofItemAtPath: profile.path
+        )
+
+        let messages = guidance(
+            commandDirectory: directories.root.appendingPathComponent("bin", isDirectory: true),
+            environment: [
+                "HOME": directories.root.path,
+                "PATH": "/usr/bin:/bin",
+                "SHELL": "/bin/zsh",
+            ]
+        )
+
+        #expect(messages.contains(where: { $0.contains("writable zsh login profile") }))
+        #expect(!messages.contains(where: { $0.contains("printf '") }))
+        #expect(messages.contains(where: { $0.hasPrefix("    export PATH=") }))
+    }
+
+    @Test func zshGuidanceDoesNotSuggestCreatingAProfileUnderAMissingZDotDir() throws {
+        let directories = try makeTemporaryTestDirectories()
+        let missingZDotDir = directories.root.appendingPathComponent("missing", isDirectory: true)
+
+        let messages = guidance(
+            commandDirectory: directories.root.appendingPathComponent("bin", isDirectory: true),
+            environment: [
+                "HOME": directories.root.path,
+                "PATH": "/usr/bin:/bin",
+                "SHELL": "/bin/zsh",
+                "ZDOTDIR": missingZDotDir.path,
+            ]
+        )
+
+        #expect(messages.contains(where: { $0.contains("writable zsh login profile") }))
+        #expect(!messages.contains(where: { $0.contains("printf '") }))
+        #expect(!messages.contains(where: { $0.contains(".zprofile") }))
+    }
+
+    @Test func zshGuidanceAcceptsAProfileSymlinkToAReadableFile() throws {
+        let directories = try makeTemporaryTestDirectories()
+        let realProfile = directories.root.appendingPathComponent("shared-profile")
+        let profile = directories.root.appendingPathComponent(".zprofile")
+        try Data().write(to: realProfile)
+        try FileManager.default.createSymbolicLink(at: profile, withDestinationURL: realProfile)
+
+        let messages = guidance(
+            commandDirectory: directories.root.appendingPathComponent("bin", isDirectory: true),
+            environment: [
+                "HOME": directories.root.path,
+                "PATH": "/usr/bin:/bin",
+                "SHELL": "/bin/zsh",
+            ]
+        )
+
+        #expect(messages.contains(where: { $0.contains("printf '") && $0.contains(profile.path) }))
+        #expect(!messages.contains(where: { $0.contains("writable zsh login profile") }))
+    }
+
+    @Test func existingProfileEntryIsNotSuggestedAgain() throws {
+        let directories = try makeTemporaryTestDirectories()
+        let commandDirectory = directories.root.appendingPathComponent("bin", isDirectory: true)
+        let profile = directories.root.appendingPathComponent(".zprofile")
+        let exportLine = "export PATH='\(commandDirectory.path)':\"$PATH\""
+        try Data("\(exportLine)\n".utf8).write(to: profile)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o444],
+            ofItemAtPath: profile.path
+        )
+
+        let messages = guidance(
+            commandDirectory: commandDirectory,
+            environment: [
+                "HOME": directories.root.path,
+                "PATH": "/usr/bin:/bin",
+                "SHELL": "/bin/zsh",
+            ]
+        )
+
+        #expect(messages.contains(where: { $0.contains("already contains the PATH entry") }))
+        #expect(!messages.contains(where: { $0.contains("printf '") }))
+        #expect(messages.contains("    \(exportLine)"))
+    }
+
+    @Test func bashGuidanceUsesTheFirstExistingLoginProfile() throws {
+        let directories = try makeTemporaryTestDirectories()
+        let bashLogin = directories.root.appendingPathComponent(".bash_login")
+        let profile = directories.root.appendingPathComponent(".profile")
+        try Data().write(to: bashLogin)
+        try Data().write(to: profile)
+
+        let messages = guidance(
+            commandDirectory: directories.root.appendingPathComponent("bin", isDirectory: true),
+            environment: [
+                "HOME": directories.root.path,
+                "PATH": "/usr/bin:/bin",
+                "SHELL": "/opt/homebrew/bin/bash",
+            ]
+        )
+
+        #expect(messages.contains(where: { $0.contains(bashLogin.path) }))
+        #expect(!messages.contains(where: { $0.contains(profile.path) }))
+    }
+
+    @Test func bashGuidanceSkipsAnUnreadableLoginProfile() throws {
+        let directories = try makeTemporaryTestDirectories()
+        let bashProfile = directories.root.appendingPathComponent(".bash_profile")
+        let bashLogin = directories.root.appendingPathComponent(".bash_login")
+        try Data().write(to: bashProfile)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o000],
+            ofItemAtPath: bashProfile.path
+        )
+        try Data().write(to: bashLogin)
+
+        let messages = guidance(
+            commandDirectory: directories.root.appendingPathComponent("bin", isDirectory: true),
+            environment: [
+                "HOME": directories.root.path,
+                "PATH": "/usr/bin:/bin",
+                "SHELL": "/bin/bash",
+            ]
+        )
+
+        #expect(messages.contains(where: { $0.contains(bashLogin.path) }))
+        #expect(!messages.contains(where: { $0.contains(bashProfile.path) }))
+    }
+
+    @Test func bashGuidanceDoesNotAppendToMalformedProfiles() throws {
+        let directories = try makeTemporaryTestDirectories()
+        let bashProfile = directories.root.appendingPathComponent(".bash_profile")
+        try FileManager.default.createDirectory(at: bashProfile, withIntermediateDirectories: true)
+
+        let messages = guidance(
+            commandDirectory: directories.root.appendingPathComponent("bin", isDirectory: true),
+            environment: [
+                "HOME": directories.root.path,
+                "PATH": "/usr/bin:/bin",
+                "SHELL": "/bin/bash",
+            ]
+        )
+
+        #expect(messages.contains(where: { $0.contains("writable bash login profile") }))
+        #expect(!messages.contains(where: { $0.contains("printf '") }))
+        #expect(messages.contains(where: { $0.hasPrefix("    export PATH=") }))
+    }
+
+    @Test func unknownShellDoesNotGuessAProfileOrShellSyntax() throws {
+        let directories = try makeTemporaryTestDirectories()
+        let commandDirectory = directories.root.appendingPathComponent("bin", isDirectory: true)
+
+        let messages = guidance(
+            commandDirectory: commandDirectory,
+            environment: [
+                "HOME": directories.root.path,
+                "PATH": "/usr/bin:/bin",
+                "SHELL": "/usr/local/bin/fish",
+            ]
+        )
+
+        #expect(messages.contains("    \(commandDirectory.path)"))
+        #expect(!messages.contains(where: { $0.contains("export PATH=") }))
+        #expect(!messages.contains(where: { $0.contains(".zprofile") }))
+        #expect(!messages.contains(where: { $0.contains(".bash_profile") }))
+    }
+
+    @Test func unrepresentableDirectoryUsesManualGuidance() throws {
+        let directories = try makeTemporaryTestDirectories()
+        let commandDirectory = directories.root.appendingPathComponent("colon:bin", isDirectory: true)
+
+        let messages = guidance(
+            commandDirectory: commandDirectory,
+            environment: [
+                "HOME": directories.root.path,
+                "PATH": "/usr/bin:/bin",
+                "SHELL": "/bin/zsh",
+            ]
+        )
+
+        #expect(messages.contains(where: { $0.contains("cannot be represented safely") }))
+        #expect(!messages.contains(where: { $0.contains("export PATH=") }))
+        #expect(!messages.contains(where: { $0.contains("printf '") }))
+    }
+
+    private func guidance(
+        commandDirectory: URL,
+        environment: [String: String]
+    ) -> [String] {
+        InstallPathGuidance(
+            commandDirectory: commandDirectory,
+            environment: environment,
+            fileManager: .default
+        ).messages()
+    }
+
+    private func firstPATHEntry(afterRunning exportLine: String) throws -> String {
+        let process = Process()
+        let standardOutput = Pipe()
+        process.executableURL = URL(fileURLWithPath: "/bin/sh")
+        process.arguments = [
+            "-c",
+            "\(exportLine)\nprintf '%s' \"${PATH%%:*}\"",
+        ]
+        process.environment = ["PATH": "/usr/bin:/bin"]
+        process.standardOutput = standardOutput
+        try process.run()
+        process.waitUntilExit()
+        #expect(process.terminationStatus == 0)
+        let data = standardOutput.fileHandleForReading.readDataToEndOfFile()
+        return String(decoding: data, as: UTF8.self)
+    }
+}
+#endif

--- a/Tests/PrivateHeaderKitInstallTests/PrivateHeaderKitInstallTests.swift
+++ b/Tests/PrivateHeaderKitInstallTests/PrivateHeaderKitInstallTests.swift
@@ -188,6 +188,56 @@ struct VersionCohortInstallerTests {
         try assertInstalledCohortIsExact(cohort.manifest, layout: layout)
     }
 
+    @Test func installReportsPathGuidanceFromTheCanonicalCommandDirectory() async throws {
+        let directories = try makeTemporaryTestDirectories()
+        let realPrefix = directories.root.appendingPathComponent("real-prefix", isDirectory: true)
+        let prefixAlias = directories.root.appendingPathComponent("prefix-alias", isDirectory: true)
+        try FileManager.default.createDirectory(at: realPrefix, withIntermediateDirectories: true)
+        try FileManager.default.createSymbolicLink(at: prefixAlias, withDestinationURL: realPrefix)
+        let layout = try resolveInstallLayout(prefix: prefixAlias.path, bindir: nil)
+        let cohort = try await makeTestCohort(
+            under: directories.root,
+            version: "v1.0.0",
+            commit: String(repeating: "a", count: 40),
+            marker: "guidance"
+        )
+        let releaseDirectory = try cohortDirectory(cohort)
+        let output = OSAllocatedUnfairLock(initialState: [String]())
+        let options = InstallOptions(
+            prefix: prefixAlias.path,
+            bindir: nil,
+            dryRun: false,
+            buildConfiguration: nil,
+            releaseDirectory: releaseDirectory.path,
+            expectedReleaseVersion: cohort.manifest.version,
+            expectedReleaseCommit: cohort.manifest.commit
+        )
+
+        try await runInstall(
+            options: options,
+            currentExecutableURL: nil,
+            currentDirectoryURL: directories.root,
+            environment: [
+                "HOME": directories.root.path,
+                "PATH": "/usr/bin:/bin",
+                "SHELL": "/bin/zsh",
+            ],
+            runner: RecordingCommandRunner(),
+            fileManager: .default,
+            inspectArtifact: testArtifactInspector,
+            outputLogger: { message in
+                output.withLock { $0.append(message) }
+            }
+        )
+
+        let messages = output.withLock { $0 }
+        #expect(messages.contains("Command: \(layout.publicCommandURL.path)"))
+        #expect(messages.contains("Next steps:"))
+        #expect(messages.contains(where: { $0.contains(layout.binDir.path) }))
+        #expect(!messages.contains(where: { $0.contains(prefixAlias.path) }))
+        #expect(messages.contains(where: { $0.contains(".zprofile") }))
+    }
+
     @Test func stagingFailureKeepsPreviousCohortActive() async throws {
         let directories = try makeTemporaryTestDirectories()
         let layout = try testLayout(in: directories.root)

--- a/scripts/install-release.sh.in
+++ b/scripts/install-release.sh.in
@@ -175,21 +175,10 @@ if [ -n "$BINDIR" ]; then
     --expected-version "$VERSION" \
     --expected-commit "$COMMIT" \
     --bindir "$BINDIR"
-  installed_bin="$BINDIR"
 else
   "$temporary_directory/bin/privateheaderkit-install" \
     --release-dir "$temporary_directory/cohort" \
     --expected-version "$VERSION" \
     --expected-commit "$COMMIT" \
     --prefix "$PREFIX"
-  installed_bin="$PREFIX/bin"
 fi
-
-echo "Installed PrivateHeaderKit $VERSION."
-case ":${PATH}:" in
-  *":${installed_bin}:"*) ;;
-  *)
-    echo "Add this directory to PATH:"
-    echo "  export PATH=\"${installed_bin}:\$PATH\""
-    ;;
-esac


### PR DESCRIPTION
## Purpose

Make release and source installs lead users to a runnable `privateheaderkit` command without requiring a hard-coded command path in onboarding.

## Changes

- Generate PATH guidance from the canonical installed command directory.
- Print safe zsh or bash login-profile and current-session commands only when PATH setup is needed.
- Keep shell profiles untouched and handle custom paths, symlinks, unknown shells, and unusable profiles conservatively.
- Remove duplicate PATH guidance from the release wrapper.
- Add focused installer regression coverage.

## Testing

- `swift test --filter PrivateHeaderKitInstallTests` — 84 tests passed
- `scripts/test-release-scripts.sh`
- `sh -n scripts/install-release.sh.in`
- `bash -n scripts/render-install-script.sh`
- `bash -n scripts/test-release-scripts.sh`
- `git diff --check`
- Codex review: no actionable findings