### PR TITLE
Add pull request and main branch CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,58 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  package-checks:
+    name: Package Checks
+    runs-on: macos-26
+    timeout-minutes: 20
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_26.6.app/Contents/Developer
+    steps:
+      - name: Checkout
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          persist-credentials: false
+
+      - name: Verify toolchain
+        run: |
+          set -euo pipefail
+          xcodebuild -version
+          swift --version
+          xcrun --sdk iphonesimulator --show-sdk-path
+
+      - name: Run Swift tests
+        run: swift test
+
+      - name: Run release script contract tests
+        run: scripts/test-release-scripts.sh
+
+      - name: Compile iOS Core surface
+        run: |
+          set -euo pipefail
+          PHK_IOS_SIMULATOR_SDK="$(xcrun --sdk iphonesimulator --show-sdk-path)"
+          PHK_IOS_SIMULATOR_TRIPLE="$(uname -m)-apple-ios17.0-simulator"
+          PHK_IOS_BUILD_SCRATCH="$PWD/.build/privateheaderkit-ios-compile/$PHK_IOS_SIMULATOR_TRIPLE"
+          swift build \
+            --scratch-path "$PHK_IOS_BUILD_SCRATCH" \
+            --sdk "$PHK_IOS_SIMULATOR_SDK" \
+            --triple "$PHK_IOS_SIMULATOR_TRIPLE" \
+            --target PrivateHeaderKitCore
+          swift build \
+            --scratch-path "$PHK_IOS_BUILD_SCRATCH" \
+            --sdk "$PHK_IOS_SIMULATOR_SDK" \
+            --triple "$PHK_IOS_SIMULATOR_TRIPLE" \
+            --target PrivateHeaderKitCoreTests


### PR DESCRIPTION
## Summary

- run CI for every pull request and every push to `main`, including merged pull requests
- validate the package with the documented Swift test suite, release-script contract tests, and iOS Core/test cross-compilation
- use the Swift 6.3 baseline from Xcode 26.6 on the GitHub-hosted `macos-26` arm64 runner
- cancel superseded runs for the same ref and keep workflow permissions read-only
- pin `actions/checkout` to the audited `v5.0.1` commit using its Node 24 runtime, without persisting credentials

## Why

PrivateHeaderKit previously had only the manually dispatched release workflow, so pull requests and changes merged or pushed to `main` did not automatically run the repository's normal validation contract.

The initial CI intentionally uses one job without caches or sharding. The current suite is small enough that the added complexity is not justified, and the workflow can be split later if actual Actions timings require it.

## Validation

- `swift test`
- `scripts/test-release-scripts.sh`
- iOS `PrivateHeaderKitCore` and `PrivateHeaderKitCoreTests` cross-compilation
- `actionlint`
- external `uses:` full-SHA audit
- `git diff --check`
- Codex review against `main`: no findings

Local package validation used Xcode 27 / Swift 6.4 because Xcode 26.6 is not installed locally. The workflow pins Xcode 26.6, whose path and installed Simulator SDK were verified against the current GitHub `macos-26` arm64 runner manifest.
