### PR TITLE
Remove obsolete public commands during installation

### DIFF
--- a/Docs/installation.md
+++ b/Docs/installation.md
@@ -107,6 +107,13 @@ The default layout is:
 Only `privateheaderkit` is a public command. The helpers are always resolved
 through the active validated cohort.
 
+After activating a validated cohort, the installer removes the retired
+`privateheaderkit-dump`, `headerdump`, and `headerdump-sim` commands from the
+selected command directory. Release and source installation use the same
+cleanup path. These names are reserved PrivateHeaderKit installation paths;
+choosing a custom `--prefix` or `--bindir` also authorizes their removal from
+that selected command directory.
+
 An older direct install containing all three executables is migrated under the
 installer lock. Partial, ambiguous, or modified legacy install layouts are
 rejected instead of guessed. An interrupted install migration is recovered

--- a/Sources/PrivateHeaderKitInstall/ObsoleteCommandCleanup.swift
+++ b/Sources/PrivateHeaderKitInstall/ObsoleteCommandCleanup.swift
@@ -1,0 +1,65 @@
+import Foundation
+
+#if canImport(Darwin)
+import Darwin
+#endif
+
+// PrivateHeaderKit's pre-cohort installer reserved these exact product names in
+// the selected command directory. Keep the names explicit and remove by path:
+// legacy installs have no receipt, and content heuristics cannot recognize every
+// locally built version without leaving the retired commands executable.
+enum ObsoletePublicCommand: String, CaseIterable, Sendable {
+    case privateHeaderKitDump = "privateheaderkit-dump"
+    case headerDump = "headerdump"
+    case headerDumpSimulator = "headerdump-sim"
+}
+
+extension InstallLayout {
+    func url(for command: ObsoletePublicCommand) -> URL {
+        binDir.appendingPathComponent(command.rawValue, isDirectory: false)
+    }
+}
+
+extension VersionCohortInstaller {
+    func validateObsoleteCommandCleanupTargets() throws {
+        for command in ObsoletePublicCommand.allCases {
+            let url = layout.url(for: command)
+            switch try fileSystemItemKind(at: url, fileManager: fileManager) {
+            case .absent, .regularFile, .symbolicLink:
+                continue
+            case .directory, .other:
+                throw InstallError.message(
+                    "obsolete command path is not a removable file: \(url.path)"
+                )
+            }
+        }
+    }
+
+    func removeObsoletePublicCommands() throws -> [URL] {
+        var removed: [URL] = []
+        for command in ObsoletePublicCommand.allCases {
+            let url = layout.url(for: command)
+#if canImport(Darwin)
+            let result = url.path.withCString { path in
+                Darwin.unlink(path)
+            }
+            if result == 0 {
+                removed.append(url)
+                continue
+            }
+            let failure = errno
+            if failure == ENOENT {
+                continue
+            }
+            throw InstallError.message(
+                "new cohort is active, but failed to remove obsolete command at \(url.path): errno \(failure)"
+            )
+#else
+            throw InstallError.message(
+                "obsolete command cleanup is unavailable on this platform: \(url.path)"
+            )
+#endif
+        }
+        return removed
+    }
+}

