### PR TITLE
Render demangled Objective-C header names

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -46,6 +46,10 @@ let package = Package(
             url: "https://github.com/MxIris-Reverse-Engineering/MachOSwiftSection.git",
             "0.15.1" ..< "0.16.0"
         ),
+        .package(
+            url: "https://github.com/MxIris-Reverse-Engineering/swift-demangling",
+            "0.4.5" ..< "0.5.0"
+        ),
     ],
     targets: [
         .target(
@@ -69,6 +73,7 @@ let package = Package(
                 .product(name: "MachOKit", package: "MachOKit"),
                 .product(name: "MachOObjCSection", package: "MachOObjCSection"),
                 .product(name: "ObjCDump", package: "swift-objc-dump"),
+                .product(name: "Demangling", package: "swift-demangling"),
                 .product(name: "MachOSwiftSection", package: "MachOSwiftSection"),
                 .product(name: "SwiftDeclaration", package: "MachOSwiftSection"),
                 .product(name: "SwiftDeclarationRendering", package: "MachOSwiftSection"),
@@ -169,6 +174,7 @@ let package = Package(
                     condition: .when(platforms: [.macOS, .iOS])
                 ),
                 .product(name: "MachOKit", package: "MachOKit"),
+                .product(name: "ObjCDump", package: "swift-objc-dump"),
             ]
         ),
         .testTarget(

--- a/Sources/PrivateHeaderKitRawDumpCore/PrivateHeaderKitRawDumpMain.swift
+++ b/Sources/PrivateHeaderKitRawDumpCore/PrivateHeaderKitRawDumpMain.swift
@@ -1128,7 +1128,9 @@ private func logicalClassIdentity(name: String, runtimeOrigin: Bool) -> String {
         ? SwiftObjCNameResolver.resolveRuntimeOriginClassName(name)
         : SwiftObjCNameResolver.resolve(name)
     if case .resolved(let resolved) = lookup, resolved.kind == .class {
-        return "swift:\(resolved.canonicalName)"
+        // Runtime-qualified names have no intrinsic mangling tree. Bridge them to
+        // static metadata only through the explicit kind + display projection.
+        return "swift-display:class:\(resolved.displayName.utf8.count):\(resolved.displayName)"
     }
     return "objc:\(name)"
 }

--- a/Sources/PrivateHeaderKitRawDumpCore/PrivateHeaderKitRawDumpMain.swift
+++ b/Sources/PrivateHeaderKitRawDumpCore/PrivateHeaderKitRawDumpMain.swift
@@ -706,13 +706,15 @@ enum ObjCHeaderSymbolKind: String, Comparable {
 
 struct ObjCHeaderEntry: Equatable {
     let symbolKind: ObjCHeaderSymbolKind
-    let baseName: String
+    let rawIdentity: String
+    let displayBaseName: String
     let headerString: String
 }
 
 struct ResolvedObjCHeaderEntry: Equatable {
     let symbolKind: ObjCHeaderSymbolKind
-    let baseName: String
+    let rawIdentity: String
+    let displayBaseName: String
     let headerString: String
     let fileName: String
     let hadNameCollision: Bool
@@ -1000,7 +1002,7 @@ private func caseInsensitiveFileNameKey(_ fileName: String) -> String {
 }
 
 private func collisionSuffix(for entry: ObjCHeaderEntry) -> String {
-    "~\(stableHashHex("\(entry.symbolKind.rawValue):\(entry.baseName)"))"
+    "~\(stableHashHex("\(entry.symbolKind.rawValue):\(entry.rawIdentity)"))"
 }
 
 func resolveObjCHeaderEntries(_ entries: [ObjCHeaderEntry], options: DumpOptions) -> [ResolvedObjCHeaderEntry] {
@@ -1008,14 +1010,17 @@ func resolveObjCHeaderEntries(_ entries: [ObjCHeaderEntry], options: DumpOptions
         if lhs.symbolKind != rhs.symbolKind {
             return lhs.symbolKind < rhs.symbolKind
         }
-        if lhs.baseName != rhs.baseName {
-            return lhs.baseName < rhs.baseName
+        if lhs.displayBaseName != rhs.displayBaseName {
+            return lhs.displayBaseName < rhs.displayBaseName
+        }
+        if lhs.rawIdentity != rhs.rawIdentity {
+            return lhs.rawIdentity < rhs.rawIdentity
         }
         return lhs.headerString < rhs.headerString
     }
 
     let pending = sortedEntries.map { entry in
-        let fileName = safeFileName(baseName: entry.baseName, extension: ".h")
+        let fileName = safeFileName(baseName: entry.displayBaseName, extension: ".h")
         return PendingObjCHeaderFileName(
             entry: entry,
             fileName: fileName,
@@ -1029,13 +1034,13 @@ func resolveObjCHeaderEntries(_ entries: [ObjCHeaderEntry], options: DumpOptions
         let resolvedFileName: String
         if hadCollision {
             resolvedFileName = safeFileName(
-                baseName: item.entry.baseName,
+                baseName: item.entry.displayBaseName,
                 suffix: collisionSuffix(for: item.entry),
                 extension: ".h"
             )
             if options.verbose {
                 fputs(
-                    "privateheaderkit __raw-dump: resolved case-insensitive header name collision \(item.entry.symbolKind.rawValue):\(item.entry.baseName) -> \(resolvedFileName)\n",
+                    "privateheaderkit __raw-dump: resolved case-insensitive header name collision \(item.entry.symbolKind.rawValue):\(item.entry.rawIdentity) -> \(resolvedFileName)\n",
                     stderr
                 )
             }
@@ -1045,7 +1050,8 @@ func resolveObjCHeaderEntries(_ entries: [ObjCHeaderEntry], options: DumpOptions
 
         return ResolvedObjCHeaderEntry(
             symbolKind: item.entry.symbolKind,
-            baseName: item.entry.baseName,
+            rawIdentity: item.entry.rawIdentity,
+            displayBaseName: item.entry.displayBaseName,
             headerString: item.entry.headerString,
             fileName: resolvedFileName,
             hadNameCollision: hadCollision
@@ -1076,9 +1082,10 @@ private func dumpObjC(
                 stderr
             )
         }
-        for info in runtimeInfos where metadata.classInfos[info.name] == nil {
-            metadata.classInfos[info.name] = info
-        }
+        metadata.runtimeOriginClassNames = supplementMissingRuntimeClassInfos(
+            runtimeInfos,
+            into: &metadata.classInfos
+        )
     }
 #endif
 
@@ -1094,6 +1101,49 @@ private struct CollectedObjCMetadata {
     var classInfos: [String: ObjCClassInfo] = [:]
     var protocolInfos: [String: ObjCProtocolInfo] = [:]
     var categoryInfos: [String: ObjCCategoryInfo] = [:]
+    var runtimeOriginClassNames: Set<String> = []
+}
+
+@discardableResult
+func supplementMissingRuntimeClassInfos(
+    _ runtimeInfos: [ObjCClassInfo],
+    into classInfos: inout [String: ObjCClassInfo]
+) -> Set<String> {
+    var logicalIdentities = Set(classInfos.values.map {
+        logicalClassIdentity(name: $0.name, runtimeOrigin: false)
+    })
+    var insertedNames: Set<String> = []
+    for info in runtimeInfos.sorted(by: { runtimeClassSortKey($0.name) < runtimeClassSortKey($1.name) }) {
+        guard classInfos[info.name] == nil else { continue }
+        let logicalIdentity = logicalClassIdentity(name: info.name, runtimeOrigin: true)
+        guard logicalIdentities.insert(logicalIdentity).inserted else { continue }
+        classInfos[info.name] = info
+        insertedNames.insert(info.name)
+    }
+    return insertedNames
+}
+
+private func logicalClassIdentity(name: String, runtimeOrigin: Bool) -> String {
+    let lookup = runtimeOrigin
+        ? SwiftObjCNameResolver.resolveRuntimeOriginClassName(name)
+        : SwiftObjCNameResolver.resolve(name)
+    if case .resolved(let resolved) = lookup, resolved.kind == .class {
+        return "swift:\(resolved.canonicalName)"
+    }
+    return "objc:\(name)"
+}
+
+private func runtimeClassSortKey(_ name: String) -> String {
+    let rank: Int
+    if case .resolved(let resolved) = SwiftObjCNameResolver.resolve(name),
+       resolved.source == .objcRuntimeName {
+        rank = 0
+    } else if case .resolved = SwiftObjCNameResolver.resolveRuntimeOriginClassName(name) {
+        rank = 1
+    } else {
+        rank = 2
+    }
+    return "\(rank):\(name)"
 }
 
 private func collectObjCMetadata<Section: ObjCSectionRepresentable>(
@@ -1168,10 +1218,9 @@ private func writeObjCMetadata(
             continue
         }
         entries.append(
-            ObjCHeaderEntry(
-                symbolKind: .class,
-                baseName: info.name,
-                headerString: info.headerString
+            SwiftObjCHeaderRendering.classEntry(
+                info,
+                runtimeOrigin: metadata.runtimeOriginClassNames.contains(info.name)
             )
         )
     }
@@ -1184,13 +1233,7 @@ private func writeObjCMetadata(
             }
             continue
         }
-        entries.append(
-            ObjCHeaderEntry(
-                symbolKind: .protocol,
-                baseName: info.name,
-                headerString: info.headerString
-            )
-        )
+        entries.append(SwiftObjCHeaderRendering.protocolEntry(info))
     }
 
     for info in categoryInfos.values {
@@ -1204,14 +1247,7 @@ private func writeObjCMetadata(
             }
             continue
         }
-        let baseName = "\(info.className)+\(info.name)"
-        entries.append(
-            ObjCHeaderEntry(
-                symbolKind: .category,
-                baseName: baseName,
-                headerString: info.headerString
-            )
-        )
+        entries.append(SwiftObjCHeaderRendering.categoryEntry(info))
     }
 
     for entry in resolveObjCHeaderEntries(entries, options: options) {
@@ -1271,7 +1307,7 @@ private func runtimeProtocolInfo(
 
 private func runtimeClassInfo(
     for cls: AnyClass,
-    fallbackName: String,
+    runtimeOriginName: String,
     imagePath: String,
     options: DumpOptions
 ) -> ObjCClassInfo? {
@@ -1280,19 +1316,22 @@ private func runtimeClassInfo(
         if options.verbose {
             let stage = (failedStage as String?) ?? "unknown"
             fputs(
-                "privateheaderkit __raw-dump: runtime fallback skip class \(fallbackName) image=\(imagePath) stage=\(stage)\n",
+                "privateheaderkit __raw-dump: runtime fallback skip class \(runtimeOriginName) image=\(imagePath) stage=\(stage)\n",
                 stderr
             )
         }
         return nil
     }
 
+    // The caller-provided runtime-origin spelling owns identity. The primary path
+    // uses `objc_copyClassNamesForImage`; its `class_getName` fallback may instead
+    // provide a qualified `Module.Type` name on current runtimes.
     return ObjCClassInfo(
-        name: snapshot.name,
+        name: runtimeOriginName,
         version: snapshot.version,
         imageName: snapshot.imageName,
         instanceSize: Int(snapshot.instanceSize),
-        superClassName: snapshot.superClassName,
+        superClassName: snapshot.superclassObjCRuntimeName,
         protocols: snapshot.protocols.map(runtimeProtocolInfo(from:)),
         ivars: snapshot.ivars.map(runtimeIvarInfo(from:)),
         classProperties: snapshot.classProperties.map(runtimePropertyInfo(from:)),
@@ -1346,7 +1385,7 @@ private func runtimeClassInfos(for imagePath: String, options: DumpOptions) -> [
         if let cls = NSClassFromString(name) ?? (objc_getClass(name) as? AnyClass) {
             if let info = runtimeClassInfo(
                 for: cls,
-                fallbackName: name,
+                runtimeOriginName: name,
                 imagePath: imagePath,
                 options: options
             ) {
@@ -1389,7 +1428,7 @@ private func runtimeClassInfosByImageName(
         if let only = options.onlyOneClass, only != name { continue }
         if let info = runtimeClassInfo(
             for: cls,
-            fallbackName: name,
+            runtimeOriginName: name,
             imagePath: imagePath,
             options: options
         ) {

--- a/Sources/PrivateHeaderKitRawDumpCore/SwiftObjCHeaderRendering.swift
+++ b/Sources/PrivateHeaderKitRawDumpCore/SwiftObjCHeaderRendering.swift
@@ -1,0 +1,621 @@
+import Demangling
+import Foundation
+import ObjCDump
+
+struct ResolvedSwiftObjCName: Equatable, Sendable {
+    enum Source: Equatable, Sendable {
+        case objcRuntimeName
+        case runtimeQualifiedName
+        case classMetadataSymbol
+    }
+
+    enum Kind: Equatable, Sendable {
+        case `class`
+        case `protocol`
+    }
+
+    let rawName: String
+    let source: Source
+    let kind: Kind
+    let displayName: String
+    let canonicalName: String
+    let objcIdentifier: String
+    let fileStem: String
+}
+
+private extension ResolvedSwiftObjCName.Kind {
+    var hashDiscriminator: String {
+        switch self {
+        case .class: "class"
+        case .protocol: "protocol"
+        }
+    }
+}
+
+enum SwiftObjCNameLookup: Equatable, Sendable {
+    case notSwift
+    case unavailable(rawName: String)
+    case resolved(ResolvedSwiftObjCName)
+}
+
+enum SwiftObjCNameResolver {
+    private static let objcIdentifierPrefix = "PHKSwift__"
+    private static let maxReadableIdentifierBytes = 96
+    private static let maxPortableFileStemBytes = 200
+    private static let hashLength = 16
+
+    static func resolve(_ rawName: String) -> SwiftObjCNameLookup {
+        let source: ResolvedSwiftObjCName.Source
+        if rawName.hasPrefix("_Tt") {
+            source = .objcRuntimeName
+        } else if rawName.hasPrefix("_$s") || rawName.hasPrefix("$s") {
+            guard rawName.hasSuffix("N") else {
+                return .unavailable(rawName: rawName)
+            }
+            source = .classMetadataSymbol
+        } else {
+            return .notSwift
+        }
+
+        guard rawName.unicodeScalars.allSatisfy({
+            $0.properties.generalCategory != .control
+        }) else {
+            return .unavailable(rawName: rawName)
+        }
+
+        do {
+            let root = try demangleAsNode(rawName, internsSubtrees: false)
+            guard let extracted = extractType(from: root, source: source) else {
+                return .unavailable(rawName: rawName)
+            }
+            let displayName = extracted.node.print(using: .default)
+            guard isValidDisplayName(displayName) else {
+                return .unavailable(rawName: rawName)
+            }
+            return resolvedName(
+                rawName: rawName,
+                source: source,
+                kind: extracted.kind,
+                displayName: displayName
+            )
+        } catch {
+            return .unavailable(rawName: rawName)
+        }
+    }
+
+    static func resolveRuntimeOriginClassName(_ rawName: String) -> SwiftObjCNameLookup {
+        let lookup = resolve(rawName)
+        switch lookup {
+        case .resolved, .unavailable:
+            return lookup
+        case .notSwift:
+            // Only runtime enumeration may promote Module.Type to a Swift identity;
+            // the same spelling in static metadata remains an ordinary ObjC name.
+            guard isStrictRuntimeQualifiedClassName(rawName) else {
+                return .notSwift
+            }
+            return resolvedName(
+                rawName: rawName,
+                source: .runtimeQualifiedName,
+                kind: .class,
+                displayName: rawName
+            )
+        }
+    }
+
+    static func portableFileStem(
+        displayName: String,
+        canonicalName: String
+    ) -> String {
+        let hash = stableHashHex("\(displayName)\u{0}\(canonicalName)")
+        return portableFileStem(
+            displayName: displayName,
+            canonicalName: canonicalName,
+            hash: hash
+        )
+    }
+
+    private static func extractType(
+        from root: Node,
+        source: ResolvedSwiftObjCName.Source
+    ) -> (node: Node, kind: ResolvedSwiftObjCName.Kind)? {
+        guard root.kind == .global, root.children.count == 1,
+              let rootPayload = root.firstChild
+        else { return nil }
+
+        switch source {
+        case .runtimeQualifiedName:
+            return nil
+        case .objcRuntimeName:
+            guard rootPayload.kind == .typeMangling,
+                  rootPayload.children.count == 1,
+                  let typeWrapper = rootPayload.firstChild,
+                  typeWrapper.kind == .type,
+                  typeWrapper.children.count == 1,
+                  let typeNode = typeWrapper.firstChild
+            else { return nil }
+            switch typeNode.kind {
+            case .class, .boundGenericClass:
+                return (typeNode, .class)
+            case .protocolList:
+                guard typeNode.children.count == 1,
+                      let typeList = typeNode.firstChild,
+                      typeList.kind == .typeList,
+                      typeList.children.count == 1,
+                      let protocolType = typeList.firstChild,
+                      protocolType.kind == .type,
+                      protocolType.children.count == 1,
+                      let protocolNode = protocolType.firstChild,
+                      protocolNode.kind == .protocol
+                else { return nil }
+                return (protocolNode, .protocol)
+            default:
+                return nil
+            }
+
+        case .classMetadataSymbol:
+            guard rootPayload.kind == .typeMetadata,
+                  rootPayload.children.count == 1,
+                  let typeWrapper = rootPayload.firstChild,
+                  typeWrapper.kind == .type,
+                  typeWrapper.children.count == 1,
+                  let typeNode = typeWrapper.firstChild,
+                  typeNode.kind == .class || typeNode.kind == .boundGenericClass
+            else { return nil }
+            return (typeNode, .class)
+        }
+    }
+
+    private static func resolvedName(
+        rawName: String,
+        source: ResolvedSwiftObjCName.Source,
+        kind: ResolvedSwiftObjCName.Kind,
+        displayName: String
+    ) -> SwiftObjCNameLookup {
+        // Hash the extracted type identity, not its source symbol. Legacy `_Tt`
+        // names and modern `...CN` metadata symbols for one type must share an alias.
+        let canonicalName = "\(kind.hashDiscriminator):\(displayName)"
+        let hash = stableHashHex(canonicalName)
+        return .resolved(
+            ResolvedSwiftObjCName(
+                rawName: rawName,
+                source: source,
+                kind: kind,
+                displayName: displayName,
+                canonicalName: canonicalName,
+                objcIdentifier: objcIdentifier(displayName: displayName, hash: hash),
+                fileStem: portableFileStem(
+                    displayName: displayName,
+                    canonicalName: canonicalName,
+                    hash: hash
+                )
+            )
+        )
+    }
+
+    private static func isStrictRuntimeQualifiedClassName(_ name: String) -> Bool {
+        let components = name.split(separator: ".", omittingEmptySubsequences: false)
+        guard components.count >= 2 else { return false }
+        return components.allSatisfy { component in
+            guard let first = component.unicodeScalars.first,
+                  first == "_" || isASCIIAlpha(first)
+            else { return false }
+            return component.unicodeScalars.dropFirst().allSatisfy {
+                $0 == "_" || isASCIIAlpha($0) || ($0.value >= 48 && $0.value <= 57)
+            }
+        }
+    }
+
+    private static func isASCIIAlpha(_ scalar: UnicodeScalar) -> Bool {
+        scalar.isASCII
+            && ((scalar.value >= 65 && scalar.value <= 90)
+                || (scalar.value >= 97 && scalar.value <= 122))
+    }
+
+    private static func isValidDisplayName(_ displayName: String) -> Bool {
+        !displayName.isEmpty
+            && displayName.unicodeScalars.allSatisfy {
+                $0.properties.generalCategory != .control
+            }
+    }
+
+    private static func objcIdentifier(displayName: String, hash: String) -> String {
+        var readable = sanitizedASCII(
+            displayName,
+            allowedPunctuation: [],
+            replacement: "_"
+        )
+        readable = readable.trimmingCharacters(in: CharacterSet(charactersIn: "_"))
+        if readable.isEmpty {
+            readable = "Type"
+        }
+        readable = String(readable.prefix(maxReadableIdentifierBytes))
+        return "\(objcIdentifierPrefix)\(readable)__\(hash)"
+    }
+
+    private static func portableFileStem(
+        displayName: String,
+        canonicalName: String,
+        hash: String
+    ) -> String {
+        var stem = sanitizedASCII(
+            displayName,
+            allowedPunctuation: [".", "-", "+"],
+            replacement: "_"
+        )
+        if stem.isEmpty || stem == "." || stem == ".." {
+            stem = "SwiftType"
+        }
+        guard stem.utf8.count > maxPortableFileStemBytes else {
+            return stem
+        }
+        let suffix = "~\(hash)"
+        let prefixBytes = maxPortableFileStemBytes - suffix.utf8.count
+        let prefix = String(stem.prefix(prefixBytes))
+        precondition(!canonicalName.isEmpty, "resolved Swift name must have a canonical identity")
+        return prefix + suffix
+    }
+
+    private static func sanitizedASCII(
+        _ value: String,
+        allowedPunctuation: Set<UnicodeScalar>,
+        replacement: Character
+    ) -> String {
+        var result = ""
+        var previousWasReplacement = false
+        for scalar in value.unicodeScalars {
+            let isASCIIAlphanumeric = scalar.isASCII
+                && ((scalar.value >= 48 && scalar.value <= 57)
+                    || (scalar.value >= 65 && scalar.value <= 90)
+                    || (scalar.value >= 97 && scalar.value <= 122))
+            if isASCIIAlphanumeric || scalar == "_" || allowedPunctuation.contains(scalar) {
+                result.unicodeScalars.append(scalar)
+                previousWasReplacement = false
+            } else if !previousWasReplacement {
+                result.append(replacement)
+                previousWasReplacement = true
+            }
+        }
+        return result
+    }
+
+    private static func stableHashHex(_ value: String) -> String {
+        var hash: UInt64 = 0xcbf29ce484222325
+        for byte in value.utf8 {
+            hash ^= UInt64(byte)
+            hash &*= 0x100000001b3
+        }
+        let hex = String(hash, radix: 16)
+        if hex.count >= hashLength {
+            return hex
+        }
+        return String(repeating: "0", count: hashLength - hex.count) + hex
+    }
+}
+
+enum SwiftObjCHeaderRendering {
+    static func classEntry(
+        _ info: ObjCClassInfo,
+        runtimeOrigin: Bool = false
+    ) -> ObjCHeaderEntry {
+        var projection = Projection(allowsRuntimeQualifiedClassNames: runtimeOrigin)
+        let ownName = projection.name(info.name, expectedKind: .class)
+        let renderedInfo = ObjCClassInfo(
+            name: ownName.outputName,
+            version: info.version,
+            imageName: info.imageName,
+            instanceSize: info.instanceSize,
+            superClassName: info.superClassName.map {
+                projection.name($0, expectedKind: .class).outputName
+            },
+            protocols: info.protocols.map { projection.protocolReference($0) },
+            ivars: info.ivars.map { projection.ivar($0) },
+            classProperties: info.classProperties.map { projection.property($0) },
+            properties: info.properties.map { projection.property($0) },
+            classMethods: info.classMethods.map { projection.method($0) },
+            methods: info.methods.map { projection.method($0) }
+        )
+        return ObjCHeaderEntry(
+            symbolKind: .class,
+            rawIdentity: info.name,
+            displayBaseName: ownName.resolved?.fileStem ?? info.name,
+            headerString: projection.headerString(
+                renderedInfo.headerString,
+                runtimeName: ownName.runtimeName(for: .class)
+            )
+        )
+    }
+
+    static func protocolEntry(_ info: ObjCProtocolInfo) -> ObjCHeaderEntry {
+        var projection = Projection(allowsRuntimeQualifiedClassNames: false)
+        let ownName = projection.name(info.name, expectedKind: .protocol)
+        let renderedInfo = ObjCProtocolInfo(
+            name: ownName.outputName,
+            protocols: info.protocols.map { projection.protocolReference($0) },
+            classProperties: info.classProperties.map { projection.property($0) },
+            properties: info.properties.map { projection.property($0) },
+            classMethods: info.classMethods.map { projection.method($0) },
+            methods: info.methods.map { projection.method($0) },
+            optionalClassProperties: info.optionalClassProperties.map { projection.property($0) },
+            optionalProperties: info.optionalProperties.map { projection.property($0) },
+            optionalClassMethods: info.optionalClassMethods.map { projection.method($0) },
+            optionalMethods: info.optionalMethods.map { projection.method($0) }
+        )
+        return ObjCHeaderEntry(
+            symbolKind: .protocol,
+            rawIdentity: info.name,
+            displayBaseName: ownName.resolved?.fileStem ?? info.name,
+            headerString: projection.headerString(
+                renderedInfo.headerString,
+                runtimeName: ownName.runtimeName(for: .protocol)
+            )
+        )
+    }
+
+    static func categoryEntry(_ info: ObjCCategoryInfo) -> ObjCHeaderEntry {
+        var projection = Projection(allowsRuntimeQualifiedClassNames: false)
+        let className = projection.name(info.className, expectedKind: .class)
+        let renderedInfo = ObjCCategoryInfo(
+            name: info.name,
+            className: className.outputName,
+            protocols: info.protocols.map { projection.protocolReference($0) },
+            classProperties: info.classProperties.map { projection.property($0) },
+            properties: info.properties.map { projection.property($0) },
+            classMethods: info.classMethods.map { projection.method($0) },
+            methods: info.methods.map { projection.method($0) }
+        )
+        let rawIdentity = "\(info.className)+\(info.name)"
+        let displayBaseName: String
+        if let resolved = className.resolved {
+            displayBaseName = SwiftObjCNameResolver.portableFileStem(
+                displayName: "\(resolved.displayName)+\(info.name)",
+                canonicalName: "\(resolved.canonicalName)\u{0}category\u{0}\(info.name)"
+            )
+        } else {
+            displayBaseName = rawIdentity
+        }
+        return ObjCHeaderEntry(
+            symbolKind: .category,
+            rawIdentity: rawIdentity,
+            displayBaseName: displayBaseName,
+            headerString: projection.headerString(renderedInfo.headerString, runtimeName: nil)
+        )
+    }
+}
+
+private extension SwiftObjCHeaderRendering {
+    enum Annotation: Equatable {
+        case resolved(String)
+        case unavailable
+    }
+
+    struct ProjectedName {
+        let rawName: String
+        let outputName: String
+        let resolved: ResolvedSwiftObjCName?
+
+        func runtimeName(for expectedKind: ResolvedSwiftObjCName.Kind) -> String? {
+            guard let resolved,
+                  (resolved.source == .objcRuntimeName
+                    || resolved.source == .runtimeQualifiedName),
+                  resolved.kind == expectedKind
+            else { return nil }
+            return rawName
+        }
+    }
+
+    struct Projection {
+        let allowsRuntimeQualifiedClassNames: Bool
+        private var annotations: [String: Annotation] = [:]
+
+        init(allowsRuntimeQualifiedClassNames: Bool) {
+            self.allowsRuntimeQualifiedClassNames = allowsRuntimeQualifiedClassNames
+        }
+
+        mutating func name(
+            _ rawName: String,
+            expectedKind: ResolvedSwiftObjCName.Kind
+        ) -> ProjectedName {
+            let lookup = if expectedKind == .class && allowsRuntimeQualifiedClassNames {
+                SwiftObjCNameResolver.resolveRuntimeOriginClassName(rawName)
+            } else {
+                SwiftObjCNameResolver.resolve(rawName)
+            }
+            switch lookup {
+            case .notSwift:
+                return ProjectedName(rawName: rawName, outputName: rawName, resolved: nil)
+            case .unavailable:
+                record(.unavailable, for: rawName)
+                return ProjectedName(rawName: rawName, outputName: rawName, resolved: nil)
+            case .resolved(let resolved):
+                guard resolved.kind == expectedKind else {
+                    record(.unavailable, for: rawName)
+                    return ProjectedName(rawName: rawName, outputName: rawName, resolved: nil)
+                }
+                record(.resolved(resolved.displayName), for: rawName)
+                return ProjectedName(
+                    rawName: rawName,
+                    outputName: resolved.objcIdentifier,
+                    resolved: resolved
+                )
+            }
+        }
+
+        mutating func protocolReference(_ info: ObjCProtocolInfo) -> ObjCProtocolInfo {
+            let projectedName = name(info.name, expectedKind: .protocol).outputName
+            return ObjCProtocolInfo(
+                name: projectedName,
+                protocols: [],
+                classProperties: [],
+                properties: [],
+                classMethods: [],
+                methods: [],
+                optionalClassProperties: [],
+                optionalProperties: [],
+                optionalClassMethods: [],
+                optionalMethods: []
+            )
+        }
+
+        mutating func ivar(_ info: ObjCIvarInfo) -> ObjCIvarInfo {
+            ObjCIvarInfo(
+                name: info.name,
+                typeEncoding: rewrittenTypeEncoding(info.typeEncoding),
+                offset: info.offset
+            )
+        }
+
+        mutating func property(_ info: ObjCPropertyInfo) -> ObjCPropertyInfo {
+            ObjCPropertyInfo(
+                name: info.name,
+                attributesString: rewrittenTypeEncoding(info.attributesString),
+                isClassProperty: info.isClassProperty
+            )
+        }
+
+        mutating func method(_ info: ObjCMethodInfo) -> ObjCMethodInfo {
+            ObjCMethodInfo(
+                name: info.name,
+                typeEncoding: rewrittenTypeEncoding(info.typeEncoding),
+                isClassMethod: info.isClassMethod,
+                imp: info.imp
+            )
+        }
+
+        mutating func headerString(_ body: String, runtimeName: String?) -> String {
+            var prefix = annotations.keys.sorted().map { rawName in
+                switch annotations[rawName] {
+                case .resolved(let displayName):
+                    "// Swift name: \(rawName) -> \(displayName)"
+                case .unavailable:
+                    "// Swift name unavailable: \(rawName)"
+                case nil:
+                    preconditionFailure("annotation key must have a value")
+                }
+            }
+            if let runtimeName {
+                prefix.append(
+                    "__attribute__((objc_runtime_name(\"\(escapedCString(runtimeName))\")))"
+                )
+            }
+            guard !prefix.isEmpty else { return body }
+            prefix.append(body)
+            return prefix.joined(separator: "\n")
+        }
+
+        private mutating func rewrittenTypeEncoding(_ encoding: String) -> String {
+            var result = ""
+            var cursor = encoding.startIndex
+            while cursor < encoding.endIndex {
+                let next = encoding.index(after: cursor)
+                guard encoding[cursor] == "@",
+                      next < encoding.endIndex,
+                      encoding[next] == "\""
+                else {
+                    result.append(encoding[cursor])
+                    cursor = next
+                    continue
+                }
+
+                result += "@\""
+                let contentStart = encoding.index(after: next)
+                guard let closingQuote = closingQuote(in: encoding, from: contentStart) else {
+                    result.append(contentsOf: encoding[contentStart...])
+                    return result
+                }
+                let descriptor = String(encoding[contentStart..<closingQuote])
+                result += rewrittenObjectDescriptor(descriptor)
+                result.append("\"")
+                cursor = encoding.index(after: closingQuote)
+            }
+            return result
+        }
+
+        private func closingQuote(in value: String, from start: String.Index) -> String.Index? {
+            var cursor = start
+            var escaped = false
+            while cursor < value.endIndex {
+                let character = value[cursor]
+                if character == "\"" && !escaped {
+                    return cursor
+                }
+                if character == "\\" {
+                    escaped.toggle()
+                } else {
+                    escaped = false
+                }
+                cursor = value.index(after: cursor)
+            }
+            return nil
+        }
+
+        private mutating func rewrittenObjectDescriptor(_ descriptor: String) -> String {
+            guard let firstProtocolStart = descriptor.firstIndex(of: "<") else {
+                return name(descriptor, expectedKind: .class).outputName
+            }
+
+            var result = ""
+            let className = String(descriptor[..<firstProtocolStart])
+            if !className.isEmpty {
+                result += name(className, expectedKind: .class).outputName
+            }
+            var cursor = firstProtocolStart
+            while cursor < descriptor.endIndex {
+                guard descriptor[cursor] == "<",
+                      let close = descriptor[cursor...].firstIndex(of: ">")
+                else {
+                    result.append(contentsOf: descriptor[cursor...])
+                    break
+                }
+                result.append("<")
+                let contentStart = descriptor.index(after: cursor)
+                let content = String(descriptor[contentStart..<close])
+                result += rewrittenProtocolList(content)
+                result.append(">")
+                cursor = descriptor.index(after: close)
+            }
+            return result
+        }
+
+        private mutating func rewrittenProtocolList(_ content: String) -> String {
+            content.split(separator: ",", omittingEmptySubsequences: false)
+                .map { component in
+                    let raw = String(component)
+                    let leading = raw.prefix { $0.isWhitespace }
+                    let trailing = raw.reversed().prefix { $0.isWhitespace }.reversed()
+                    let start = raw.index(raw.startIndex, offsetBy: leading.count)
+                    let end = raw.index(raw.endIndex, offsetBy: -trailing.count)
+                    guard start <= end else { return raw }
+                    let protocolName = String(raw[start..<end])
+                    guard !protocolName.isEmpty else { return raw }
+                    return String(leading)
+                        + name(protocolName, expectedKind: .protocol).outputName
+                        + String(trailing)
+                }
+                .joined(separator: ",")
+        }
+
+        private mutating func record(_ annotation: Annotation, for rawName: String) {
+            if let existing = annotations[rawName] {
+                precondition(existing == annotation, "one raw Swift name must have one resolution")
+            } else {
+                annotations[rawName] = annotation
+            }
+        }
+
+        private func escapedCString(_ value: String) -> String {
+            var result = ""
+            for character in value {
+                switch character {
+                case "\\": result += "\\\\"
+                case "\"": result += "\\\""
+                case "\n": result += "\\n"
+                case "\r": result += "\\r"
+                case "\t": result += "\\t"
+                default: result.append(character)
+                }
+            }
+            return result
+        }
+    }
+}

--- a/Sources/PrivateHeaderKitRawDumpCore/SwiftObjCHeaderRendering.swift
+++ b/Sources/PrivateHeaderKitRawDumpCore/SwiftObjCHeaderRendering.swift
@@ -76,7 +76,11 @@ enum SwiftObjCNameResolver {
                 rawName: rawName,
                 source: source,
                 kind: extracted.kind,
-                displayName: displayName
+                displayName: displayName,
+                canonicalName: structuralCanonicalName(
+                    kind: extracted.kind,
+                    node: extracted.node
+                )
             )
         } catch {
             return .unavailable(rawName: rawName)
@@ -98,7 +102,11 @@ enum SwiftObjCNameResolver {
                 rawName: rawName,
                 source: .runtimeQualifiedName,
                 kind: .class,
-                displayName: rawName
+                displayName: rawName,
+                canonicalName: lengthPrefixed(
+                    tag: "runtime-qualified-class",
+                    value: rawName
+                )
             )
         }
     }
@@ -170,12 +178,13 @@ enum SwiftObjCNameResolver {
         rawName: String,
         source: ResolvedSwiftObjCName.Source,
         kind: ResolvedSwiftObjCName.Kind,
-        displayName: String
+        displayName: String,
+        canonicalName: String
     ) -> SwiftObjCNameLookup {
-        // Hash the extracted type identity, not its source symbol. Legacy `_Tt`
-        // names and modern `...CN` metadata symbols for one type must share an alias.
-        let canonicalName = "\(kind.hashDiscriminator):\(displayName)"
-        let hash = stableHashHex(canonicalName)
+        // Aliases are a presentation projection. Equivalent `_Tt`, metadata,
+        // and runtime-qualified spellings must share one suffix even though only
+        // the first two have an intrinsic structural identity.
+        let hash = stableHashHex(presentationIdentity(kind: kind, displayName: displayName))
         return .resolved(
             ResolvedSwiftObjCName(
                 rawName: rawName,
@@ -195,21 +204,53 @@ enum SwiftObjCNameResolver {
 
     private static func isStrictRuntimeQualifiedClassName(_ name: String) -> Bool {
         let components = name.split(separator: ".", omittingEmptySubsequences: false)
-        guard components.count >= 2 else { return false }
-        return components.allSatisfy { component in
-            guard let first = component.unicodeScalars.first,
-                  first == "_" || isASCIIAlpha(first)
-            else { return false }
-            return component.unicodeScalars.dropFirst().allSatisfy {
-                $0 == "_" || isASCIIAlpha($0) || ($0.value >= 48 && $0.value <= 57)
-            }
+        guard components.count >= 2, components.allSatisfy({ !$0.isEmpty }) else {
+            return false
+        }
+        guard !name.contains(where: \.isWhitespace) else { return false }
+        return name.unicodeScalars.allSatisfy { scalar in
+            scalar != "\0"
+                && scalar != "/"
+                && scalar != "\\"
+                && scalar.properties.generalCategory != .control
         }
     }
 
-    private static func isASCIIAlpha(_ scalar: UnicodeScalar) -> Bool {
-        scalar.isASCII
-            && ((scalar.value >= 65 && scalar.value <= 90)
-                || (scalar.value >= 97 && scalar.value <= 122))
+    private static func structuralCanonicalName(
+        kind: ResolvedSwiftObjCName.Kind,
+        node: Node
+    ) -> String {
+        lengthPrefixed(tag: "type-kind", value: kind.hashDiscriminator)
+            + lengthPrefixed(tag: "node", value: structuralSerialization(of: node))
+    }
+
+    private static func structuralSerialization(of node: Node) -> String {
+        var result = lengthPrefixed(tag: "kind", value: node.kind.rawValue)
+        switch node.contents {
+        case .none:
+            result += lengthPrefixed(tag: "contents-none", value: "")
+        case .index(let index):
+            result += lengthPrefixed(tag: "contents-index", value: String(index))
+        case .text(let text):
+            result += lengthPrefixed(tag: "contents-text", value: text)
+        }
+        result += lengthPrefixed(tag: "children-count", value: String(node.children.count))
+        for child in node.children {
+            result += lengthPrefixed(tag: "child", value: structuralSerialization(of: child))
+        }
+        return result
+    }
+
+    private static func presentationIdentity(
+        kind: ResolvedSwiftObjCName.Kind,
+        displayName: String
+    ) -> String {
+        lengthPrefixed(tag: "type-kind", value: kind.hashDiscriminator)
+            + lengthPrefixed(tag: "display", value: displayName)
+    }
+
+    private static func lengthPrefixed(tag: String, value: String) -> String {
+        "\(tag):\(value.utf8.count):\(value)"
     }
 
     private static func isValidDisplayName(_ displayName: String) -> Bool {
@@ -408,6 +449,7 @@ private extension SwiftObjCHeaderRendering {
     struct Projection {
         let allowsRuntimeQualifiedClassNames: Bool
         private var annotations: [String: Annotation] = [:]
+        private var runtimeBindingUnavailableNames: Set<String> = []
 
         init(allowsRuntimeQualifiedClassNames: Bool) {
             self.allowsRuntimeQualifiedClassNames = allowsRuntimeQualifiedClassNames
@@ -434,6 +476,10 @@ private extension SwiftObjCHeaderRendering {
                     return ProjectedName(rawName: rawName, outputName: rawName, resolved: nil)
                 }
                 record(.resolved(resolved.displayName), for: rawName)
+                if resolved.source == .runtimeQualifiedName
+                    || resolved.source == .classMetadataSymbol {
+                    runtimeBindingUnavailableNames.insert(rawName)
+                }
                 return ProjectedName(
                     rawName: rawName,
                     outputName: resolved.objcIdentifier,
@@ -493,6 +539,9 @@ private extension SwiftObjCHeaderRendering {
                 case nil:
                     preconditionFailure("annotation key must have a value")
                 }
+            }
+            prefix += runtimeBindingUnavailableNames.sorted().map {
+                "// Objective-C runtime binding unavailable: \($0)"
             }
             if let runtimeName {
                 prefix.append(

--- a/Sources/PrivateHeaderKitRawDumpCore/SwiftObjCHeaderRendering.swift
+++ b/Sources/PrivateHeaderKitRawDumpCore/SwiftObjCHeaderRendering.swift
@@ -395,9 +395,10 @@ private extension SwiftObjCHeaderRendering {
         let resolved: ResolvedSwiftObjCName?
 
         func runtimeName(for expectedKind: ResolvedSwiftObjCName.Kind) -> String? {
+            // Do not promote `class_getName`'s qualified `Module.Type` display to
+            // `objc_runtime_name`: the linker class symbol can remain `_Tt...`.
             guard let resolved,
-                  (resolved.source == .objcRuntimeName
-                    || resolved.source == .runtimeQualifiedName),
+                  resolved.source == .objcRuntimeName,
                   resolved.kind == expectedKind
             else { return nil }
             return rawName

--- a/Sources/PrivateHeaderKitRawDumpRuntimeObjC/RuntimeFallbackClassInfo.m
+++ b/Sources/PrivateHeaderKitRawDumpRuntimeObjC/RuntimeFallbackClassInfo.m
@@ -118,11 +118,11 @@ static NSString * const PHRuntimeStageOptionalMethods = @"optionalMethods";
 @end
 
 @interface PHRuntimeObjCClassSnapshot ()
-- (instancetype)initWithName:(NSString *)name
+- (instancetype)initWithObjCRuntimeName:(NSString *)objcRuntimeName
                      version:(int32_t)version
                    imageName:(NSString * _Nullable)imageName
                 instanceSize:(NSUInteger)instanceSize
-              superClassName:(NSString * _Nullable)superClassName
+   superclassObjCRuntimeName:(NSString * _Nullable)superclassObjCRuntimeName
                    protocols:(NSArray<PHRuntimeObjCProtocolSnapshot *> *)protocols
                        ivars:(NSArray<PHRuntimeObjCIvarSnapshot *> *)ivars
              classProperties:(NSArray<PHRuntimeObjCPropertySnapshot *> *)classProperties
@@ -132,11 +132,11 @@ static NSString * const PHRuntimeStageOptionalMethods = @"optionalMethods";
 @end
 
 @implementation PHRuntimeObjCClassSnapshot
-- (instancetype)initWithName:(NSString *)name
+- (instancetype)initWithObjCRuntimeName:(NSString *)objcRuntimeName
                      version:(int32_t)version
                    imageName:(NSString * _Nullable)imageName
                 instanceSize:(NSUInteger)instanceSize
-              superClassName:(NSString * _Nullable)superClassName
+   superclassObjCRuntimeName:(NSString * _Nullable)superclassObjCRuntimeName
                    protocols:(NSArray<PHRuntimeObjCProtocolSnapshot *> *)protocols
                        ivars:(NSArray<PHRuntimeObjCIvarSnapshot *> *)ivars
              classProperties:(NSArray<PHRuntimeObjCPropertySnapshot *> *)classProperties
@@ -145,11 +145,11 @@ static NSString * const PHRuntimeStageOptionalMethods = @"optionalMethods";
                      methods:(NSArray<PHRuntimeObjCMethodSnapshot *> *)methods {
     self = [super init];
     if (self) {
-        _name = [name copy];
+        _objcRuntimeName = [objcRuntimeName copy];
         _version = version;
         _imageName = [imageName copy];
         _instanceSize = instanceSize;
-        _superClassName = [superClassName copy];
+        _superclassObjCRuntimeName = [superclassObjCRuntimeName copy];
         _protocols = [protocols copy];
         _ivars = [ivars copy];
         _classProperties = [classProperties copy];
@@ -428,14 +428,17 @@ PHRuntimeProtocolSnapshotsForClass(Class cls, NSString * _Nullable * _Nullable f
                                     failedStage:(NSString * _Nullable * _Nullable)failedStage {
     if (failedStage) { *failedStage = nil; }
 
-    NSString *name = nil;
+    NSString *objcRuntimeName = nil;
     @try {
-        name = NSStringFromClass(cls);
+        const char *name = class_getName(cls);
+        if (name) {
+            objcRuntimeName = [NSString stringWithUTF8String:name];
+        }
     } @catch (NSException *) {
         if (failedStage) { *failedStage = PHRuntimeStageName; }
         return nil;
     }
-    if (!name) {
+    if (!objcRuntimeName) {
         if (failedStage) { *failedStage = PHRuntimeStageName; }
         return nil;
     }
@@ -467,11 +470,14 @@ PHRuntimeProtocolSnapshotsForClass(Class cls, NSString * _Nullable * _Nullable f
         return nil;
     }
 
-    NSString *superClassName = nil;
+    NSString *superclassObjCRuntimeName = nil;
     @try {
         Class superClass = class_getSuperclass(cls);
         if (superClass) {
-            superClassName = NSStringFromClass(superClass);
+            const char *name = class_getName(superClass);
+            if (name) {
+                superclassObjCRuntimeName = [NSString stringWithUTF8String:name];
+            }
         }
     } @catch (NSException *) {
         if (failedStage) { *failedStage = PHRuntimeStageSuperclass; }
@@ -491,16 +497,16 @@ PHRuntimeProtocolSnapshotsForClass(Class cls, NSString * _Nullable * _Nullable f
     NSArray<PHRuntimeObjCMethodSnapshot *> *methods = PHRuntimeMethodSnapshotsForClass(cls, YES, PHRuntimeStageMethods, failedStage);
     if (!methods && failedStage && *failedStage) { return nil; }
 
-    return [[PHRuntimeObjCClassSnapshot alloc] initWithName:name
-                                                    version:version
-                                                  imageName:imageName
-                                               instanceSize:instanceSize
-                                             superClassName:superClassName
-                                                  protocols:protocols ?: @[]
-                                                      ivars:ivars ?: @[]
-                                            classProperties:classProperties ?: @[]
-                                                 properties:properties ?: @[]
-                                               classMethods:classMethods ?: @[]
-                                                    methods:methods ?: @[]];
+    return [[PHRuntimeObjCClassSnapshot alloc] initWithObjCRuntimeName:objcRuntimeName
+                                                               version:version
+                                                             imageName:imageName
+                                                          instanceSize:instanceSize
+                                             superclassObjCRuntimeName:superclassObjCRuntimeName
+                                                             protocols:protocols ?: @[]
+                                                                 ivars:ivars ?: @[]
+                                                       classProperties:classProperties ?: @[]
+                                                            properties:properties ?: @[]
+                                                          classMethods:classMethods ?: @[]
+                                                               methods:methods ?: @[]];
 }
 @end

--- a/Sources/PrivateHeaderKitRawDumpRuntimeObjC/include/PrivateHeaderKitRawDumpRuntimeObjC.h
+++ b/Sources/PrivateHeaderKitRawDumpRuntimeObjC/include/PrivateHeaderKitRawDumpRuntimeObjC.h
@@ -43,11 +43,11 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 @interface PHRuntimeObjCClassSnapshot : NSObject
-@property (nonatomic, readonly, copy) NSString *name;
+@property (nonatomic, readonly, copy) NSString *objcRuntimeName;
 @property (nonatomic, readonly) int32_t version;
 @property (nonatomic, readonly, copy, nullable) NSString *imageName;
 @property (nonatomic, readonly) NSUInteger instanceSize;
-@property (nonatomic, readonly, copy, nullable) NSString *superClassName;
+@property (nonatomic, readonly, copy, nullable) NSString *superclassObjCRuntimeName;
 @property (nonatomic, readonly, copy) NSArray<PHRuntimeObjCProtocolSnapshot *> *protocols;
 @property (nonatomic, readonly, copy) NSArray<PHRuntimeObjCIvarSnapshot *> *ivars;
 @property (nonatomic, readonly, copy) NSArray<PHRuntimeObjCPropertySnapshot *> *classProperties;

--- a/Tests/PrivateHeaderKitRawDumpTests/PrivateHeaderKitRawDumpTests.swift
+++ b/Tests/PrivateHeaderKitRawDumpTests/PrivateHeaderKitRawDumpTests.swift
@@ -581,7 +581,7 @@ struct PrivateHeaderKitRawDumpObjCHeaderNameTests {
     @Test func resolveObjCHeaderEntriesLeavesNonCollidingNamesUnchanged() {
         let options = DumpOptions(outputDir: URL(fileURLWithPath: "/tmp/out"))
         let entries = [
-            ObjCHeaderEntry(symbolKind: .class, baseName: "FooHeader", headerString: "@interface FooHeader\n@end\n")
+            entry(symbolKind: .class, name: "FooHeader", headerString: "@interface FooHeader\n@end\n")
         ]
 
         let resolved = resolveObjCHeaderEntries(entries, options: options)
@@ -594,8 +594,8 @@ struct PrivateHeaderKitRawDumpObjCHeaderNameTests {
     @Test func resolveObjCHeaderEntriesDisambiguatesCaseOnlyCollisions() {
         let options = DumpOptions(outputDir: URL(fileURLWithPath: "/tmp/out"))
         let entries = [
-            ObjCHeaderEntry(symbolKind: .class, baseName: "MTRBaseClusterWakeOnLAN", headerString: "@interface A\n@end\n"),
-            ObjCHeaderEntry(symbolKind: .class, baseName: "MTRBaseClusterWakeOnLan", headerString: "@interface B\n@end\n")
+            entry(symbolKind: .class, name: "MTRBaseClusterWakeOnLAN", headerString: "@interface A\n@end\n"),
+            entry(symbolKind: .class, name: "MTRBaseClusterWakeOnLan", headerString: "@interface B\n@end\n")
         ]
 
         let resolved = resolveObjCHeaderEntries(entries, options: options)
@@ -603,15 +603,15 @@ struct PrivateHeaderKitRawDumpObjCHeaderNameTests {
 
         #expect(fileNames.count == 2)
         #expect(resolved.allSatisfy { $0.hadNameCollision })
-        #expect(resolved.contains { $0.baseName == "MTRBaseClusterWakeOnLAN" && $0.fileName.hasPrefix("MTRBaseClusterWakeOnLAN~") })
-        #expect(resolved.contains { $0.baseName == "MTRBaseClusterWakeOnLan" && $0.fileName.hasPrefix("MTRBaseClusterWakeOnLan~") })
+        #expect(resolved.contains { $0.displayBaseName == "MTRBaseClusterWakeOnLAN" && $0.fileName.hasPrefix("MTRBaseClusterWakeOnLAN~") })
+        #expect(resolved.contains { $0.displayBaseName == "MTRBaseClusterWakeOnLan" && $0.fileName.hasPrefix("MTRBaseClusterWakeOnLan~") })
     }
 
     @Test func resolveObjCHeaderEntriesDisambiguatesAcrossSymbolKinds() {
         let options = DumpOptions(outputDir: URL(fileURLWithPath: "/tmp/out"))
         let entries = [
-            ObjCHeaderEntry(symbolKind: .class, baseName: "SharedHeaderName", headerString: "@interface SharedHeaderName\n@end\n"),
-            ObjCHeaderEntry(symbolKind: .protocol, baseName: "SharedHeaderName", headerString: "@protocol SharedHeaderName\n@end\n")
+            entry(symbolKind: .class, name: "SharedHeaderName", headerString: "@interface SharedHeaderName\n@end\n"),
+            entry(symbolKind: .protocol, name: "SharedHeaderName", headerString: "@protocol SharedHeaderName\n@end\n")
         ]
 
         let resolved = resolveObjCHeaderEntries(entries, options: options)
@@ -627,8 +627,8 @@ struct PrivateHeaderKitRawDumpObjCHeaderNameTests {
         let options = DumpOptions(outputDir: URL(fileURLWithPath: "/tmp/out"))
         let longBaseName = String(repeating: "VeryLongHeaderName", count: 20)
         let entries = [
-            ObjCHeaderEntry(symbolKind: .class, baseName: longBaseName, headerString: "@interface LongHeader\n@end\n"),
-            ObjCHeaderEntry(symbolKind: .protocol, baseName: longBaseName, headerString: "@protocol LongHeader\n@end\n")
+            entry(symbolKind: .class, name: longBaseName, headerString: "@interface LongHeader\n@end\n"),
+            entry(symbolKind: .protocol, name: longBaseName, headerString: "@protocol LongHeader\n@end\n")
         ]
 
         let resolved = resolveObjCHeaderEntries(entries, options: options)
@@ -641,15 +641,28 @@ struct PrivateHeaderKitRawDumpObjCHeaderNameTests {
     @Test func resolveObjCHeaderEntriesIsStableAcrossRuns() {
         let options = DumpOptions(outputDir: URL(fileURLWithPath: "/tmp/out"))
         let entries = [
-            ObjCHeaderEntry(symbolKind: .protocol, baseName: "SharedHeaderName", headerString: "@protocol SharedHeaderName\n@end\n"),
-            ObjCHeaderEntry(symbolKind: .class, baseName: "MTRBaseClusterWakeOnLan", headerString: "@interface MTRBaseClusterWakeOnLan\n@end\n"),
-            ObjCHeaderEntry(symbolKind: .class, baseName: "MTRBaseClusterWakeOnLAN", headerString: "@interface MTRBaseClusterWakeOnLAN\n@end\n")
+            entry(symbolKind: .protocol, name: "SharedHeaderName", headerString: "@protocol SharedHeaderName\n@end\n"),
+            entry(symbolKind: .class, name: "MTRBaseClusterWakeOnLan", headerString: "@interface MTRBaseClusterWakeOnLan\n@end\n"),
+            entry(symbolKind: .class, name: "MTRBaseClusterWakeOnLAN", headerString: "@interface MTRBaseClusterWakeOnLAN\n@end\n")
         ]
 
         let first = resolveObjCHeaderEntries(entries, options: options)
         let second = resolveObjCHeaderEntries(Array(entries.reversed()), options: options)
 
         #expect(first == second)
+    }
+
+    private func entry(
+        symbolKind: ObjCHeaderSymbolKind,
+        name: String,
+        headerString: String
+    ) -> ObjCHeaderEntry {
+        ObjCHeaderEntry(
+            symbolKind: symbolKind,
+            rawIdentity: name,
+            displayBaseName: name,
+            headerString: headerString
+        )
     }
 }
 
@@ -770,7 +783,8 @@ struct PrivateHeaderKitRawDumpRuntimeInspectorTests {
         let snapshot = PHRuntimeObjCInspector.snapshot(for: NSObject.self, failedStage: &failedStage)
         #expect(snapshot != nil)
         #expect(failedStage == nil)
-        #expect(snapshot?.name == "NSObject")
+        #expect(snapshot?.objcRuntimeName == "NSObject")
+        #expect(snapshot?.superclassObjCRuntimeName == nil)
     }
     #endif
 }

--- a/Tests/PrivateHeaderKitRawDumpTests/SwiftObjCHeaderRenderingTests.swift
+++ b/Tests/PrivateHeaderKitRawDumpTests/SwiftObjCHeaderRenderingTests.swift
@@ -56,12 +56,35 @@ struct SwiftObjCNameResolverTests {
         #expect(metadata.displayName == runtime.displayName)
         #expect(metadata.canonicalName == runtime.canonicalName)
         #expect(metadata.objcIdentifier == runtime.objcIdentifier)
+        #expect(runtime.canonicalName != "class:Demo.Foo")
+        #expect(runtime.canonicalName.contains("node:"))
+        #expect(runtime.canonicalName.utf8.count > runtime.displayName.utf8.count)
 
         let genericRuntime = try resolved("_TtGC4Demo3BoxSi_")
         let genericMetadata = try resolved("_$s4Demo3BoxCySiGN")
         #expect(genericMetadata.displayName == "Demo.Box<Swift.Int>")
         #expect(genericMetadata.canonicalName == genericRuntime.canonicalName)
         #expect(genericMetadata.objcIdentifier == genericRuntime.objcIdentifier)
+    }
+
+    @Test func runtimeQualifiedNamesAcceptUnicodeNestedAndGenericPresentation() throws {
+        for displayName in ["デモ.可視", "Demo.Outer.Inner", "Demo.Box<Swift.Int>"] {
+            guard case .resolved(let resolved) =
+                SwiftObjCNameResolver.resolveRuntimeOriginClassName(displayName)
+            else {
+                throw SwiftObjCHeaderRenderingTestError.expectedResolvedName(displayName)
+            }
+            #expect(resolved.source == .runtimeQualifiedName)
+            #expect(resolved.displayName == displayName)
+            #expect(resolved.objcIdentifier.hasPrefix("PHKSwift__"))
+            #expect(resolved.objcIdentifier.unicodeScalars.allSatisfy { $0.isASCII })
+        }
+
+        for rejected in ["Demo..Foo", "Demo. Foo", "Demo/Foo", "Demo\\Foo", "Demo.\0Foo"] {
+            #expect(
+                SwiftObjCNameResolver.resolveRuntimeOriginClassName(rejected) == .notSwift
+            )
+        }
     }
 
     @Test func rejectsNonTypeAndMalformedSwiftMarkersVisibly() {
@@ -275,6 +298,7 @@ struct SwiftObjCHeaderProjectionTests {
                 "__attribute__((objc_runtime_name(\"\(rawName)\")))\n@protocol"
             )
         )
+        #expect(!entry.headerString.contains("Objective-C runtime binding unavailable"))
     }
 
     @Test func categoryMetadataSymbolUsesAliasWithoutRuntimeAttribute() throws {
@@ -295,6 +319,11 @@ struct SwiftObjCHeaderProjectionTests {
         #expect(entry.displayBaseName.hasPrefix("Demo.Foo+Extras"))
         #expect(entry.headerString.contains("@interface \(resolved.objcIdentifier) (Extras)"))
         #expect(!entry.headerString.contains("objc_runtime_name"))
+        #expect(
+            entry.headerString.contains(
+                "// Objective-C runtime binding unavailable: \(metadataSymbol)"
+            )
+        )
     }
 
     @Test func runtimeOnlyQualifiedNameUsesAliasWithoutUnprovenRuntimeAttribute() throws {
@@ -312,10 +341,39 @@ struct SwiftObjCHeaderProjectionTests {
         )
 
         #expect(qualified.objcIdentifier == mangled.objcIdentifier)
+        #expect(qualified.canonicalName != mangled.canonicalName)
         #expect(entry.displayBaseName == "Demo.Foo")
         #expect(entry.headerString.hasPrefix("// Swift name: Demo.Foo -> Demo.Foo\n"))
         #expect(entry.headerString.contains("@interface \(mangled.objcIdentifier)"))
         #expect(!entry.headerString.contains("objc_runtime_name"))
+        #expect(
+            entry.headerString.contains(
+                "// Objective-C runtime binding unavailable: Demo.Foo"
+            )
+        )
+    }
+
+    @Test func unicodeRuntimeQualifiedNameNeverLeaksIntoObjectiveCDeclaration() throws {
+        let qualifiedName = "デモ.可視"
+        guard case .resolved(let resolved) =
+            SwiftObjCNameResolver.resolveRuntimeOriginClassName(qualifiedName)
+        else {
+            throw SwiftObjCHeaderRenderingTestError.expectedResolvedName(qualifiedName)
+        }
+
+        let entry = SwiftObjCHeaderRendering.classEntry(
+            makeClassInfo(name: qualifiedName),
+            runtimeOrigin: true
+        )
+
+        #expect(entry.headerString.contains("@interface \(resolved.objcIdentifier)"))
+        #expect(!entry.headerString.contains("@interface \(qualifiedName)"))
+        #expect(entry.headerString.contains("// Swift name: \(qualifiedName) -> \(qualifiedName)"))
+        #expect(
+            entry.headerString.contains(
+                "// Objective-C runtime binding unavailable: \(qualifiedName)"
+            )
+        )
     }
 
     @Test func rawIdentityDeterminesCollisionSuffixAndInputOrderDoesNot() {

--- a/Tests/PrivateHeaderKitRawDumpTests/SwiftObjCHeaderRenderingTests.swift
+++ b/Tests/PrivateHeaderKitRawDumpTests/SwiftObjCHeaderRenderingTests.swift
@@ -1,0 +1,518 @@
+import Foundation
+import ObjCDump
+import Testing
+@testable import PrivateHeaderKitRawDumpCore
+#if canImport(ObjectiveC) && canImport(PrivateHeaderKitRawDumpRuntimeObjC)
+import ObjectiveC
+import PrivateHeaderKitRawDumpRuntimeObjC
+#endif
+
+@Suite
+struct SwiftObjCNameResolverTests {
+    @Test func resolvesSupportedLegacyTypeShapes() throws {
+        let topLevel = try resolved("_TtC4Demo3Foo")
+        #expect(topLevel.displayName == "Demo.Foo")
+        #expect(topLevel.kind == .class)
+        #expect(topLevel.source == .objcRuntimeName)
+        #expect(topLevel.objcIdentifier.hasPrefix("PHKSwift__Demo_Foo__"))
+        #expect(topLevel.fileStem == "Demo.Foo")
+
+        let nested = try resolved("_TtCC4Demo6Parent5Child")
+        #expect(nested.displayName == "Demo.Parent.Child")
+
+        let generic = try resolved(
+            "_TtGC18PhotosIntelligence12AssetElectorCSo8PHPerson_"
+        )
+        #expect(generic.displayName == "PhotosIntelligence.AssetElector<__C.PHPerson>")
+        #expect(generic.fileStem.contains("PhotosIntelligence.AssetElector"))
+
+        let privateType = try resolved(
+            "_TtC33AppleMediaServicesUIPaymentSheetsP33_03AA647FCA97033A1DFDB2F3E86BC43E19ResourceBundleClass"
+        )
+        let otherPrivateType = try resolved(
+            "_TtC33AppleMediaServicesUIPaymentSheetsP33_13AA647FCA97033A1DFDB2F3E86BC43E19ResourceBundleClass"
+        )
+        #expect(privateType.displayName.contains("ResourceBundleClass"))
+        #expect(privateType.displayName.contains("03AA647FCA97033A1DFDB2F3E86BC43E"))
+        #expect(otherPrivateType.displayName.contains("13AA647FCA97033A1DFDB2F3E86BC43E"))
+        #expect(otherPrivateType.objcIdentifier != privateType.objcIdentifier)
+
+        let localType = try resolved(
+            "_TtCFIZvE14VoiceShortcutsCSo8NSBundle8_currentS0_iU_FT_S0_L_2__"
+        )
+        #expect(localType.displayName.contains("closure #1"))
+        #expect(localType.objcIdentifier.hasPrefix("PHKSwift__"))
+
+        let `protocol` = try resolved("_TtP4Demo5Proto_")
+        #expect(`protocol`.displayName == "Demo.Proto")
+        #expect(`protocol`.kind == .protocol)
+    }
+
+    @Test func metadataSymbolAndRuntimeNameShareCanonicalAlias() throws {
+        let runtime = try resolved("_TtC4Demo3Foo")
+        let metadata = try resolved("_$s4Demo3FooCN")
+
+        #expect(metadata.source == .classMetadataSymbol)
+        #expect(metadata.displayName == runtime.displayName)
+        #expect(metadata.canonicalName == runtime.canonicalName)
+        #expect(metadata.objcIdentifier == runtime.objcIdentifier)
+
+        let genericRuntime = try resolved("_TtGC4Demo3BoxSi_")
+        let genericMetadata = try resolved("_$s4Demo3BoxCySiGN")
+        #expect(genericMetadata.displayName == "Demo.Box<Swift.Int>")
+        #expect(genericMetadata.canonicalName == genericRuntime.canonicalName)
+        #expect(genericMetadata.objcIdentifier == genericRuntime.objcIdentifier)
+    }
+
+    @Test func rejectsNonTypeAndMalformedSwiftMarkersVisibly() {
+        #expect(
+            SwiftObjCNameResolver.resolve("$s4Demo3fooyyF")
+                == .unavailable(rawName: "$s4Demo3fooyyF")
+        )
+        #expect(
+            SwiftObjCNameResolver.resolve("_TtNotAType")
+                == .unavailable(rawName: "_TtNotAType")
+        )
+        #expect(SwiftObjCNameResolver.resolve("_Zi") == .notSwift)
+        #expect(SwiftObjCNameResolver.resolve("NSObject") == .notSwift)
+    }
+
+    @Test func aliasesAreASCIIIdentifiersAndBounded() throws {
+        let resolved = try resolved(
+            "_TtGC19SiriContactsIntents17BaseIntentHandlerCS_16GetContactIntentCS_24GetContactIntentResponseCS_37GetContactSiriMatchesResolutionResult_"
+        )
+
+        #expect(resolved.objcIdentifier.utf8.count <= 128)
+        #expect(resolved.objcIdentifier.first?.isLetter == true)
+        #expect(
+            resolved.objcIdentifier.unicodeScalars.allSatisfy {
+                $0.isASCII
+                    && (($0.value >= 48 && $0.value <= 57)
+                        || ($0.value >= 65 && $0.value <= 90)
+                        || ($0.value >= 97 && $0.value <= 122)
+                        || $0 == "_")
+            }
+        )
+        #expect(resolved.fileStem.utf8.count <= 200)
+    }
+
+    private func resolved(_ rawName: String) throws -> ResolvedSwiftObjCName {
+        guard case .resolved(let resolved) = SwiftObjCNameResolver.resolve(rawName) else {
+            throw SwiftObjCHeaderRenderingTestError.expectedResolvedName(rawName)
+        }
+        return resolved
+    }
+}
+
+@Suite
+struct SwiftObjCClassSelectionTests {
+    @Test func runtimeOnlySupplementsMissingRawIdentity() {
+        let sharedRawName = "_TtC4Demo3Foo"
+        let staticInfo = makeClassInfo(
+            name: sharedRawName,
+            ivars: [ObjCIvarInfo(name: "staticOnly", typeEncoding: "@", offset: 0)]
+        )
+        let runtimeInfo = makeClassInfo(
+            name: sharedRawName,
+            ivars: [ObjCIvarInfo(name: "runtimeOnly", typeEncoding: "@", offset: 0)]
+        )
+        let runtimeOnly = makeClassInfo(name: "_TtC4Demo3Bar")
+        var classInfos = [staticInfo.name: staticInfo]
+
+        supplementMissingRuntimeClassInfos(
+            [runtimeInfo, runtimeOnly],
+            into: &classInfos
+        )
+
+        #expect(classInfos.count == 2)
+        #expect(classInfos[sharedRawName] == staticInfo)
+        #expect(classInfos[runtimeOnly.name] == runtimeOnly)
+    }
+
+    @Test func qualifiedRuntimeOriginMatchesStaticMangledIdentity() {
+        let staticInfo = makeClassInfo(
+            name: "_TtC4Demo3Foo",
+            ivars: [ObjCIvarInfo(name: "staticOnly", typeEncoding: "@", offset: 0)]
+        )
+        let runtimeInfo = makeClassInfo(
+            name: "Demo.Foo",
+            ivars: [ObjCIvarInfo(name: "runtimeOnly", typeEncoding: "@", offset: 0)]
+        )
+        var classInfos = [staticInfo.name: staticInfo]
+
+        let inserted = supplementMissingRuntimeClassInfos([runtimeInfo], into: &classInfos)
+
+        #expect(inserted.isEmpty)
+        #expect(classInfos == [staticInfo.name: staticInfo])
+    }
+
+    @Test func runtimeLogicalDuplicatesPreferRawSpellingRegardlessOfInputOrder() {
+        let raw = makeClassInfo(name: "_TtC4Demo3Foo")
+        let qualified = makeClassInfo(name: "Demo.Foo")
+        var first: [String: ObjCClassInfo] = [:]
+        var second: [String: ObjCClassInfo] = [:]
+
+        let firstInserted = supplementMissingRuntimeClassInfos(
+            [qualified, raw],
+            into: &first
+        )
+        let secondInserted = supplementMissingRuntimeClassInfos(
+            [raw, qualified],
+            into: &second
+        )
+
+        #expect(first == [raw.name: raw])
+        #expect(second == first)
+        #expect(firstInserted == [raw.name])
+        #expect(secondInserted == firstInserted)
+    }
+}
+
+@Suite
+struct SwiftObjCHeaderProjectionTests {
+    @Test func projectsEveryRenderedTypeReferenceWithSortedMappings() throws {
+        let foo = "_TtC4Demo3Foo"
+        let bar = "_TtC4Demo3Bar"
+        let baz = "_TtC4Demo3Baz"
+        let proto = "_TtP4Demo5Proto_"
+        let info = makeClassInfo(
+            name: foo,
+            superClassName: bar,
+            protocols: [makeProtocolInfo(name: proto)],
+            ivars: [
+                ObjCIvarInfo(name: "_Zi", typeEncoding: "@\"\(baz)\"", offset: 0),
+                ObjCIvarInfo(
+                    name: "composition",
+                    typeEncoding: "@\"NativeRoot<\(proto)>\"",
+                    offset: 8
+                ),
+            ],
+            properties: [
+                ObjCPropertyInfo(
+                    name: "$state",
+                    attributesString: "T@\"\(baz)\",&,N,V_state",
+                    isClassProperty: false
+                )
+            ],
+            methods: [
+                ObjCMethodInfo(
+                    name: "convert:",
+                    typeEncoding: "@\"\(baz)\"24@0:8@\"\(bar)\"16",
+                    isClassMethod: false,
+                    imp: 0
+                )
+            ]
+        )
+
+        let entry = SwiftObjCHeaderRendering.classEntry(info)
+        let fooName = try resolved(foo)
+        let barName = try resolved(bar)
+        let bazName = try resolved(baz)
+        let protoName = try resolved(proto)
+
+        #expect(entry.rawIdentity == foo)
+        #expect(entry.displayBaseName == "Demo.Foo")
+        #expect(entry.headerString.contains("@interface \(fooName.objcIdentifier) : \(barName.objcIdentifier) <\(protoName.objcIdentifier)>"))
+        #expect(entry.headerString.contains("\(bazName.objcIdentifier) *_Zi;"))
+        #expect(entry.headerString.contains("NativeRoot<\(protoName.objcIdentifier)> *composition;"))
+        #expect(entry.headerString.contains("@property(retain, nonatomic) \(bazName.objcIdentifier) *$state;"))
+        #expect(entry.headerString.contains("- (\(bazName.objcIdentifier) *)convert:(\(barName.objcIdentifier) *)arg0;"))
+        #expect(entry.headerString.contains("_Zi"))
+        #expect(entry.headerString.contains("$state"))
+
+        let commentLines = entry.headerString.split(separator: "\n").prefix {
+            $0.hasPrefix("// Swift name:")
+        }.map(String.init)
+        var expectedComments: [String] = []
+        for rawName in [foo, bar, baz, proto].sorted() {
+            let displayName = try resolved(rawName).displayName
+            expectedComments.append("// Swift name: \(rawName) -> \(displayName)")
+        }
+        #expect(commentLines == expectedComments)
+        #expect(
+            entry.headerString.contains(
+                "__attribute__((objc_runtime_name(\"\(foo)\")))\n@interface"
+            )
+        )
+    }
+
+    @Test func ordinaryObjectiveCHeaderIsByteForByteUnchanged() {
+        let info = makeClassInfo(
+            name: "NativeClass",
+            superClassName: "NativeBase",
+            ivars: [ObjCIvarInfo(name: "_Zi", typeEncoding: "@\"NativeValue\"", offset: 0)]
+        )
+
+        let entry = SwiftObjCHeaderRendering.classEntry(info)
+
+        #expect(entry.displayBaseName == info.name)
+        #expect(entry.headerString == info.headerString)
+    }
+
+    @Test func malformedSwiftNameRemainsRawAndVisible() {
+        let rawName = "_TtNotAType"
+        let info = makeClassInfo(name: rawName)
+
+        let entry = SwiftObjCHeaderRendering.classEntry(info)
+
+        #expect(entry.displayBaseName == rawName)
+        #expect(entry.headerString.hasPrefix("// Swift name unavailable: \(rawName)\n"))
+        #expect(entry.headerString.contains("@interface \(rawName)"))
+        #expect(!entry.headerString.contains("objc_runtime_name"))
+    }
+
+    @Test func protocolOwnNameCarriesRuntimeAttribute() throws {
+        let rawName = "_TtP4Demo5Proto_"
+        let info = makeProtocolInfo(name: rawName)
+        let resolved = try resolved(rawName)
+
+        let entry = SwiftObjCHeaderRendering.protocolEntry(info)
+
+        #expect(entry.displayBaseName == "Demo.Proto")
+        #expect(entry.headerString.contains("@protocol \(resolved.objcIdentifier)"))
+        #expect(
+            entry.headerString.contains(
+                "__attribute__((objc_runtime_name(\"\(rawName)\")))\n@protocol"
+            )
+        )
+    }
+
+    @Test func categoryMetadataSymbolUsesAliasWithoutRuntimeAttribute() throws {
+        let metadataSymbol = "_$s4Demo3FooCN"
+        let resolved = try resolved(metadataSymbol)
+        let info = ObjCCategoryInfo(
+            name: "Extras",
+            className: metadataSymbol,
+            protocols: [],
+            classProperties: [],
+            properties: [],
+            classMethods: [],
+            methods: []
+        )
+
+        let entry = SwiftObjCHeaderRendering.categoryEntry(info)
+
+        #expect(entry.displayBaseName.hasPrefix("Demo.Foo+Extras"))
+        #expect(entry.headerString.contains("@interface \(resolved.objcIdentifier) (Extras)"))
+        #expect(!entry.headerString.contains("objc_runtime_name"))
+    }
+
+    @Test func runtimeOnlyQualifiedNameUsesCanonicalAliasAndRuntimeAttribute() throws {
+        let qualifiedName = "Demo.Foo"
+        guard case .resolved(let qualified) =
+            SwiftObjCNameResolver.resolveRuntimeOriginClassName(qualifiedName)
+        else {
+            throw SwiftObjCHeaderRenderingTestError.expectedResolvedName(qualifiedName)
+        }
+        let mangled = try resolved("_TtC4Demo3Foo")
+
+        let entry = SwiftObjCHeaderRendering.classEntry(
+            makeClassInfo(name: qualifiedName),
+            runtimeOrigin: true
+        )
+
+        #expect(qualified.objcIdentifier == mangled.objcIdentifier)
+        #expect(entry.displayBaseName == "Demo.Foo")
+        #expect(entry.headerString.hasPrefix("// Swift name: Demo.Foo -> Demo.Foo\n"))
+        #expect(entry.headerString.contains("@interface \(mangled.objcIdentifier)"))
+        #expect(
+            entry.headerString.contains(
+                "__attribute__((objc_runtime_name(\"Demo.Foo\")))\n@interface"
+            )
+        )
+    }
+
+    @Test func rawIdentityDeterminesCollisionSuffixAndInputOrderDoesNot() {
+        let options = DumpOptions(outputDir: URL(fileURLWithPath: "/tmp/out"))
+        let entries = [
+            ObjCHeaderEntry(
+                symbolKind: .class,
+                rawIdentity: "_TtC4Demo3Foo",
+                displayBaseName: "Demo.Foo",
+                headerString: "first"
+            ),
+            ObjCHeaderEntry(
+                symbolKind: .class,
+                rawIdentity: "_$s4Demo3FooCN",
+                displayBaseName: "Demo.Foo",
+                headerString: "second"
+            ),
+        ]
+
+        let first = resolveObjCHeaderEntries(entries, options: options)
+        let second = resolveObjCHeaderEntries(Array(entries.reversed()), options: options)
+
+        #expect(first == second)
+        #expect(Set(first.map(\.fileName)).count == 2)
+        #expect(first.allSatisfy { $0.fileName.hasPrefix("Demo.Foo~") })
+    }
+
+    #if os(macOS)
+    @Test func generatedAliasGraphParsesAsObjectiveC() throws {
+        let nativeRoot = SwiftObjCHeaderRendering.classEntry(
+            makeClassInfo(name: "NativeRoot")
+        )
+        let proto = SwiftObjCHeaderRendering.protocolEntry(
+            makeProtocolInfo(name: "_TtP4Demo5Proto_")
+        )
+        let bar = SwiftObjCHeaderRendering.classEntry(
+            makeClassInfo(name: "_TtC4Demo3Bar")
+        )
+        let baz = SwiftObjCHeaderRendering.classEntry(
+            makeClassInfo(name: "_TtC4Demo3Baz")
+        )
+        let foo = SwiftObjCHeaderRendering.classEntry(
+            makeClassInfo(
+                name: "_TtC4Demo3Foo",
+                superClassName: "_TtC4Demo3Bar",
+                protocols: [makeProtocolInfo(name: "_TtP4Demo5Proto_")],
+                ivars: [
+                    ObjCIvarInfo(
+                        name: "value",
+                        typeEncoding: "@\"_TtC4Demo3Baz\"",
+                        offset: 0
+                    ),
+                    ObjCIvarInfo(
+                        name: "composition",
+                        typeEncoding: "@\"NativeRoot<_TtP4Demo5Proto_>\"",
+                        offset: 8
+                    ),
+                ],
+                properties: [
+                    ObjCPropertyInfo(
+                        name: "value",
+                        attributesString: "T@\"_TtC4Demo3Baz\",&,N,Vvalue",
+                        isClassProperty: false
+                    )
+                ],
+                methods: [
+                    ObjCMethodInfo(
+                        name: "convert:",
+                        typeEncoding: "@\"_TtC4Demo3Baz\"24@0:8@\"_TtC4Demo3Bar\"16",
+                        isClassMethod: false,
+                        imp: 0
+                    )
+                ]
+            )
+        )
+        let source = [
+            nativeRoot.headerString,
+            proto.headerString,
+            bar.headerString,
+            baz.headerString,
+            foo.headerString,
+        ]
+            .joined(separator: "\n")
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/xcrun")
+        process.arguments = ["clang", "-fsyntax-only", "-Wno-objc-root-class", "-x", "objective-c", "-"]
+        let input = Pipe()
+        let diagnostics = Pipe()
+        process.standardInput = input
+        process.standardError = diagnostics
+        try process.run()
+        try input.fileHandleForWriting.write(contentsOf: Data(source.utf8))
+        try input.fileHandleForWriting.close()
+        process.waitUntilExit()
+        let diagnosticText = String(
+            data: diagnostics.fileHandleForReading.readDataToEndOfFile(),
+            encoding: .utf8
+        ) ?? ""
+
+        #expect(process.terminationStatus == 0, Comment(rawValue: diagnosticText))
+    }
+    #endif
+
+    private func resolved(_ rawName: String) throws -> ResolvedSwiftObjCName {
+        guard case .resolved(let resolved) = SwiftObjCNameResolver.resolve(rawName) else {
+            throw SwiftObjCHeaderRenderingTestError.expectedResolvedName(rawName)
+        }
+        return resolved
+    }
+}
+
+#if canImport(ObjectiveC) && canImport(PrivateHeaderKitRawDumpRuntimeObjC)
+class RuntimeNameBaseFixture: NSObject {}
+final class RuntimeNameChildFixture: RuntimeNameBaseFixture {}
+private final class PrivateRuntimeNameFixture: NSObject {}
+
+@Suite
+struct SwiftObjCRuntimeIdentityTests {
+    @Test func inspectorUsesClassAndSuperclassRuntimeAPINames() throws {
+        var failedStage: NSString?
+        let snapshot = try #require(
+            PHRuntimeObjCInspector.snapshot(
+                for: RuntimeNameChildFixture.self,
+                failedStage: &failedStage
+            )
+        )
+        let rawName = String(cString: class_getName(RuntimeNameChildFixture.self))
+        let superclassRawName = String(cString: class_getName(RuntimeNameBaseFixture.self))
+
+        #expect(failedStage == nil)
+        #expect(snapshot.objcRuntimeName == rawName)
+        #expect(snapshot.superclassObjCRuntimeName == superclassRawName)
+        #expect(snapshot.objcRuntimeName == NSStringFromClass(RuntimeNameChildFixture.self))
+    }
+
+    @Test func inspectorPreservesPrivateRuntimeSpelling() throws {
+        var failedStage: NSString?
+        let snapshot = try #require(
+            PHRuntimeObjCInspector.snapshot(
+                for: PrivateRuntimeNameFixture.self,
+                failedStage: &failedStage
+            )
+        )
+        let rawName = String(cString: class_getName(PrivateRuntimeNameFixture.self))
+
+        #expect(failedStage == nil)
+        #expect(snapshot.objcRuntimeName == rawName)
+        #expect(rawName.hasPrefix("_Tt"))
+    }
+}
+#endif
+
+private enum SwiftObjCHeaderRenderingTestError: Error {
+    case expectedResolvedName(String)
+}
+
+private func makeClassInfo(
+    name: String,
+    superClassName: String? = nil,
+    protocols: [ObjCProtocolInfo] = [],
+    ivars: [ObjCIvarInfo] = [],
+    classProperties: [ObjCPropertyInfo] = [],
+    properties: [ObjCPropertyInfo] = [],
+    classMethods: [ObjCMethodInfo] = [],
+    methods: [ObjCMethodInfo] = []
+) -> ObjCClassInfo {
+    ObjCClassInfo(
+        name: name,
+        version: 0,
+        imageName: nil,
+        instanceSize: 0,
+        superClassName: superClassName,
+        protocols: protocols,
+        ivars: ivars,
+        classProperties: classProperties,
+        properties: properties,
+        classMethods: classMethods,
+        methods: methods
+    )
+}
+
+private func makeProtocolInfo(name: String) -> ObjCProtocolInfo {
+    ObjCProtocolInfo(
+        name: name,
+        protocols: [],
+        classProperties: [],
+        properties: [],
+        classMethods: [],
+        methods: [],
+        optionalClassProperties: [],
+        optionalProperties: [],
+        optionalClassMethods: [],
+        optionalMethods: []
+    )
+}

--- a/Tests/PrivateHeaderKitRawDumpTests/SwiftObjCHeaderRenderingTests.swift
+++ b/Tests/PrivateHeaderKitRawDumpTests/SwiftObjCHeaderRenderingTests.swift
@@ -297,7 +297,7 @@ struct SwiftObjCHeaderProjectionTests {
         #expect(!entry.headerString.contains("objc_runtime_name"))
     }
 
-    @Test func runtimeOnlyQualifiedNameUsesCanonicalAliasAndRuntimeAttribute() throws {
+    @Test func runtimeOnlyQualifiedNameUsesAliasWithoutUnprovenRuntimeAttribute() throws {
         let qualifiedName = "Demo.Foo"
         guard case .resolved(let qualified) =
             SwiftObjCNameResolver.resolveRuntimeOriginClassName(qualifiedName)
@@ -315,11 +315,7 @@ struct SwiftObjCHeaderProjectionTests {
         #expect(entry.displayBaseName == "Demo.Foo")
         #expect(entry.headerString.hasPrefix("// Swift name: Demo.Foo -> Demo.Foo\n"))
         #expect(entry.headerString.contains("@interface \(mangled.objcIdentifier)"))
-        #expect(
-            entry.headerString.contains(
-                "__attribute__((objc_runtime_name(\"Demo.Foo\")))\n@interface"
-            )
-        )
+        #expect(!entry.headerString.contains("objc_runtime_name"))
     }
 
     @Test func rawIdentityDeterminesCollisionSuffixAndInputOrderDoesNot() {


### PR DESCRIPTION
## Purpose

Make generated private headers searchable by demangled Swift names without losing verified Objective-C runtime identity or emitting duplicate static/runtime class headers.

## Changes

- Resolve supported Swift runtime names and class metadata symbols into stable structural identities, readable filenames, and deterministic Objective-C aliases.
- Preserve verified raw runtime symbols with `objc_runtime_name`; surface unbound runtime-qualified and metadata-only names explicitly.
- Reconcile static and runtime class views by logical identity while keeping the static whole-record declaration authoritative.
- Rewrite Swift names in superclass, protocol, ivar, property, and method type positions without post-processing completed headers.
- Add runtime, collision, malformed-name, Unicode, type-position, and Clang syntax contract tests.
- Promote the existing `swift-demangling` 0.4.5 dependency to a direct RawDumpCore dependency.

## Testing

- `swift test` — 454 tests in 40 suites passed.
- `scripts/test-release-scripts.sh` — passed.
- iOS Simulator compile of `PrivateHeaderKitRawDumpCore` and `PrivateHeaderKitRawDumpTests` — passed.
- `swift build -c release --product privateheaderkit-raw-helper` — passed.
- End-to-end generated-dylib probe — produced only `Demo.Visible.h`, `Demo.Other.h`, and `Demo.Talker.h`; no `_Tt*.h` siblings.
- Base-`main` Codex review — 0 findings.
- Package-scheme `xcodebuild -only-testing` was attempted but is blocked before RawDump tests by the existing `PrivateHeaderKitToolingTestHelper` top-level-code/`@main` conflict; the repository-prescribed `swift test` suite passes.