### PR TITLE
Simplify onboarding documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,66 @@
+# Contributing
+
+PrivateHeaderKit uses Swift 6.3 as its baseline. Source builds and release
+cohorts require Xcode with `xcrun` and an installed iOS Simulator SDK.
+
+## Tests
+
+Run the full Swift test suite:
+
+```bash
+swift test
+```
+
+Run the release-script contract tests when changing installation or release
+packaging:
+
+```bash
+scripts/test-release-scripts.sh
+```
+
+Regular tests must be deterministic. Use fixture trees, injected environments,
+and stub command runners. Do not make the default suite depend on the host dyld
+shared cache, installed applications, simulator availability or boot state,
+wall-clock timing, generated `swiftc` binaries, network access, or stress
+loops. Gate a necessary integration smoke test behind an explicit opt-in such
+as `PHK_RUN_INTEGRATION_TESTS=1`.
+
+## iOS Compile Check
+
+Compile the platform-neutral Core target and its test surface for iOS without
+launching a simulator:
+
+```bash
+PHK_IOS_SIMULATOR_SDK="$(xcrun --sdk iphonesimulator --show-sdk-path)"
+PHK_IOS_SIMULATOR_TRIPLE="$(uname -m)-apple-ios17.0-simulator"
+PHK_IOS_BUILD_SCRATCH="$PWD/.build/privateheaderkit-ios-compile/$PHK_IOS_SIMULATOR_TRIPLE"
+swift build \
+  --scratch-path "$PHK_IOS_BUILD_SCRATCH" \
+  --sdk "$PHK_IOS_SIMULATOR_SDK" \
+  --triple "$PHK_IOS_SIMULATOR_TRIPLE" \
+  --target PrivateHeaderKitCore
+swift build \
+  --scratch-path "$PHK_IOS_BUILD_SCRATCH" \
+  --sdk "$PHK_IOS_SIMULATOR_SDK" \
+  --triple "$PHK_IOS_SIMULATOR_TRIPLE" \
+  --target PrivateHeaderKitCoreTests
+```
+
+## Releases
+
+Maintainers prepare releases with the `Prepare Draft Release` GitHub Actions
+workflow. Dispatch it from the current default branch with:
+
+- a version tag such as `v1.2.3`
+- the full commit SHA of the current default-branch HEAD
+
+The workflow builds and verifies the cohort, then creates or repairs a draft
+GitHub Release containing exactly:
+
+- `install.sh`
+- `SHA256SUMS.txt`
+- `privateheaderkit-darwin-arm64.tar.gz`
+
+Review the draft metadata, release notes, and assets before publishing it
+manually. Publishing and tag creation are not performed by the local build or
+package scripts.

--- a/Docs/generation.md
+++ b/Docs/generation.md
@@ -1,0 +1,138 @@
+# Generation, Output, and Resume Behavior
+
+## Interactive Generation
+
+Run:
+
+```bash
+privateheaderkit
+```
+
+The wizard guides you through:
+
+1. an installed iOS Simulator runtime or the current macOS installation
+2. all available targets or a comma-separated list of target names
+3. Continue or Restart when compatible unfinished work exists
+
+The default output base is `~/PrivateHeaderKit`. The command prints the concrete
+header directory when a run starts and again in the completion summary.
+
+macOS generation works from the host system. iOS generation requires Xcode,
+`xcrun`, `simctl`, and the selected iOS Simulator runtime. PrivateHeaderKit
+selects and boots a compatible simulator device for the run.
+
+## Automation
+
+Supplying any generation option disables the wizard. Automation must provide
+all required inputs.
+
+### macOS
+
+```bash
+privateheaderkit \
+  --platform macOS \
+  --version "$(sw_vers -productVersion)" \
+  --build "$(sw_vers -buildVersion)" \
+  --system-root / \
+  --out ~/PrivateHeaderKit \
+  --target AppKit,Foundation
+```
+
+### iOS
+
+```bash
+privateheaderkit \
+  --platform iOS \
+  --version 27.0 \
+  --out ~/PrivateHeaderKit \
+  --target SwiftUI,UIKit
+```
+
+`--platform`, `--version`, `--out`, and `--target` are required in automation
+mode. `--system-root` is also required for macOS. For iOS, PrivateHeaderKit
+resolves the runtime root; supply `--build` when a version matches more than one
+runtime.
+
+| Option | Meaning |
+| --- | --- |
+| `--platform iOS\|macOS` | Source platform. |
+| `--version <version>` | Source OS version. |
+| `--build <build>` | Source build identifier; needed for ambiguous iOS versions. |
+| `--system-root <path>` | Runtime root; required for macOS and optional as an iOS override. |
+| `--out <path>` | Output base for generated headers and state. |
+| `--target all\|<query>` | All targets or comma-separated target names. |
+| `--device <name-or-udid>` | Preferred iOS Simulator device. |
+| `--sim-helper <path>` | Explicit simulator helper for controlled automation. |
+| `--resume` | Continue the latest compatible unfinished plan. |
+| `--fresh` | Start a new run and permit explicit legacy migration. |
+
+`--resume` and `--fresh` are mutually exclusive. Run `privateheaderkit --help`
+for the command's generated reference.
+
+## Output Contract
+
+Consumers should use only the concrete directory printed as `Headers`:
+
+```text
+<output-base>/generated-headers/<source-storage-id>/
+```
+
+The storage ID is versioned and owned by PrivateHeaderKit. Do not construct it
+from the displayed source name.
+
+The complete output base is:
+
+```text
+<output-base>/
+  <source-storage-id> -> .privateheaderkit/<source-storage-id>/current
+  generated-headers/
+    <source-storage-id>/
+      Frameworks/...
+      PrivateFrameworks/...
+      SystemLibrary/...
+      usr/lib/...
+  .privateheaderkit/
+    <source-storage-id>/
+      current -> generations/<generation-id>
+      generations/<generation-id>/...
+      legacy-backups/...
+  .state/
+    <source-storage-id>/generation.sqlite
+```
+
+Completed targets are published into `generated-headers` one target at a time.
+If a later target or finalization fails, already published targets remain
+available. Failed or interrupted targets retain their last successfully
+published files. The immutable generation under `.privateheaderkit` is a
+recovery snapshot, not a visibility gate for generated headers.
+
+State, attempts, publication intent, and run diagnostics are stored in
+`generation.sqlite`, outside the published header tree. The top-level source
+link and `.privateheaderkit` tree are internal recovery artifacts; consumers
+should not use them instead of the printed `Headers` directory.
+
+## Continue or Restart
+
+- `--resume` continues the latest compatible plan and runs only unfinished or
+  missing targets. A changed plan or smaller selected target set is rejected.
+- `--fresh` starts a new run for every selected target. It also permits an
+  explicit migration from legacy state or output.
+- With neither flag, automation starts a new run when no prior state exists.
+  Compatible completed state may be reused, but unfinished state requires an
+  explicit `--resume` or `--fresh` decision.
+
+The interactive wizard presents the same Continue or Restart choice when it
+finds compatible unfinished work.
+
+## Legacy Output
+
+PrivateHeaderKit does not silently adopt either legacy form:
+
+- Older JSON state is not imported as resumable state. A fresh migration
+  creates `generation.sqlite` and leaves the JSON paths in place.
+- An unmanaged output directory is inventoried and copied into the draft
+  generation. A fresh migration atomically publishes the managed path and
+  keeps the original directory under `legacy-backups`.
+
+If output validation or the atomic swap cannot be completed, the original
+output path is left in place and migration fails.