--- a/Sources/PrivateHeaderKitInstall/PrivateHeaderKitInstallMain.swift
+++ b/Sources/PrivateHeaderKitInstall/PrivateHeaderKitInstallMain.swift
@@ -619,12 +619,16 @@ func defaultSimulatorHelperTriple(
 }
 
 func dryRunInstallMessages(layout: InstallLayout) -> [String] {
-    [
+    var messages = [
         "Would acquire install lock: \(layout.lockURL.path)",
         "Would stage all three artifacts under: \(layout.versionsDirectory.path)",
         "Would atomically switch: \(layout.currentURL.path)",
         "Would maintain stable command symlink: \(layout.publicCommandURL.path)",
     ]
+    messages.append(contentsOf: ObsoletePublicCommand.allCases.map { command in
+        "Would remove obsolete command if present: \(layout.url(for: command).path)"
+    })
+    return messages
 }
 
 private func nonEmptyCLIValue(

--- a/Sources/PrivateHeaderKitInstall/VersionCohortInstaller.swift
+++ b/Sources/PrivateHeaderKitInstall/VersionCohortInstaller.swift
@@ -91,6 +91,7 @@ enum InstallFaultPoint: Equatable, Sendable {
     case publicRestorationStarted
     case currentRestorationStarted
     case legacyCleanupStarted
+    case obsoleteCommandCleanupStarted
 }
 
 typealias InstallFaultInjector = @Sendable (InstallFaultPoint) throws -> Void
@@ -158,6 +159,7 @@ struct VersionCohortInstaller {
     func installLocked(_ cohort: ReleaseCohort) async throws -> InstallResult {
         try Task.checkCancellation()
         try await preflight(cohort)
+        try validateObsoleteCommandCleanupTargets()
         try faultInjector(.preflightComplete)
         try validateOwnedDirectoryIfPresent(layout.installRoot, label: "install root")
         try validateOwnedDirectoryIfPresent(layout.versionsDirectory, label: "versions path")
@@ -359,8 +361,13 @@ struct VersionCohortInstaller {
                 )
             }
         }
+        try faultInjector(.obsoleteCommandCleanupStarted)
+        let removedObsoleteCommands = try removeObsoletePublicCommands()
         for warning in cleanupWarnings {
             outputLogger("warning: \(warning)")
+        }
+        for url in removedObsoleteCommands {
+            outputLogger("Removed obsolete command: \(url.path)")
         }
 
         outputLogger(

--- a/Tests/PrivateHeaderKitInstallTests/PrivateHeaderKitInstallTests.swift
+++ b/Tests/PrivateHeaderKitInstallTests/PrivateHeaderKitInstallTests.swift
@@ -21,6 +21,13 @@ struct InstallOptionTests {
         #expect(layout.versionsDirectory.path == "/prefix/libexec/privateheaderkit/versions")
         #expect(layout.currentURL.path == "/prefix/libexec/privateheaderkit/current")
         #expect(layout.rawDumpHelperURL.path == "/prefix/libexec/privateheaderkit/privateheaderkit-raw-helper")
+        #expect(
+            ObsoletePublicCommand.allCases.map { layout.url(for: $0).path } == [
+                "/prefix/bin/privateheaderkit-dump",
+                "/prefix/bin/headerdump",
+                "/prefix/bin/headerdump-sim",
+            ]
+        )
 
         let custom = try resolveInstallLayout(
             prefix: "/ignored",
@@ -29,6 +36,13 @@ struct InstallOptionTests {
         #expect(custom.prefix.path == "/custom")
         #expect(custom.publicCommandURL.path == "/custom/bin/privateheaderkit")
         #expect(custom.installRoot.path == "/custom/libexec/privateheaderkit")
+        #expect(
+            dryRunInstallMessages(layout: custom).suffix(3) == [
+                "Would remove obsolete command if present: /custom/bin/privateheaderkit-dump",
+                "Would remove obsolete command if present: /custom/bin/headerdump",
+                "Would remove obsolete command if present: /custom/bin/headerdump-sim",
+            ]
+        )
     }
 
 }
@@ -186,6 +200,225 @@ struct VersionCohortInstallerTests {
         )
         #expect(try activePublicCommandContents(layout: layout) == "first-privateheaderkit")
         try assertInstalledCohortIsExact(cohort.manifest, layout: layout)
+    }
+
+    @Test func installRemovesEveryObsoletePublicCommand() async throws {
+        let directories = try makeTemporaryTestDirectories()
+        let layout = try testLayout(in: directories.root)
+        for command in ObsoletePublicCommand.allCases {
+            try writeExecutable("obsolete-\(command.rawValue)", to: layout.url(for: command))
+        }
+        let cohort = try await makeTestCohort(
+            under: directories.root,
+            version: "v1.0.0",
+            commit: String(repeating: "2", count: 40),
+            marker: "cleanup"
+        )
+
+        _ = try await testInstaller(layout: layout).install(cohort)
+
+        try assertActive(cohort.manifest, layout: layout, marker: "cleanup")
+        for command in ObsoletePublicCommand.allCases {
+            #expect(!FileManager.default.fileExists(atPath: layout.url(for: command).path))
+        }
+    }
+
+    @Test func obsoleteCommandCleanupRemovesLinksWithoutRemovingTheirTargets() async throws {
+        let directories = try makeTemporaryTestDirectories()
+        let layout = try testLayout(in: directories.root)
+        var targets: [URL] = []
+        for command in ObsoletePublicCommand.allCases {
+            let target = directories.root.appendingPathComponent(
+                "target-\(command.rawValue)",
+                isDirectory: false
+            )
+            try writeExecutable("target-\(command.rawValue)", to: target)
+            targets.append(target)
+            try FileManager.default.createDirectory(
+                at: layout.binDir,
+                withIntermediateDirectories: true
+            )
+            try FileManager.default.createSymbolicLink(
+                at: layout.url(for: command),
+                withDestinationURL: target
+            )
+        }
+        let cohort = try await makeTestCohort(
+            under: directories.root,
+            version: "v1.0.0",
+            commit: String(repeating: "3", count: 40),
+            marker: "linked-cleanup"
+        )
+
+        _ = try await testInstaller(layout: layout).install(cohort)
+
+        for command in ObsoletePublicCommand.allCases {
+            #expect(!FileManager.default.fileExists(atPath: layout.url(for: command).path))
+        }
+        for target in targets {
+            #expect(FileManager.default.fileExists(atPath: target.path))
+        }
+    }
+
+    @Test func obsoleteCommandCleanupRemovesADanglingLink() async throws {
+        let directories = try makeTemporaryTestDirectories()
+        let layout = try testLayout(in: directories.root)
+        try FileManager.default.createDirectory(
+            at: layout.binDir,
+            withIntermediateDirectories: true
+        )
+        let commandURL = layout.url(for: .privateHeaderKitDump)
+        try FileManager.default.createSymbolicLink(
+            atPath: commandURL.path,
+            withDestinationPath: "missing-privateheaderkit-dump"
+        )
+        let cohort = try await makeTestCohort(
+            under: directories.root,
+            version: "v1.0.0",
+            commit: String(repeating: "4", count: 40),
+            marker: "dangling-cleanup"
+        )
+
+        _ = try await testInstaller(layout: layout).install(cohort)
+
+        guard case .absent = try fileSystemItemKind(
+            at: commandURL,
+            fileManager: .default
+        ) else {
+            Issue.record("expected dangling obsolete command link to be removed")
+            return
+        }
+    }
+
+    @Test func activationFailureLeavesObsoleteCommandsUntouched() async throws {
+        let directories = try makeTemporaryTestDirectories()
+        let layout = try testLayout(in: directories.root)
+        try writeObsoleteCommands(layout: layout)
+        let cohort = try await makeTestCohort(
+            under: directories.root,
+            version: "v1.0.0",
+            commit: String(repeating: "5", count: 40),
+            marker: "failed-activation"
+        )
+        let installer = testInstaller(
+            layout: layout,
+            faultInjector: { point in
+                if point == .stableCommandSwitched {
+                    throw TestInstallFailure.activation
+                }
+            }
+        )
+
+        await #expect(throws: TestInstallFailure.self) {
+            _ = try await installer.install(cohort)
+        }
+
+        for command in ObsoletePublicCommand.allCases {
+            #expect(
+                try String(
+                    contentsOf: layout.url(for: command),
+                    encoding: .utf8
+                ) == "obsolete-\(command.rawValue)"
+            )
+        }
+    }
+
+    @Test func directLayoutMigrationAlsoRemovesObsoletePublicCommands() async throws {
+        let directories = try makeTemporaryTestDirectories()
+        let layout = try testLayout(in: directories.root)
+        try writeLegacyLayout(layout: layout)
+        try writeObsoleteCommands(layout: layout)
+        let cohort = try await makeTestCohort(
+            under: directories.root,
+            version: "v2.0.0",
+            commit: String(repeating: "6", count: 40),
+            marker: "migrated-cleanup"
+        )
+
+        _ = try await testInstaller(layout: layout).install(cohort)
+
+        try assertActive(cohort.manifest, layout: layout, marker: "migrated-cleanup")
+        for command in ObsoletePublicCommand.allCases {
+            #expect(!FileManager.default.fileExists(atPath: layout.url(for: command).path))
+        }
+        #expect(!FileManager.default.fileExists(atPath: layout.rawDumpHelperURL.path))
+        #expect(!FileManager.default.fileExists(atPath: layout.simulatorHelperURL.path))
+    }
+
+    @Test func obsoleteCommandDirectoryFailsBeforeInstallMutation() async throws {
+        let directories = try makeTemporaryTestDirectories()
+        let layout = try testLayout(in: directories.root)
+        let directory = layout.url(for: .headerDump)
+        try FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true
+        )
+        let cohort = try await makeTestCohort(
+            under: directories.root,
+            version: "v1.0.0",
+            commit: String(repeating: "4", count: 40),
+            marker: "blocked-cleanup"
+        )
+
+        await #expect(throws: InstallError.self) {
+            _ = try await testInstaller(layout: layout).install(cohort)
+        }
+
+        #expect(!FileManager.default.fileExists(atPath: layout.currentURL.path))
+        #expect(FileManager.default.fileExists(atPath: directory.path))
+    }
+
+    @Test func obsoleteCommandCleanupRaceFailsAfterLeavingTheNewCohortActive() async throws {
+        let directories = try makeTemporaryTestDirectories()
+        let layout = try testLayout(in: directories.root)
+        try writeObsoleteCommands(layout: layout)
+        let racedDirectory = layout.url(for: .headerDump)
+        let cohort = try await makeTestCohort(
+            under: directories.root,
+            version: "v1.0.0",
+            commit: String(repeating: "5", count: 40),
+            marker: "raced-cleanup"
+        )
+        let installer = testInstaller(
+            layout: layout,
+            faultInjector: { point in
+                if point == .obsoleteCommandCleanupStarted {
+                    try FileManager.default.removeItem(at: racedDirectory)
+                    try FileManager.default.createDirectory(
+                        at: racedDirectory,
+                        withIntermediateDirectories: true
+                    )
+                }
+            }
+        )
+
+        do {
+            _ = try await installer.install(cohort)
+            Issue.record("expected obsolete command cleanup to fail")
+        } catch let error as InstallError {
+            #expect(error.description.contains("new cohort is active"))
+            #expect(error.description.contains(racedDirectory.path))
+        }
+
+        try assertActive(cohort.manifest, layout: layout, marker: "raced-cleanup")
+        #expect(FileManager.default.fileExists(atPath: racedDirectory.path))
+        #expect(
+            !FileManager.default.fileExists(
+                atPath: layout.url(for: .privateHeaderKitDump).path
+            )
+        )
+        #expect(
+            FileManager.default.fileExists(
+                atPath: layout.url(for: .headerDumpSimulator).path
+            )
+        )
+
+        try FileManager.default.removeItem(at: racedDirectory)
+        _ = try await testInstaller(layout: layout).install(cohort)
+
+        for command in ObsoletePublicCommand.allCases {
+            #expect(!FileManager.default.fileExists(atPath: layout.url(for: command).path))
+        }
     }
 
     @Test func installReportsPathGuidanceFromTheCanonicalCommandDirectory() async throws {
@@ -2514,6 +2747,15 @@ private func writeLegacyLayout(layout: InstallLayout) throws {
     try writeExecutable("legacy-main", to: layout.publicCommandURL)
     try writeExecutable("legacy-raw", to: layout.rawDumpHelperURL)
     try writeExecutable("legacy-sim", to: layout.simulatorHelperURL)
+}
+
+private func writeObsoleteCommands(layout: InstallLayout) throws {
+    for command in ObsoletePublicCommand.allCases {
+        try writeExecutable(
+            "obsolete-\(command.rawValue)",
+            to: layout.url(for: command)
+        )
+    }
 }
 
 private func activePublicCommandContents(


### PR DESCRIPTION
## Summary

- remove `privateheaderkit-dump`, `headerdump`, and `headerdump-sim` from the selected command directory after a new cohort is activated and verified
- apply the cleanup consistently to release and source installations, including custom `--prefix` and `--bindir` destinations
- report planned removals in dry-run output and document the reserved legacy command paths
- cover activation failures, partial cleanup recovery, direct-layout migration, regular files, symlinks, dangling symlinks, and unsafe directory targets

## Why

Older installers published multiple public command names directly into the selected command directory. Installing the current single-command layout did not retire those paths, so users could continue invoking stale binaries after a successful update.

The historical installers did not write ownership receipts. The selected command directory therefore treats those three exact legacy names as reserved PrivateHeaderKit installation paths and removes them by pathname only after the replacement cohort has passed activation verification.

## Validation

- `swift test`
- `swift test --filter PrivateHeaderKitInstallTests`
- `scripts/test-release-scripts.sh`
- shell syntax checks for release installer scripts
- `git diff --check`
- Codex review: no findings