--- a/Docs/installation.md
+++ b/Docs/installation.md
@@ -1,0 +1,115 @@
+# Installation and Updates
+
+PrivateHeaderKit installs one public command, `privateheaderkit`. The raw macOS
+and iOS Simulator helpers are internal artifacts that are installed and updated
+with it as one validated cohort.
+
+## Requirements
+
+GitHub release installation requires:
+
+- an Apple Silicon Mac
+- macOS 14 or later
+
+It does not require a Swift toolchain. Generating iOS headers additionally
+requires Xcode with the matching iOS Simulator runtime.
+
+## Install a Release
+
+```bash
+curl -fsSL https://github.com/lynnswap/PrivateHeaderKit/releases/latest/download/install.sh | sh
+```
+
+The default command is installed at `~/.local/bin/privateheaderkit`.
+
+The installer checks whether the resolved command directory is already on
+`PATH`. If it is missing, the installer prints a `Next steps` block with:
+
+- a command to update the appropriate zsh or bash login profile when that
+  profile can be updated safely
+- an `export` command for the current shell
+- the `privateheaderkit` command to run next
+
+The installer never creates, edits, or sources a shell profile itself. For an
+unknown login shell, it prints the command directory instead of guessing a
+profile or shell syntax.
+
+### Custom destination
+
+Install under another prefix. The public command is placed in `<prefix>/bin`:
+
+```bash
+curl -fsSL https://github.com/lynnswap/PrivateHeaderKit/releases/latest/download/install.sh | sh -s -- --prefix ~/Tools/PrivateHeaderKit
+```
+
+Or choose the public command directory directly:
+
+```bash
+curl -fsSL https://github.com/lynnswap/PrivateHeaderKit/releases/latest/download/install.sh | sh -s -- --bindir ~/bin
+```
+
+Choose either `--prefix` or `--bindir`. The installer resolves `~`, relative
+paths, and symlinked ancestors before installing and reporting the command
+location.
+
+### Install a specific release
+
+Replace `<version>` with a release tag such as `v1.2.3`:
+
+```text
+https://github.com/lynnswap/PrivateHeaderKit/releases/download/<version>/install.sh
+```
+
+## Install from Source
+
+Source installation builds the public command and both internal helpers from
+the same checkout:
+
+```bash
+git clone https://github.com/lynnswap/PrivateHeaderKit.git
+cd PrivateHeaderKit
+swift run -c release privateheaderkit-install
+```
+
+This path requires Swift 6.3 and Xcode with `xcrun` and an installed iOS
+Simulator SDK because the installed cohort always includes the simulator
+helper. `--prefix` and `--bindir` are also available for source installation.
+
+## Update
+
+Run the download command again, or update the source checkout and rerun
+`swift run -c release privateheaderkit-install`. Preserve the same `--prefix`
+or `--bindir` option when updating a custom destination.
+
+The installer verifies the archive checksum, exact archive contents, release
+manifest, executable hashes, architecture, platform, permissions, and code
+signatures before activation. It publishes an immutable cohort and switches
+the stable command only after the complete cohort passes validation. Download,
+build, validation, or staging failures leave the previous cohort active; an
+activation failure attempts to restore it and reports any restoration failure.
+
+## Installed Layout
+
+The default layout is:
+
+```text
+~/.local/bin/privateheaderkit
+  -> ../libexec/privateheaderkit/current/privateheaderkit
+~/.local/libexec/privateheaderkit/
+  current -> versions/<version>+<cohort-sha256>
+  versions/<version>+<cohort-sha256>/
+    privateheaderkit
+    privateheaderkit-raw-helper
+    privateheaderkit-sim-helper
+    release.json
+```
+
+Only `privateheaderkit` is a public command. The helpers are always resolved
+through the active validated cohort.
+
+An older direct install containing all three executables is migrated under the
+installer lock. Partial, ambiguous, or modified legacy install layouts are
+rejected instead of guessed. An interrupted install migration is recovered
+from its recorded intent on the next install. Generation-state and output
+migration is a separate contract described in
+[Generation, Output, and Resume Behavior](generation.md#legacy-output).

--- a/Docs/installation.md
+++ b/Docs/installation.md
@@ -17,7 +17,7 @@ requires Xcode with the matching iOS Simulator runtime.
 ## Install a Release
 
 ```bash
-curl -fsSL https://github.com/lynnswap/PrivateHeaderKit/releases/latest/download/install.sh | sh
+curl -fsSLO https://github.com/lynnswap/PrivateHeaderKit/releases/latest/download/install.sh && sh ./install.sh
 ```
 
 The default command is installed at `~/.local/bin/privateheaderkit`.
@@ -39,13 +39,13 @@ profile or shell syntax.
 Install under another prefix. The public command is placed in `<prefix>/bin`:
 
 ```bash
-curl -fsSL https://github.com/lynnswap/PrivateHeaderKit/releases/latest/download/install.sh | sh -s -- --prefix ~/Tools/PrivateHeaderKit
+curl -fsSLO https://github.com/lynnswap/PrivateHeaderKit/releases/latest/download/install.sh && sh ./install.sh --prefix ~/Tools/PrivateHeaderKit
 ```
 
 Or choose the public command directory directly:
 
 ```bash
-curl -fsSL https://github.com/lynnswap/PrivateHeaderKit/releases/latest/download/install.sh | sh -s -- --bindir ~/bin
+curl -fsSLO https://github.com/lynnswap/PrivateHeaderKit/releases/latest/download/install.sh && sh ./install.sh --bindir ~/bin
 ```
 
 Choose either `--prefix` or `--bindir`. The installer resolves `~`, relative

--- a/Docs/troubleshooting.md
+++ b/Docs/troubleshooting.md
@@ -1,0 +1,71 @@
+# Troubleshooting
+
+## `privateheaderkit: command not found`
+
+The default command directory is `~/.local/bin`. When it is not on `PATH`, the
+installer prints a `Next steps` block for the detected login shell, including
+an export for the current session. Copy those commands exactly, or open a new
+terminal if the profile already contains the printed entry.
+
+Rerunning the installer is safe and will print the guidance again when needed.
+The installer does not edit or source shell profiles itself.
+
+## No iOS source appears in the wizard
+
+iOS generation requires full Xcode and an installed iOS Simulator runtime.
+Confirm that Xcode's command-line tools are selected and inspect the available
+runtimes:
+
+```bash
+xcode-select -p
+xcrun simctl list runtimes
+```
+
+Install the desired runtime from Xcode settings, then rerun `privateheaderkit`.
+macOS generation remains available without an iOS runtime.
+
+## More than one iOS runtime matches `--version`
+
+Use the interactive wizard, or add the source build identifier in automation:
+
+```bash
+privateheaderkit \
+  --platform iOS \
+  --version 27.0 \
+  --build 24A000 \
+  --out ~/PrivateHeaderKit \
+  --target all
+```
+
+Replace the example version and build with a pair listed by `xcrun simctl list
+runtimes`.
+
+## An unfinished run already exists
+
+Run `privateheaderkit` and choose Continue or Restart. In automation, rerun with
+the same plan and `--resume`, or use `--fresh` to start every selected target
+again.
+
+PrivateHeaderKit rejects an implicit decision here so that a script cannot
+discard or reinterpret unfinished work accidentally.
+
+## Legacy state or output blocks a run
+
+Use the interactive wizard to review what will be preserved and backed up. In
+automation, `--fresh` is the explicit permission to migrate. PrivateHeaderKit
+does not treat legacy JSON state as resumable state and does not silently adopt
+an unmanaged output directory.
+
+See [Generation, Output, and Resume Behavior](generation.md#legacy-output) for
+the migration contract.
+
+## An install or update failed
+
+Read the first reported validation or filesystem error. Download, build,
+validation, and staging failures do not replace the active validated cohort.
+If activation itself fails, the installer reports whether restoring the
+previous cohort also failed.
+
+Run the same install command again after correcting the reported cause. Do not
+manually replace individual helper binaries; the public command and both
+helpers are validated and activated as one cohort.

--- a/README.ja.md
+++ b/README.ja.md
@@ -12,7 +12,7 @@ macOS 14 以降が必要です。prebuilt release は Apple Silicon 向けです
 ## クイックスタート
 
 ```bash
-curl -fsSL https://github.com/lynnswap/PrivateHeaderKit/releases/latest/download/install.sh | sh
+curl -fsSLO https://github.com/lynnswap/PrivateHeaderKit/releases/latest/download/install.sh && sh ./install.sh
 ```
 
 installer が `Next steps` を表示した場合は、下の command の代わりにその内容を実行します。
@@ -35,7 +35,7 @@ installer が shell profile を勝手に編集することはありません。
 command を `~/bin` にインストールする場合:
 
 ```bash
-curl -fsSL https://github.com/lynnswap/PrivateHeaderKit/releases/latest/download/install.sh | sh -s -- --bindir ~/bin
+curl -fsSLO https://github.com/lynnswap/PrivateHeaderKit/releases/latest/download/install.sh && sh ./install.sh --bindir ~/bin
 ```
 
 checkout から build してインストールする場合:

--- a/README.ja.md
+++ b/README.ja.md
@@ -2,67 +2,43 @@
 
 [English](README.md)
 
-iOS / macOS の private framework ヘッダを生成します。
+この Mac またはインストール済み iOS Simulator runtime から、検索可能な private
+header を生成します。
 
-- iOS: Simulator ランタイムと dyld shared cache から生成
-- macOS: ホストの `/System/Library/{Frameworks,PrivateFrameworks}` から生成
+macOS 14 以降が必要です。prebuilt release は Apple Silicon 向けです。iOS の header
+生成には Xcode とインストール済み iOS Simulator runtime が必要です。source install
+には Swift 6.3 と iOS Simulator SDK を含む Xcode が必要です。
 
-## 動作要件
+## クイックスタート
 
-PrivateHeaderKit の CLI、installer、internal helper は Darwin / macOS host のみを
-サポートします。Linux などの non-Darwin host はサポート対象外です。
+```bash
+curl -fsSL https://github.com/lynnswap/PrivateHeaderKit/releases/latest/download/install.sh | sh
+```
 
-## コマンド構成
-
-PrivateHeaderKit がユーザー向けに公開するコマンドは 1 つです。
+installer が `Next steps` を表示した場合は、下の command の代わりにその内容を実行します。
+表示されなかった場合は:
 
 ```bash
 privateheaderkit
 ```
 
-旧 `privateheaderkit-dump` / `headerdump` / `headerdump-sim` は
-user-facing command としてインストールしません。低レベルの raw dump は、公開
-コマンドと同じ cohort としてインストール・更新される internal helper が扱います。
+source を選び、全 target または個別の framework、bundle、dylib 名を指定します。
+デフォルトでは `~/PrivateHeaderKit` に生成し、実際の出力先を `Headers` として表示します。
 
-## インストール
+installer が shell profile を勝手に編集することはありません。
 
-Apple Silicon Mac では、version を焼き込んだ installer から最新の検証済み
-release cohort をインストールできます。
+## インストールオプション
 
-```bash
-curl -fsSLO https://github.com/lynnswap/PrivateHeaderKit/releases/latest/download/install.sh
-sh install.sh
-```
+<details>
+<summary>インストール先の変更と source install</summary>
 
-各 release の downloadable asset は、次の 3 ファイルだけです。
-
-- `install.sh`
-- `SHA256SUMS.txt`
-- `privateheaderkit-darwin-arm64.tar.gz`
-
-version-baked installer は対応する archive と checksum file を取得し、archive の
-checksum と内容の完全一致を確認します。続いて `release.json` と 3 executable
-すべてについて、SHA-256、architecture、platform、実行権限、code signature を
-検証します。cohort 全体が検証を通った後にだけ immutable cohort を publish し、
-active な `current` link を切り替えます。デフォルトの stable user-facing command
-は `~/.local/bin/privateheaderkit` です。
-
-`~/.local/bin` が `PATH` に入っていない場合は追加してください。
+command を `~/bin` にインストールする場合:
 
 ```bash
-echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.zshrc
-source ~/.zshrc
+curl -fsSL https://github.com/lynnswap/PrivateHeaderKit/releases/latest/download/install.sh | sh -s -- --bindir ~/bin
 ```
 
-prefix または command directory を変更する場合:
-
-```bash
-sh install.sh --prefix "$HOME/.local"
-# または: $HOME を prefix、$HOME/bin を stable command directory にする
-sh install.sh --bindir "$HOME/bin"
-```
-
-checkout から全 artifact を build してインストールする場合:
+checkout から build してインストールする場合:
 
 ```bash
 git clone https://github.com/lynnswap/PrivateHeaderKit.git
@@ -70,171 +46,50 @@ cd PrivateHeaderKit
 swift run -c release privateheaderkit-install
 ```
 
-release install と source install は同じ immutable layout を使います。
+source install には Swift 6.3 と iOS Simulator SDK を含む Xcode が必要です。
 
-```text
-~/.local/bin/privateheaderkit
-  -> ../libexec/privateheaderkit/current/privateheaderkit
-~/.local/libexec/privateheaderkit/
-  current -> versions/<version>+<cohort-sha256>
-  versions/<version>+<cohort-sha256>/
-    privateheaderkit
-    privateheaderkit-raw-helper
-    privateheaderkit-sim-helper
-    release.json
-```
+</details>
 
-public command は `privateheaderkit` だけです。2 つの helper は常に同じ検証済み
-cohort から解決されます。更新時は最新の `install.sh` を再取得して実行するか、
-source checkout を更新して `swift run -c release privateheaderkit-install` を再実行
-します。build、download、validation、staging のいずれかが失敗した場合は、以前の
-検証済み cohort が active なまま維持されます。activation に失敗した場合、installer
-は以前の cohort の復元を試み、rollback 自体の失敗も隠さず報告します。tag のない
-source checkout は commit を含む `0.0.0-dev.<short-commit>` version namespace を使います。
+## 自動実行
 
-3 つの executable file を直接置く旧 install は、installer lock の下で移行します。
-移行が中断された場合は、次回の install で記録済み migration intent から復旧します。
-一部欠損または曖昧な legacy layout は拒否し、intent の記録後に file が変化していた
-場合も推測で復旧しません。内容が変わった retired helper は削除せず残しますが、検証
-済みの `current` と public command の link が managed layout を確定した後は、その
-leftover が後続の managed install を妨げることはありません。
-
-maintainer は `Prepare Draft Release` workflow で release を準備します。workflow は
-version と、現在の default branch HEAD の full SHA を指定して dispatch する必要が
-あります。workflow は、上記 3 asset だけを持つ draft GitHub Release を作成または
-修復します。draft と release note の確認後に手動で publish します。
-
-## 生成
+通常は引数なしの interactive mode を推奨します。script から使う場合は、生成条件を
+すべて明示します。
 
 ```bash
-privateheaderkit
-privateheaderkit --help
+privateheaderkit \
+  --platform macOS \
+  --version "$(sw_vers -productVersion)" \
+  --build "$(sw_vers -buildVersion)" \
+  --system-root / \
+  --out ~/PrivateHeaderKit \
+  --target AppKit,Foundation
 ```
-
-`privateheaderkit` を引数なしで実行すると interactive generation wizard を開始し、
-デフォルトの output base として `~/PrivateHeaderKit` を使います。互換性のある未完了
-state があれば `Continue` / `Restart` の明示選択を求め、legacy state または output
-を移行する前にも確認を求めます。両方が存在する場合は、同じ確認画面に双方の path と
-保存または backup の扱いを表示してから移行します。automation / CI では generation
-option を直接渡します。
-
-生成済み header は `~/PrivateHeaderKit/generated-headers/<source-storage-id>/` に出力
-されます。実行開始時にも、この実際の出力先を terminal に表示します。
 
 ```bash
-privateheaderkit --platform iOS --version 27.0 --build 24A5355q --out "$HOME/PrivateHeaderKit" --target "SwiftUI,UIKit"
-privateheaderkit --platform iOS --version 27.0 --build 24A5355q --system-root /path/to/RuntimeRoot --device "iPhone 17" --out "$HOME/PrivateHeaderKit" --target "SwiftUI,UIKit" --fresh
-privateheaderkit --platform macOS --version 16.0 --system-root / --out "$HOME/PrivateHeaderKit" --target "AppKit,Foundation" --resume
+privateheaderkit \
+  --platform iOS \
+  --version 27.0 \
+  --out ~/PrivateHeaderKit \
+  --target SwiftUI,UIKit
 ```
 
-iOS 生成では、`privateheaderkit` が `--version` / `--build` から利用可能な Simulator
-runtime を解決し、device を選択・boot して internal simulator helper を使います。
-`--system-root` は iOS では任意です。指定した場合はその runtime root を使い、解決
-した runtime path で置き換えません。`--device <name-or-udid>` と
-`--sim-helper <path>` は automation 用の任意 flag です。
+全 option は `privateheaderkit --help` で確認できます。例の iOS version はインストール
+済み runtime に合わせて変更してください。同じ version に一致する runtime が複数ある
+場合は `--build <build>` も指定します。
 
-`--target` は comma-separated target query であり、stable target ID list では
-ありません。`--resume` と `--fresh` は同時に指定できません。
+## 更新
 
-- `--resume` は最新の互換 plan を継続し、未完了または欠損している target を実行
-  します。plan fingerprint が変わった場合や、選択 target が以前より減った場合は
-  incompatible として拒否します。
-- `--fresh` は選択した全 target について新しい run を開始します。legacy JSON state
-  と legacy output directory の明示的な移行も許可します。
-- どちらも指定しない場合、過去の state がなければ新しい run を開始します。未完了
-  work がない互換 state は再利用できますが、未完了 state がある場合は、呼び出し側
-  が `--resume` または `--fresh` を明示するまで拒否します。
+install command を再実行してください。release は検証後にだけ activate されます。
+download、build、validation、staging の失敗では以前の cohort が active なまま残り、
+activation の失敗では復元を試み、その復元も失敗した場合は明示的に報告します。
 
-`--fresh` は処理開始前に現在 publish 済みの header tree を削除しません。完了した
-target は、次の target を開始する前に自身が所有する file を
-`generated-headers/<source-storage-id>/` へ反映します。後続 target や run 全体の
-finalize が失敗しても、先に完了した target の file は残り、`--resume` では再実行
-せず続きから処理します。失敗または中断した target には、最後に publish 成功した
-file を残します。run 終了時の immutable generation は recovery 用の内部 snapshot
-であり、生成中に header を見えなくする publication gate ではありません。旧
-`<version>` positional style は public surface に含みません。
+## ドキュメント
 
-TTY では処理中の target を `.`, `..`, `...` の一時的な1行として更新します。成功行
-は次の target で置き換え、terminal に成功 target の一覧を残しません。失敗した
-target と短い診断だけを残します。raw helper の通常出力は terminal へ転送せず、失敗
-時の bounded diagnostic tail は target の `failureSummary` として SQLite state に保存
-します。
-
-## Output Layout Contract
-
-output base には、人が直接参照する incremental header tree、recovery 用の immutable
-generation、source ごとの SQLite state database を配置します。
-
-```text
-<output-base>/
-  generated-headers/
-    <source-storage-id>/
-      Frameworks/...
-      PrivateFrameworks/...
-      SystemLibrary/...
-      usr/lib/...
-  .privateheaderkit/
-    <source-storage-id>/
-      current -> generations/<generation-id>
-      generations/
-        <generation-id>/
-          .privateheaderkit-generation.json
-          Frameworks/...
-          PrivateFrameworks/...
-      legacy-backups/...
-  .state/
-    <source-storage-id>/
-      generation.sqlite
-```
-
-`--out` は `<output-base>` を指定します。consumer は
-`<output-base>/generated-headers/<source-storage-id>/` を使います。完了 target の
-artifact と SQLite の published-target record は target 単位で確定し、内部 snapshot
-は `.privateheaderkit` 以下で run 終了時に整合させます。`legacy-backups` は rewrite 前
-の output directory を移行した場合にだけ作成します。generation state、target
-attempt、publication intent、run log は `generation.sqlite` に保存します。storage ID
-は PrivateHeaderKit が所有する versioned identifier であり、consumer は表示用 source
-label から組み立てません。
-
-## Legacy Output の移行
-
-旧 `.state/<source-storage-id>/manifest.json` と `runs/` の data は resumable state として
-import しません。`generation.sqlite` がなく、これらの path が存在する場合、
-`--fresh` なしの run は停止します。明示的な fresh migration は
-`generation.sqlite` を作成し、旧 JSON path はそのまま残します。
-
-実 directory として存在する `<output-base>/<source-storage-id>/` は黙って取り込みません。
-`--fresh` を指定すると、PrivateHeaderKit はその通常 file を inventory して draft
-generation にコピーし、owner のない opaque file として記録します。その後、directory
-と symlink を atomic swap して managed stable path を publish し、元の directory を
-`.privateheaderkit/<source-storage-id>/legacy-backups/` 以下に保持します。legacy tree を検証
-できない場合や filesystem が atomic swap を実行できない場合は、元の output path を
-置き換えずに migration を失敗させます。
-
-## メモ
-
-- iOS runtime discovery と simulator execution には、`xcrun`、`simctl`、および
-  iPhone Simulator SDK がインストールされた Xcode が必要です。
-- source からの build には Swift 6.3 toolchain が必要です。source install では
-  simulator helper を含む cohort 全体を作るため、`xcrun` と iPhone Simulator SDK
-  がインストールされた Xcode も必要です。
-- state、log、staging data は publish 済み generated header tree の外に置きます。
-
-## テスト
-
-`swift test` は deterministic であることを期待します。通常テストは固定 fixture tree、注入された environment、stub command runner を使ってください。
-
-simulator を起動せず、platform-neutral な Core target とその test surface を iOS 向けに compile するには、次を実行します。
-
-```bash
-PHK_IOS_SIMULATOR_SDK="$(xcrun --sdk iphonesimulator --show-sdk-path)"
-PHK_IOS_SIMULATOR_TRIPLE="$(uname -m)-apple-ios17.0-simulator"
-PHK_IOS_BUILD_SCRATCH="$PWD/.build/privateheaderkit-ios-compile/$PHK_IOS_SIMULATOR_TRIPLE"
-swift build --scratch-path "$PHK_IOS_BUILD_SCRATCH" --sdk "$PHK_IOS_SIMULATOR_SDK" --triple "$PHK_IOS_SIMULATOR_TRIPLE" --target PrivateHeaderKitCore
-swift build --scratch-path "$PHK_IOS_BUILD_SCRATCH" --sdk "$PHK_IOS_SIMULATOR_SDK" --triple "$PHK_IOS_SIMULATOR_TRIPLE" --target PrivateHeaderKitCoreTests
-```
-host dyld shared cache、インストール済み system app、simulator availability、runtime boot state、wall-clock time、生成済み `swiftc` binary、network access、stress loop に依存する通常テストは追加しないでください。integration smoke test にそれらが必要な場合は、`PHK_RUN_INTEGRATION_TESTS=1` のような明示 opt-in の後ろに置き、default acceptance path から外してください。
+- [インストールと更新（英語）](Docs/installation.md)
+- [生成、出力、resume の仕様（英語）](Docs/generation.md)
+- [トラブルシューティング（英語）](Docs/troubleshooting.md)
+- [開発と release（英語）](CONTRIBUTING.md)
 
 ## ライセンス
 
-- このワークスペースは MIT: `LICENSE` を参照
+PrivateHeaderKit は [MIT License](LICENSE) で提供します。

--- a/README.md
+++ b/README.md
@@ -1,69 +1,45 @@
 # PrivateHeaderKit
 
-[Japanese](README.ja.md)
+[日本語](README.ja.md)
 
-Generate private framework headers for iOS and macOS.
+Generate searchable private headers from this Mac or an installed iOS Simulator
+runtime.
 
-- iOS: dump from simulator runtimes and dyld shared caches.
-- macOS: dump from host `/System/Library/{Frameworks,PrivateFrameworks}`.
+Requires macOS 14 or later. Prebuilt releases require Apple Silicon. iOS
+generation requires Xcode and an installed iOS Simulator runtime. Source
+installation requires Swift 6.3 and Xcode with an iOS Simulator SDK.
 
-## Requirements
+## Quick Start
 
-The PrivateHeaderKit CLI, installer, and internal helpers support Darwin/macOS
-hosts only. Non-Darwin hosts such as Linux are unsupported.
+```bash
+curl -fsSL https://github.com/lynnswap/PrivateHeaderKit/releases/latest/download/install.sh | sh
+```
 
-## Command Model
-
-PrivateHeaderKit exposes one user-facing command:
+If the installer prints a `Next steps` block, follow it instead of the command
+below. Otherwise run:
 
 ```bash
 privateheaderkit
 ```
 
-The old `privateheaderkit-dump`, `headerdump`, and `headerdump-sim` names are not
-installed as user-facing commands. Low-level raw dumping is handled by internal
-helpers that are installed and updated with the public command as one cohort.
+Choose a source, then generate all targets or enter specific framework, bundle,
+or dylib names. PrivateHeaderKit writes to `~/PrivateHeaderKit` by default and
+prints the exact `Headers` directory for the generated files.
 
-## Installation
+The installer does not edit shell profiles.
 
-On an Apple Silicon Mac, install the latest validated release cohort with the
-version-baked installer:
+## Install Options
 
-```bash
-curl -fsSLO https://github.com/lynnswap/PrivateHeaderKit/releases/latest/download/install.sh
-sh install.sh
-```
+<details>
+<summary>Custom directories and source installation</summary>
 
-Each release has exactly three downloadable assets:
-
-- `install.sh`
-- `SHA256SUMS.txt`
-- `privateheaderkit-darwin-arm64.tar.gz`
-
-The version-baked installer downloads the matching archive and checksum file,
-verifies the archive checksum and exact archive contents, then validates
-`release.json` and all three executables for SHA-256, architecture, platform,
-executable permissions, and code signature. Only after the complete cohort has
-passed validation does it publish the immutable cohort and switch the active
-`current` link. By default, the stable user-facing command is
-`~/.local/bin/privateheaderkit`.
-
-If `~/.local/bin` is not in your `PATH`, add it:
+Install the command in `~/bin`:
 
 ```bash
-echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.zshrc
-source ~/.zshrc
+curl -fsSL https://github.com/lynnswap/PrivateHeaderKit/releases/latest/download/install.sh | sh -s -- --bindir ~/bin
 ```
 
-To choose another prefix or command directory:
-
-```bash
-sh install.sh --prefix "$HOME/.local"
-# or: this uses $HOME as the prefix and $HOME/bin for the stable command
-sh install.sh --bindir "$HOME/bin"
-```
-
-To build and install all artifacts from a checkout instead:
+Build and install from a checkout:
 
 ```bash
 git clone https://github.com/lynnswap/PrivateHeaderKit.git
@@ -71,182 +47,51 @@ cd PrivateHeaderKit
 swift run -c release privateheaderkit-install
 ```
 
-Release and source installs use the same immutable layout:
+Source installation requires Swift 6.3 and Xcode with an iOS Simulator SDK.
 
-```text
-~/.local/bin/privateheaderkit
-  -> ../libexec/privateheaderkit/current/privateheaderkit
-~/.local/libexec/privateheaderkit/
-  current -> versions/<version>+<cohort-sha256>
-  versions/<version>+<cohort-sha256>/
-    privateheaderkit
-    privateheaderkit-raw-helper
-    privateheaderkit-sim-helper
-    release.json
-```
+</details>
 
-Only `privateheaderkit` is public. Its two helpers are always resolved through
-the same validated cohort. To update, download and run the latest `install.sh`
-again, or update the source checkout and rerun `swift run -c release
-privateheaderkit-install`. A failed build, download, validation, or staging
-step leaves the previous validated cohort active. If activation fails, the
-installer attempts to restore the previous cohort and reports any rollback
-failure instead of hiding it.
-Untagged source checkouts use a commit-qualified
-`0.0.0-dev.<short-commit>` version namespace.
+## Automation
 
-An older direct install containing the three executable files is migrated under
-the installer lock. If that migration is interrupted, the next install recovers
-it from the recorded migration intent. A partial or ambiguous legacy layout is
-rejected, and recovery refuses to guess if its files changed after the intent
-was recorded. A retired helper whose contents changed is left untouched; once
-the validated `current` and public command links establish the managed layout,
-that leftover does not block a later managed install.
-
-Maintainers prepare a release with the `Prepare Draft Release` workflow. It must
-be dispatched with a version and the full SHA of the current default-branch
-HEAD. The workflow creates or repairs a draft GitHub Release with exactly the
-three assets listed above. Publishing remains a manual step after the draft and
-release notes have been reviewed.
-
-## Generation
+The no-argument command is the recommended interactive path. For scripts, pass
+all generation inputs explicitly:
 
 ```bash
-privateheaderkit
-privateheaderkit --help
+privateheaderkit \
+  --platform macOS \
+  --version "$(sw_vers -productVersion)" \
+  --build "$(sw_vers -buildVersion)" \
+  --system-root / \
+  --out ~/PrivateHeaderKit \
+  --target AppKit,Foundation
 ```
-
-Running `privateheaderkit` without arguments starts the interactive generation
-wizard; its default output base is `~/PrivateHeaderKit`. The wizard asks for an
-explicit Continue or Restart decision when compatible unfinished state exists,
-and asks for confirmation before migrating legacy state or output. If both are
-present, the same confirmation lists both paths and their preservation or
-backup effects before migration. For automation and CI, pass generation
-options directly:
-
-Generated headers are written to
-`~/PrivateHeaderKit/generated-headers/<source-storage-id>/`. The command also
-prints this concrete destination when a run starts.
 
 ```bash
-privateheaderkit --platform iOS --version 27.0 --build 24A5355q --out "$HOME/PrivateHeaderKit" --target "SwiftUI,UIKit"
-privateheaderkit --platform iOS --version 27.0 --build 24A5355q --system-root /path/to/RuntimeRoot --device "iPhone 17" --out "$HOME/PrivateHeaderKit" --target "SwiftUI,UIKit" --fresh
-privateheaderkit --platform macOS --version 16.0 --system-root / --out "$HOME/PrivateHeaderKit" --target "AppKit,Foundation" --resume
+privateheaderkit \
+  --platform iOS \
+  --version 27.0 \
+  --out ~/PrivateHeaderKit \
+  --target SwiftUI,UIKit
 ```
 
-For iOS generation, `privateheaderkit` resolves an available simulator runtime
-from `--version` and `--build`, selects and boots a simulator device, and uses
-the internal simulator helper. `--system-root` is optional for iOS; when
-supplied, it is used as the runtime root instead of being replaced by the
-resolved runtime path. `--device <name-or-udid>` and `--sim-helper <path>` are
-optional automation flags.
+Use `privateheaderkit --help` for the complete option list. If more than one iOS
+runtime matches a version, add `--build <build>`. Replace the example iOS
+version with an installed runtime version.
 
-`--target` is a comma-separated target query, not a stable target ID list.
-`--resume` and `--fresh` are mutually exclusive:
+## Update
 
-- `--resume` continues the latest compatible plan and runs its unfinished or
-  missing targets. A changed plan fingerprint or a smaller selected target set
-  is rejected as incompatible.
-- `--fresh` starts a new run for every selected target. It also permits the
-  explicit migration of legacy JSON state and a legacy output directory.
-- With neither flag, a new run starts when no prior state exists. Compatible
-  state with no unfinished work may be reused, but unfinished state is rejected
-  until the caller explicitly chooses `--resume` or `--fresh`.
+Run the install command again. A release is activated only after validation.
+Download, build, validation, and staging failures leave the previous cohort
+active; an activation failure attempts to restore it and reports if restoration
+also fails.
 
-`--fresh` does not delete the currently published header tree before work
-starts. A completed target updates the files it owns under
-`generated-headers/<source-storage-id>/` before the next target starts. A later
-target or finalization failure does not remove those files, and `--resume`
-continues without rerunning targets that were already published. Failed or
-interrupted targets retain their last successfully published files. The
-immutable generation finalized at the end of a run is an internal recovery
-snapshot, not a gate that hides headers while generation is in progress. The
-old `<version>` positional style is not part of the public surface.
+## Documentation
 
-On a TTY, the active target is one transient line animated as `.`, `..`, and
-`...`. Successful lines are replaced by the next target instead of accumulating
-in the terminal; only failed targets and concise diagnostics remain. Normal raw
-helper output is not forwarded to the terminal. A bounded diagnostic tail for
-a failed target is retained as its SQLite `failureSummary`.
-
-## Output Layout Contract
-
-The output base contains the incrementally visible header tree, internal
-immutable recovery generations, and one SQLite state database per source:
-
-```text
-<output-base>/
-  generated-headers/
-    <source-storage-id>/
-      Frameworks/...
-      PrivateFrameworks/...
-      SystemLibrary/...
-      usr/lib/...
-  .privateheaderkit/
-    <source-storage-id>/
-      current -> generations/<generation-id>
-      generations/
-        <generation-id>/
-          .privateheaderkit-generation.json
-          Frameworks/...
-          PrivateFrameworks/...
-      legacy-backups/...
-  .state/
-    <source-storage-id>/
-      generation.sqlite
-```
-
-`--out` selects `<output-base>`. Consumers use
-`<output-base>/generated-headers/<source-storage-id>/`. Completed target
-artifacts and their SQLite published-target records become durable per target;
-the internal snapshot under `.privateheaderkit` is reconciled at the end of a
-run. The `legacy-backups` directory is created only when a pre-rewrite output
-directory is migrated. Generation state, target attempts, publication intent,
-and run logs are stored in `generation.sqlite`. The storage ID is versioned and
-owned by PrivateHeaderKit; consumers must not construct it from the displayed
-source label.
-
-## Legacy Output Migration
-
-Old `.state/<source-storage-id>/manifest.json` and `runs/` data is not imported as
-resumable state. When those paths exist without `generation.sqlite`, a run
-without `--fresh` stops. An explicit fresh migration creates
-`generation.sqlite` and leaves the old JSON paths in place.
-
-An existing real `<output-base>/<source-storage-id>/` directory is not silently
-adopted. With `--fresh`, PrivateHeaderKit inventories and copies its regular
-files into the draft generation as opaque, unowned files. It then uses an
-atomic directory/symlink swap to publish the managed stable path and retains
-the original directory under
-`.privateheaderkit/<source-storage-id>/legacy-backups/`. If the legacy tree cannot be
-validated or the filesystem cannot perform the atomic swap, migration fails
-without replacing the original output path.
-
-## Notes
-
-- iOS runtime discovery and simulator execution require Xcode with `xcrun`,
-  `simctl`, and an installed iPhone Simulator SDK.
-- Building from source requires the Swift 6.3 toolchain. Source installation
-  additionally requires Xcode with `xcrun` and an installed iPhone Simulator
-  SDK because the installed cohort includes the simulator helper.
-- State, logs, and staging data are kept outside the published generated header
-  tree.
-
-## Testing
-
-`swift test` is expected to be deterministic. Regular tests should use fixed fixture trees, injected environments, and stub command runners only.
-
-Compile the platform-neutral Core target and its test surface for iOS without launching a simulator:
-
-```bash
-PHK_IOS_SIMULATOR_SDK="$(xcrun --sdk iphonesimulator --show-sdk-path)"
-PHK_IOS_SIMULATOR_TRIPLE="$(uname -m)-apple-ios17.0-simulator"
-PHK_IOS_BUILD_SCRATCH="$PWD/.build/privateheaderkit-ios-compile/$PHK_IOS_SIMULATOR_TRIPLE"
-swift build --scratch-path "$PHK_IOS_BUILD_SCRATCH" --sdk "$PHK_IOS_SIMULATOR_SDK" --triple "$PHK_IOS_SIMULATOR_TRIPLE" --target PrivateHeaderKitCore
-swift build --scratch-path "$PHK_IOS_BUILD_SCRATCH" --sdk "$PHK_IOS_SIMULATOR_SDK" --triple "$PHK_IOS_SIMULATOR_TRIPLE" --target PrivateHeaderKitCoreTests
-```
-Do not add regular tests that depend on the host dyld shared cache, installed system apps, simulator availability, runtime boot state, wall-clock time, generated `swiftc` binaries, network access, or stress loops. If an integration smoke test needs one of those dependencies, guard it behind an explicit opt-in such as `PHK_RUN_INTEGRATION_TESTS=1` and keep it out of the default acceptance path.
+- [Installation and updates](Docs/installation.md)
+- [Generation, output, and resume behavior](Docs/generation.md)
+- [Troubleshooting](Docs/troubleshooting.md)
+- [Development and releases](CONTRIBUTING.md)
 
 ## License
 
-- MIT for this workspace: see `LICENSE`.
+PrivateHeaderKit is available under the [MIT License](LICENSE).

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ installation requires Swift 6.3 and Xcode with an iOS Simulator SDK.
 ## Quick Start
 
 ```bash
-curl -fsSL https://github.com/lynnswap/PrivateHeaderKit/releases/latest/download/install.sh | sh
+curl -fsSLO https://github.com/lynnswap/PrivateHeaderKit/releases/latest/download/install.sh && sh ./install.sh
 ```
 
 If the installer prints a `Next steps` block, follow it instead of the command
@@ -36,7 +36,7 @@ The installer does not edit shell profiles.
 Install the command in `~/bin`:
 
 ```bash
-curl -fsSL https://github.com/lynnswap/PrivateHeaderKit/releases/latest/download/install.sh | sh -s -- --bindir ~/bin
+curl -fsSLO https://github.com/lynnswap/PrivateHeaderKit/releases/latest/download/install.sh && sh ./install.sh --bindir ~/bin
 ```
 
 Build and install from a checkout:


### PR DESCRIPTION
## Purpose

Make installation and first use a direct download-and-run flow followed by
`privateheaderkit`, while keeping operational details discoverable outside the
top-level README.

## Changes

- Rewrite the English and Japanese README around a short Quick Start with no
  `$HOME` command path.
- Preserve download failures by running the installer only after `curl`
  succeeds.
- Explain installer `Next steps` without implying that shell profiles are
  edited.
- Move installation, generation, output, resume, migration, troubleshooting,
  and maintainer details into focused documents.
- Keep automation examples aligned with the current CLI contract.

## Testing

- `swift test --filter PrivateHeaderKitCLIArgumentTests` — 8 tests passed
- `swift test --filter PrivateHeaderKitInstallTests` — 84 tests passed
- `scripts/test-release-scripts.sh`
- Download-failure propagation shell probe
- Markdown link-target validation
- `git diff --check`
- Layer and stack-wide Codex review: no actionable findings

## Stack

Depends on #43. Merge this PR after #43 and publication of the corresponding
release installer.
