### PR TITLE
Exclude non-loadable bundle targets

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -57,6 +57,10 @@ let package = Package(
             dependencies: []
         ),
         .target(
+            name: "PrivateHeaderKitExecutableResolution",
+            dependencies: []
+        ),
+        .target(
             name: "PrivateHeaderKitRawDumpRuntimeObjC",
             dependencies: [],
             path: "Sources/PrivateHeaderKitRawDumpRuntimeObjC",
@@ -66,6 +70,7 @@ let package = Package(
             name: "PrivateHeaderKitRawDumpCore",
             dependencies: [
                 "PrivateHeaderKitHelperProtocol",
+                "PrivateHeaderKitExecutableResolution",
                 .target(
                     name: "PrivateHeaderKitRawDumpRuntimeObjC",
                     condition: .when(platforms: [.macOS, .iOS])
@@ -95,6 +100,7 @@ let package = Package(
             name: "PrivateHeaderKitCore",
             dependencies: [
                 "PrivateHeaderKitHelperProtocol",
+                "PrivateHeaderKitExecutableResolution",
                 .product(name: "GRDB", package: "GRDB.swift"),
             ]
         ),

--- a/Sources/PrivateHeaderKitCore/PrivateHeaderGenerationExecutor.swift
+++ b/Sources/PrivateHeaderKitCore/PrivateHeaderGenerationExecutor.swift
@@ -1532,28 +1532,29 @@ extension PrivateHeaderGeneration.GenerationExecutor {
     switch request {
     case .frameworks:
       return deduplicated(
-        catalog.targets.flatMap {
-          target -> [PrivateHeaderGeneration.TargetDiscovery.DiscoveredTarget] in
-          guard target.candidate.kind == .framework || target.candidate.kind == .privateFramework
+        catalog.groups.flatMap {
+          group -> [PrivateHeaderGeneration.TargetDiscovery.DiscoveredTarget] in
+          guard group.selectionCandidate.kind == .framework
+            || group.selectionCandidate.kind == .privateFramework
           else {
             return []
           }
-          return [target] + target.childTargets
+          return group.executionTargets
         }
       )
     case .system:
       return deduplicated(
-        catalog.targets.flatMap {
-          target -> [PrivateHeaderGeneration.TargetDiscovery.DiscoveredTarget] in
-          guard target.candidate.kind != .usrLibDylib else { return [] }
-          return [target] + target.childTargets
+        catalog.groups.flatMap {
+          group -> [PrivateHeaderGeneration.TargetDiscovery.DiscoveredTarget] in
+          guard group.selectionCandidate.kind != .usrLibDylib else { return [] }
+          return group.executionTargets
         }
       )
     case .allAvailable:
-      return deduplicated(catalog.allTargetsIncludingNestedChildren)
+      return deduplicated(catalog.allExecutionTargets)
     case .identifiers(let targetIDs):
       let requested = deduplicatedTargetIDs(targetIDs)
-      let all = catalog.allTargetsIncludingNestedChildren
+      let all = catalog.allExecutionTargets
       let selected = requested.compactMap { id in all.first { $0.candidate.identifier == id } }
       if selected.count != requested.count {
         let found = Set(selected.map(\.candidate.identifier))
@@ -1566,7 +1567,7 @@ extension PrivateHeaderGeneration.GenerationExecutor {
       let targetQuery = try PrivateHeaderGeneration.TargetQuery(commaSeparated: query)
       switch catalog.resolver.resolve(targetQuery) {
       case .selected(.allAvailable):
-        return deduplicated(catalog.allTargetsIncludingNestedChildren)
+        return deduplicated(catalog.allExecutionTargets)
       case .selected(.targets(let candidates)):
         return deduplicated(
           candidates.flatMap { candidate in
@@ -1582,12 +1583,10 @@ extension PrivateHeaderGeneration.GenerationExecutor {
     identifier: String,
     catalog: PrivateHeaderGeneration.TargetDiscovery.Catalog
   ) -> [PrivateHeaderGeneration.TargetDiscovery.DiscoveredTarget] {
-    for target in catalog.targets where target.candidate.identifier == identifier {
-      return [target] + target.childTargets
+    for group in catalog.groups where group.selectionCandidate.identifier == identifier {
+      return group.executionTargets
     }
-    return catalog.allTargetsIncludingNestedChildren.filter {
-      $0.candidate.identifier == identifier
-    }
+    return []
   }
 
   fileprivate static func deduplicated(

--- a/Sources/PrivateHeaderKitCore/PrivateHeaderGenerationTargetDiscovery.swift
+++ b/Sources/PrivateHeaderKitCore/PrivateHeaderGenerationTargetDiscovery.swift
@@ -1,4 +1,5 @@
 import Foundation
+import PrivateHeaderKitExecutableResolution
 
 #if canImport(Darwin)
 import Darwin
@@ -18,52 +19,64 @@ extension PrivateHeaderGeneration {
             guard try isDirectory(root, fileManager: fileManager) else {
                 throw Error.missingSystemRoot(root.path)
             }
+            let sharedCacheImages = SharedCacheImageIndex(paths: sharedCacheImagePaths)
 
-            var targets: [DiscoveredTarget] = []
-            targets += try discoverFrameworks(
+            var groups: [DiscoveredTargetGroup] = []
+            groups += try discoverFrameworks(
                 in: root,
                 location: .publicFramework,
                 includeNestedChildren: includeNestedChildren,
+                sharedCacheImages: sharedCacheImages,
                 fileManager: fileManager
             )
-            targets += try discoverFrameworks(
+            groups += try discoverFrameworks(
                 in: root,
                 location: .privateFramework,
                 includeNestedChildren: includeNestedChildren,
+                sharedCacheImages: sharedCacheImages,
                 fileManager: fileManager
             )
-            targets += try discoverSystemLibraryBundles(
+            groups += try discoverSystemLibraryBundles(
                 in: root,
                 includeNestedChildren: includeNestedChildren,
+                sharedCacheImages: sharedCacheImages,
                 fileManager: fileManager
             )
-            targets += try discoverUsrLibDylibs(
+            groups += try discoverUsrLibDylibs(
                 in: root,
                 sharedCacheImagePaths: sharedCacheImagePaths,
                 fileManager: fileManager
             )
 
-            return Catalog(targets: targets)
+            return Catalog(groups: groups)
         }
     }
 }
 
 extension PrivateHeaderGeneration.TargetDiscovery {
     struct Catalog: Hashable, Sendable {
-        let targets: [DiscoveredTarget]
+        let groups: [DiscoveredTargetGroup]
 
         var resolverCandidates: [PrivateHeaderGeneration.TargetCandidate] {
-            targets.map(\.candidate)
+            groups.map(\.selectionCandidate)
         }
 
         var resolver: PrivateHeaderGeneration.TargetResolver {
             PrivateHeaderGeneration.TargetResolver(candidates: resolverCandidates)
         }
 
-        var allTargetsIncludingNestedChildren: [DiscoveredTarget] {
-            targets.flatMap { target in
-                [target] + target.childTargets
-            }
+        var allExecutionTargets: [DiscoveredTarget] {
+            groups.flatMap(\.executionTargets)
+        }
+    }
+
+    struct DiscoveredTargetGroup: Hashable, Sendable {
+        let selectionCandidate: PrivateHeaderGeneration.TargetCandidate
+        let primaryTarget: DiscoveredTarget?
+        let childTargets: [DiscoveredTarget]
+
+        var executionTargets: [DiscoveredTarget] {
+            primaryTarget.map { [$0] + childTargets } ?? childTargets
         }
     }
 
@@ -73,7 +86,6 @@ extension PrivateHeaderGeneration.TargetDiscovery {
         let artifactRoot: PrivateHeaderGeneration.ArtifactPath
         let inputPath: String
         let runtimeInputPath: String
-        let childTargets: [DiscoveredTarget]
     }
 
     enum SourceMetadata: Hashable, Sendable {
@@ -182,13 +194,31 @@ extension PrivateHeaderGeneration.TargetDiscovery {
     }
 }
 
+private struct SharedCacheImageIndex {
+    private let exactPaths: Set<String>
+
+    init(paths: [String]) {
+        self.exactPaths = Set(paths.compactMap(Self.normalizedAbsolutePath))
+    }
+
+    func containsAny(_ candidates: [String]) -> Bool {
+        candidates.contains { exactPaths.contains($0) }
+    }
+
+    private static func normalizedAbsolutePath(_ path: String) -> String? {
+        guard path.hasPrefix("/") else { return nil }
+        return URL(fileURLWithPath: path, isDirectory: false).standardizedFileURL.path
+    }
+}
+
 private extension PrivateHeaderGeneration.TargetDiscovery {
     static func discoverFrameworks(
         in systemRoot: URL,
         location: FrameworkLocation,
         includeNestedChildren: Bool,
+        sharedCacheImages: SharedCacheImageIndex,
         fileManager: FileManager
-    ) throws -> [DiscoveredTarget] {
+    ) throws -> [DiscoveredTargetGroup] {
         let frameworksDirectory = systemRoot
             .appendingPathComponent("System", isDirectory: true)
             .appendingPathComponent("Library", isDirectory: true)
@@ -210,37 +240,42 @@ private extension PrivateHeaderGeneration.TargetDiscovery {
         .map(\.lastPathComponent)
         .sorted()
 
-        return try bundleNames.map { bundleName in
+        return try bundleNames.compactMap { bundleName in
             let source = FrameworkSource(
                 location: location,
                 bundleName: bundleName
             )
             let sourceMetadata = SourceMetadata.framework(source)
-            let artifactRoot = try artifactRoot(
-                systemLibraryRelativePath: source.systemLibraryRelativePath
-            )
+            let bundleURL = frameworksDirectory.appendingPathComponent(bundleName, isDirectory: true)
             let childTargets = try includeNestedChildren ? nestedChildTargets(
                 parentSystemLibraryRelativePath: source.systemLibraryRelativePath,
-                parentURL: frameworksDirectory.appendingPathComponent(bundleName, isDirectory: true),
+                parentURL: bundleURL,
                 systemRoot: systemRoot,
+                sharedCacheImages: sharedCacheImages,
                 fileManager: fileManager
             ) : []
-
-            return DiscoveredTarget(
-                candidate: try PrivateHeaderGeneration.TargetCandidate(
-                    identifier: "\(location.identifierPrefix):\(bundleName)",
-                    displayName: source.frameworkName,
-                    kind: location.targetKind,
-                    aliases: [
-                        bundleName,
-                        source.systemLibraryRelativePath,
-                        "/System/Library/\(source.systemLibraryRelativePath)",
-                    ]
-                ),
+            let selectionCandidate = try PrivateHeaderGeneration.TargetCandidate(
+                identifier: "\(location.identifierPrefix):\(bundleName)",
+                displayName: source.frameworkName,
+                kind: location.targetKind,
+                aliases: [
+                    bundleName,
+                    source.systemLibraryRelativePath,
+                    "/System/Library/\(source.systemLibraryRelativePath)",
+                ]
+            )
+            let primaryTarget = try loadableBundleTarget(
+                candidate: selectionCandidate,
                 source: sourceMetadata,
-                artifactRoot: artifactRoot,
-                inputPath: hostInputPath(for: sourceMetadata, in: systemRoot),
-                runtimeInputPath: sourceMetadata.runtimeInputPath,
+                bundleURL: bundleURL,
+                systemRoot: systemRoot,
+                sharedCacheImages: sharedCacheImages,
+                fileManager: fileManager
+            )
+            guard primaryTarget != nil || !childTargets.isEmpty else { return nil }
+            return DiscoveredTargetGroup(
+                selectionCandidate: selectionCandidate,
+                primaryTarget: primaryTarget,
                 childTargets: childTargets
             )
         }
@@ -249,8 +284,9 @@ private extension PrivateHeaderGeneration.TargetDiscovery {
     static func discoverSystemLibraryBundles(
         in systemRoot: URL,
         includeNestedChildren: Bool,
+        sharedCacheImages: SharedCacheImageIndex,
         fileManager: FileManager
-    ) throws -> [DiscoveredTarget] {
+    ) throws -> [DiscoveredTargetGroup] {
         let systemLibraryDirectory = systemRoot
             .appendingPathComponent("System", isDirectory: true)
             .appendingPathComponent("Library", isDirectory: true)
@@ -285,7 +321,7 @@ private extension PrivateHeaderGeneration.TargetDiscovery {
             )
         }
 
-        var targets: [DiscoveredTarget] = []
+        var groups: [DiscoveredTargetGroup] = []
         while let url = enumerator.nextObject() as? URL {
             let standardizedPath = url.standardizedFileURL.path
             if excludedDirectories.contains(standardizedPath) {
@@ -313,29 +349,32 @@ private extension PrivateHeaderGeneration.TargetDiscovery {
                 bundleKind: bundleKind,
                 role: .topLevel
             )
-            targets.append(
-                try systemLibraryBundleTarget(
-                    source: source,
-                    bundleURL: url,
-                    systemRoot: systemRoot,
-                    includeNestedChildren: includeNestedChildren,
-                    fileManager: fileManager
-                )
-            )
+            if let group = try systemLibraryBundleGroup(
+                source: source,
+                bundleURL: url,
+                systemRoot: systemRoot,
+                includeNestedChildren: includeNestedChildren,
+                sharedCacheImages: sharedCacheImages,
+                fileManager: fileManager
+            ) {
+                groups.append(group)
+            }
             enumerator.skipDescendants()
         }
         if let (url, error) = enumerationFailure {
             throw Error.enumerationFailed(path: url.path, message: String(describing: error))
         }
 
-        return targets.sorted { $0.source.runtimeInputPath < $1.source.runtimeInputPath }
+        return groups.sorted {
+            $0.selectionCandidate.identifier < $1.selectionCandidate.identifier
+        }
     }
 
     static func discoverUsrLibDylibs(
         in systemRoot: URL,
         sharedCacheImagePaths: [String],
         fileManager: FileManager
-    ) throws -> [DiscoveredTarget] {
+    ) throws -> [DiscoveredTargetGroup] {
         let usrLibDirectory = systemRoot
             .appendingPathComponent("usr", isDirectory: true)
             .appendingPathComponent("lib", isDirectory: true)
@@ -377,19 +416,24 @@ private extension PrivateHeaderGeneration.TargetDiscovery {
             let inputPath = filesystemDylibNameSet.contains(name)
                 ? hostInputPath(for: sourceMetadata, in: systemRoot)
                 : sourceMetadata.runtimeInputPath
-            return DiscoveredTarget(
-                candidate: try PrivateHeaderGeneration.TargetCandidate(
-                    identifier: "usr-lib:\(name)",
-                    displayName: name,
-                    kind: .usrLibDylib,
-                    aliases: [
-                        "usr/lib/\(name)",
-                    ]
-                ),
+            let candidate = try PrivateHeaderGeneration.TargetCandidate(
+                identifier: "usr-lib:\(name)",
+                displayName: name,
+                kind: .usrLibDylib,
+                aliases: [
+                    "usr/lib/\(name)",
+                ]
+            )
+            let target = DiscoveredTarget(
+                candidate: candidate,
                 source: sourceMetadata,
                 artifactRoot: try PrivateHeaderGeneration.ArtifactPath("usr/lib/\(name)"),
                 inputPath: inputPath,
-                runtimeInputPath: sourceMetadata.runtimeInputPath,
+                runtimeInputPath: sourceMetadata.runtimeInputPath
+            )
+            return DiscoveredTargetGroup(
+                selectionCandidate: candidate,
+                primaryTarget: target,
                 childTargets: []
             )
         }
@@ -399,6 +443,7 @@ private extension PrivateHeaderGeneration.TargetDiscovery {
         parentSystemLibraryRelativePath: String,
         parentURL: URL,
         systemRoot: URL,
+        sharedCacheImages: SharedCacheImageIndex,
         fileManager: FileManager
     ) throws -> [DiscoveredTarget] {
         guard try isDirectory(parentURL, fileManager: fileManager) else {
@@ -437,59 +482,157 @@ private extension PrivateHeaderGeneration.TargetDiscovery {
                     bundleKind: container.bundleKind,
                     role: .nestedChild(parentRelativePath: parentSystemLibraryRelativePath)
                 )
-                targets.append(
-                    try systemLibraryBundleTarget(
-                        source: source,
-                        bundleURL: entry,
-                        systemRoot: systemRoot,
-                        includeNestedChildren: false,
-                        fileManager: fileManager
-                    )
-                )
+                let candidate = try systemLibraryCandidate(for: source)
+                if let target = try loadableBundleTarget(
+                    candidate: candidate,
+                    source: .systemLibraryBundle(source),
+                    bundleURL: entry,
+                    systemRoot: systemRoot,
+                    sharedCacheImages: sharedCacheImages,
+                    fileManager: fileManager
+                ) {
+                    targets.append(target)
+                }
             }
         }
 
         return targets.sorted { $0.source.runtimeInputPath < $1.source.runtimeInputPath }
     }
 
-    static func systemLibraryBundleTarget(
+    static func systemLibraryBundleGroup(
         source: SystemLibraryBundleSource,
         bundleURL: URL,
         systemRoot: URL,
         includeNestedChildren: Bool,
+        sharedCacheImages: SharedCacheImageIndex,
         fileManager: FileManager
-    ) throws -> DiscoveredTarget {
-        let kind: PrivateHeaderGeneration.TargetKind
-        switch source.role {
-        case .topLevel:
-            kind = .systemBundle
-        case .nestedChild:
-            kind = .nestedBundle
-        }
-
+    ) throws -> DiscoveredTargetGroup? {
         let childTargets = try includeNestedChildren ? nestedChildTargets(
             parentSystemLibraryRelativePath: source.relativePath,
             parentURL: bundleURL,
             systemRoot: systemRoot,
+            sharedCacheImages: sharedCacheImages,
             fileManager: fileManager
         ) : []
         let sourceMetadata = SourceMetadata.systemLibraryBundle(source)
-
-        return DiscoveredTarget(
-            candidate: try PrivateHeaderGeneration.TargetCandidate(
-                identifier: systemLibraryIdentifier(for: source),
-                displayName: source.relativePath,
-                kind: kind,
-                aliases: [
-                    "/System/Library/\(source.relativePath)",
-                ]
-            ),
+        let selectionCandidate = try systemLibraryCandidate(for: source)
+        let primaryTarget = try loadableBundleTarget(
+            candidate: selectionCandidate,
             source: sourceMetadata,
-            artifactRoot: try artifactRoot(systemLibraryRelativePath: source.relativePath),
-            inputPath: hostInputPath(for: sourceMetadata, in: systemRoot),
-            runtimeInputPath: sourceMetadata.runtimeInputPath,
+            bundleURL: bundleURL,
+            systemRoot: systemRoot,
+            sharedCacheImages: sharedCacheImages,
+            fileManager: fileManager
+        )
+        guard primaryTarget != nil || !childTargets.isEmpty else { return nil }
+        return DiscoveredTargetGroup(
+            selectionCandidate: selectionCandidate,
+            primaryTarget: primaryTarget,
             childTargets: childTargets
         )
+    }
+
+    static func systemLibraryCandidate(
+        for source: SystemLibraryBundleSource
+    ) throws -> PrivateHeaderGeneration.TargetCandidate {
+        let kind: PrivateHeaderGeneration.TargetKind = switch source.role {
+        case .topLevel: .systemBundle
+        case .nestedChild: .nestedBundle
+        }
+        return try PrivateHeaderGeneration.TargetCandidate(
+            identifier: systemLibraryIdentifier(for: source),
+            displayName: source.relativePath,
+            kind: kind,
+            aliases: [
+                "/System/Library/\(source.relativePath)",
+            ]
+        )
+    }
+
+    static func loadableBundleTarget(
+        candidate: PrivateHeaderGeneration.TargetCandidate,
+        source: SourceMetadata,
+        bundleURL: URL,
+        systemRoot: URL,
+        sharedCacheImages: SharedCacheImageIndex,
+        fileManager: FileManager
+    ) throws -> DiscoveredTarget? {
+        guard
+            let executableURL = selectedBundleExecutableURL(
+                bundleURL: bundleURL,
+                fileManager: fileManager
+            ),
+            safeExecutableName(executableURL.lastPathComponent) != nil
+        else {
+            return nil
+        }
+        let hasDiskExecutable = try isRegularFileOrSymlinkToRegularFile(
+            executableURL,
+            fileManager: fileManager
+        )
+        let hasSharedCacheExecutable = sharedCacheImages.containsAny(
+            ExecutableResolution.normalizedCacheImagePaths(
+                for: executableURL.path,
+                environment: ["PH_RUNTIME_ROOT": systemRoot.path]
+            )
+        )
+        guard hasDiskExecutable || hasSharedCacheExecutable else {
+            return nil
+        }
+        guard let systemLibraryRelativePath = bundleSystemLibraryRelativePath(for: source) else {
+            return nil
+        }
+        return DiscoveredTarget(
+            candidate: candidate,
+            source: source,
+            artifactRoot: try artifactRoot(systemLibraryRelativePath: systemLibraryRelativePath),
+            inputPath: hostInputPath(for: source, in: systemRoot),
+            runtimeInputPath: source.runtimeInputPath
+        )
+    }
+
+    static func bundleSystemLibraryRelativePath(for source: SourceMetadata) -> String? {
+        switch source {
+        case .framework(let framework): framework.systemLibraryRelativePath
+        case .systemLibraryBundle(let bundle): bundle.relativePath
+        case .usrLibDylib: nil
+        }
+    }
+
+    static func selectedBundleExecutableURL(
+        bundleURL: URL,
+        fileManager: FileManager
+    ) -> URL? {
+        ExecutableResolution.resolveBundleExecutableURL(
+            bundleURL,
+            fileExists: fileManager.fileExists(atPath:)
+        )
+    }
+
+    static func isRegularFileOrSymlinkToRegularFile(
+        _ url: URL,
+        fileManager: FileManager
+    ) throws -> Bool {
+        let attributes: [FileAttributeKey: Any]
+        do {
+            attributes = try fileManager.attributesOfItem(atPath: url.path)
+        } catch where isMissingFileError(error) {
+            return false
+        }
+        let type = attributes[.type] as? FileAttributeType
+        if type == .typeRegular {
+            return true
+        }
+        guard type == .typeSymbolicLink else {
+            return false
+        }
+        let resolvedURL = url.resolvingSymlinksInPath().standardizedFileURL
+        do {
+            let resolvedAttributes = try fileManager.attributesOfItem(atPath: resolvedURL.path)
+            return resolvedAttributes[.type] as? FileAttributeType == .typeRegular
+        } catch where isMissingFileError(error) {
+            return false
+        }
     }
 
     static var nestedBundleContainers: [(directoryName: String, bundleKind: BundleKind)] {
@@ -636,6 +779,19 @@ private extension PrivateHeaderGeneration.TargetDiscovery {
         }
         return false
     }
+}
+
+private func safeExecutableName(_ value: String) -> String? {
+    guard
+        !value.isEmpty,
+        value != ".",
+        value != "..",
+        !value.contains("/"),
+        !value.contains("\0")
+    else {
+        return nil
+    }
+    return value
 }
 
 private extension String {

--- a/Sources/PrivateHeaderKitExecutableResolution/PrivateHeaderKitExecutableResolution.swift
+++ b/Sources/PrivateHeaderKitExecutableResolution/PrivateHeaderKitExecutableResolution.swift
@@ -74,9 +74,15 @@ package enum ExecutableResolution {
             else {
                 continue
             }
+            let frameworkRelativePath = basePath[frameworkRange.upperBound...]
+            guard
+                !frameworkRelativePath.isEmpty,
+                !frameworkRelativePath.contains("/")
+            else {
+                continue
+            }
             let frameworkPrefix = String(basePath[..<frameworkRange.upperBound])
-            let imageName = URL(fileURLWithPath: basePath).lastPathComponent
-            guard !imageName.isEmpty else { continue }
+            let imageName = String(frameworkRelativePath)
             results.append(frameworkPrefix + "Versions/Current/" + imageName)
             results.append(frameworkPrefix + "Versions/A/" + imageName)
             results.append(frameworkPrefix + "Versions/B/" + imageName)

--- a/Sources/PrivateHeaderKitExecutableResolution/PrivateHeaderKitExecutableResolution.swift
+++ b/Sources/PrivateHeaderKitExecutableResolution/PrivateHeaderKitExecutableResolution.swift
@@ -1,0 +1,92 @@
+import Foundation
+
+package enum ExecutableResolution {
+    package static func resolveBundleExecutableURL(
+        _ bundleURL: URL,
+        fileExists: (String) -> Bool = { FileManager.default.fileExists(atPath: $0) },
+        bundleExecutableURL: (URL) -> URL? = { Bundle(url: $0)?.executableURL }
+    ) -> URL? {
+        if let executableURL = bundleExecutableURL(bundleURL) {
+            let bundleName = bundleURL.lastPathComponent
+            let components = executableURL.pathComponents
+            if let bundleIndex = components.lastIndex(of: bundleName),
+               bundleIndex + 1 < components.count
+            {
+                let suffixComponents = components[(bundleIndex + 1)...]
+                var rebased = bundleURL
+                for component in suffixComponents {
+                    rebased.appendPathComponent(component)
+                }
+                if fileExists(rebased.path) {
+                    return rebased
+                }
+            }
+            return executableURL
+        }
+
+        let baseName = bundleURL.deletingPathExtension().lastPathComponent
+        let candidates = [
+            bundleURL.appendingPathComponent(baseName),
+            bundleURL.appendingPathComponent("Versions/Current/\(baseName)"),
+            bundleURL.appendingPathComponent("Versions/A/\(baseName)"),
+            bundleURL.appendingPathComponent("Versions/B/\(baseName)"),
+            bundleURL.appendingPathComponent("Versions/C/\(baseName)"),
+        ]
+        for candidate in candidates where fileExists(candidate.path) {
+            return candidate
+        }
+        return bundleURL.appendingPathComponent(baseName)
+    }
+
+    package static func normalizedCacheImagePaths(
+        for path: String,
+        environment: [String: String]
+    ) -> [String] {
+        var basePaths: [String] = [path]
+
+        let rootCandidates = [
+            environment["PH_RUNTIME_ROOT"],
+            environment["DYLD_ROOT_PATH"],
+            environment["SIMCTL_CHILD_DYLD_ROOT_PATH"],
+        ].compactMap { $0 }
+
+        for runtimeRoot in rootCandidates {
+            let trimmedRoot = runtimeRoot.hasSuffix("/") ? String(runtimeRoot.dropLast()) : runtimeRoot
+            if path.hasPrefix(trimmedRoot + "/") {
+                let suffix = String(path.dropFirst(trimmedRoot.count))
+                if !suffix.isEmpty {
+                    basePaths.append(suffix)
+                }
+            }
+        }
+
+        if let range = path.range(of: "/System/Library/") {
+            basePaths.append(String(path[range.lowerBound...]))
+        }
+        if let range = path.range(of: "/usr/lib/") {
+            basePaths.append(String(path[range.lowerBound...]))
+        }
+
+        var results = basePaths
+        for basePath in basePaths {
+            guard let frameworkRange = basePath.range(of: ".framework/"),
+                  !basePath.contains(".framework/Versions/")
+            else {
+                continue
+            }
+            let frameworkPrefix = String(basePath[..<frameworkRange.upperBound])
+            let imageName = URL(fileURLWithPath: basePath).lastPathComponent
+            guard !imageName.isEmpty else { continue }
+            results.append(frameworkPrefix + "Versions/Current/" + imageName)
+            results.append(frameworkPrefix + "Versions/A/" + imageName)
+            results.append(frameworkPrefix + "Versions/B/" + imageName)
+            results.append(frameworkPrefix + "Versions/C/" + imageName)
+        }
+
+        var unique: [String] = []
+        for item in results where !unique.contains(item) {
+            unique.append(item)
+        }
+        return unique
+    }
+}

--- a/Sources/PrivateHeaderKitExecutableResolution/PrivateHeaderKitExecutableResolution.swift
+++ b/Sources/PrivateHeaderKitExecutableResolution/PrivateHeaderKitExecutableResolution.swift
@@ -7,6 +7,9 @@ package enum ExecutableResolution {
         bundleExecutableURL: (URL) -> URL? = { Bundle(url: $0)?.executableURL }
     ) -> URL? {
         if let executableURL = bundleExecutableURL(bundleURL) {
+            // `Bundle(url:)` may resolve symlinks, returning an executable inside the real path
+            // (e.g. `/System/Cryptexes/OS/...`). Prefer rebasing back onto the original bundle URL
+            // so output paths remain stable under `/System/Library/...` when possible.
             let bundleName = bundleURL.lastPathComponent
             let components = executableURL.pathComponents
             if let bundleIndex = components.lastIndex(of: bundleName),
@@ -35,6 +38,10 @@ package enum ExecutableResolution {
         for candidate in candidates where fileExists(candidate.path) {
             return candidate
         }
+
+        // Some system bundles (especially on modern macOS) only expose a dyld shared-cache image
+        // path while the on-disk executable symlink is intentionally absent/broken. Return the
+        // canonical in-bundle executable path so shared-cache lookup can still resolve the image.
         return bundleURL.appendingPathComponent(baseName)
     }
 
@@ -69,6 +76,9 @@ package enum ExecutableResolution {
 
         var results = basePaths
         for basePath in basePaths {
+            // Shared-cache framework identities are commonly versioned even when the
+            // filesystem-facing source path uses the unversioned bundle symlink. Restrict these
+            // aliases to direct framework images so a nested child cannot match its parent's image.
             guard let frameworkRange = basePath.range(of: ".framework/"),
                   !basePath.contains(".framework/Versions/")
             else {

--- a/Sources/PrivateHeaderKitRawDumpCore/PrivateHeaderKitRawDumpMain.swift
+++ b/Sources/PrivateHeaderKitRawDumpCore/PrivateHeaderKitRawDumpMain.swift
@@ -4,6 +4,7 @@ import MachOKit
 import MachOObjCSection
 import MachOSwiftSection
 import ObjCDump
+import PrivateHeaderKitExecutableResolution
 import PrivateHeaderKitHelperProtocol
 import SwiftDeclaration
 import SwiftDeclarationRendering
@@ -402,43 +403,11 @@ func resolveBundleExecutableURL(
     fileManager: FileExistenceChecking = FileManager.default,
     bundleExecutableURL: (URL) -> URL? = { Bundle(url: $0)?.executableURL }
 ) -> URL? {
-    if let executableURL = bundleExecutableURL(bundleURL) {
-        // `Bundle(url:)` may resolve symlinks, returning an executable inside the real path
-        // (e.g. `/System/Cryptexes/OS/...`). Prefer rebasing back onto the original bundle URL
-        // so output paths remain stable under `/System/Library/...` when possible.
-        let bundleName = bundleURL.lastPathComponent
-        let components = executableURL.pathComponents
-        if let bundleIndex = components.lastIndex(of: bundleName), bundleIndex + 1 < components.count {
-            let suffixComponents = components[(bundleIndex + 1)...]
-            var rebased = bundleURL
-            for component in suffixComponents {
-                rebased.appendPathComponent(component)
-            }
-            if fileManager.fileExists(atPath: rebased.path) {
-                return rebased
-            }
-        }
-        return executableURL
-    }
-
-    let baseName = bundleURL.deletingPathExtension().lastPathComponent
-    let candidates = [
-        bundleURL.appendingPathComponent(baseName),
-        bundleURL.appendingPathComponent("Versions/Current/\(baseName)"),
-        bundleURL.appendingPathComponent("Versions/A/\(baseName)"),
-        bundleURL.appendingPathComponent("Versions/B/\(baseName)"),
-        bundleURL.appendingPathComponent("Versions/C/\(baseName)")
-    ]
-    for candidate in candidates {
-        if fileManager.fileExists(atPath: candidate.path) {
-            return candidate
-        }
-    }
-
-    // Some system bundles (especially on modern macOS) only expose a dyld shared-cache image path
-    // while the on-disk executable symlink is intentionally absent/broken. Return the canonical
-    // in-bundle executable path so shared-cache lookup can still resolve the image.
-    return bundleURL.appendingPathComponent(baseName)
+    ExecutableResolution.resolveBundleExecutableURL(
+        bundleURL,
+        fileExists: fileManager.fileExists(atPath:),
+        bundleExecutableURL: bundleExecutableURL
+    )
 }
 
 private func dumpImage(
@@ -608,52 +577,10 @@ func normalizedCacheImagePaths(
     for path: String,
     environment: [String: String] = ProcessInfo.processInfo.environment
 ) -> [String] {
-    var basePaths: [String] = [path]
-
-    let rootCandidates = [
-        environment["PH_RUNTIME_ROOT"],
-        environment["DYLD_ROOT_PATH"],
-        environment["SIMCTL_CHILD_DYLD_ROOT_PATH"]
-    ].compactMap { $0 }
-
-    for runtimeRoot in rootCandidates {
-        let trimmedRoot = runtimeRoot.hasSuffix("/") ? String(runtimeRoot.dropLast()) : runtimeRoot
-        if path.hasPrefix(trimmedRoot + "/") {
-            let suffix = String(path.dropFirst(trimmedRoot.count))
-            if !suffix.isEmpty {
-                basePaths.append(suffix)
-            }
-        }
-    }
-
-    if let range = path.range(of: "/System/Library/") {
-        basePaths.append(String(path[range.lowerBound...]))
-    }
-    if let range = path.range(of: "/usr/lib/") {
-        basePaths.append(String(path[range.lowerBound...]))
-    }
-
-    var results = basePaths
-    for basePath in basePaths {
-        // Shared-cache framework identities are commonly versioned even when the
-        // filesystem-facing source path uses the unversioned bundle symlink.
-        guard let frameworkRange = basePath.range(of: ".framework/"),
-              !basePath.contains(".framework/Versions/")
-        else { continue }
-        let frameworkPrefix = String(basePath[..<frameworkRange.upperBound])
-        let imageName = URL(fileURLWithPath: basePath).lastPathComponent
-        guard !imageName.isEmpty else { continue }
-        results.append(frameworkPrefix + "Versions/Current/" + imageName)
-        results.append(frameworkPrefix + "Versions/A/" + imageName)
-        results.append(frameworkPrefix + "Versions/B/" + imageName)
-        results.append(frameworkPrefix + "Versions/C/" + imageName)
-    }
-
-    var unique: [String] = []
-    for item in results where !unique.contains(item) {
-        unique.append(item)
-    }
-    return unique
+    ExecutableResolution.normalizedCacheImagePaths(
+        for: path,
+        environment: environment
+    )
 }
 
 func writeDirectory(for imagePath: String, outputRoot: URL, options: DumpOptions) -> URL {

--- a/Tests/PrivateHeaderKitCLITests/PrivateHeaderKitCLITests.swift
+++ b/Tests/PrivateHeaderKitCLITests/PrivateHeaderKitCLITests.swift
@@ -2333,13 +2333,15 @@ private func assertInteractiveLegacyMigration(kind: LegacyInputKind) async throw
     let root = try temporaryDirectory()
     defer { try? FileManager.default.removeItem(at: root) }
     let systemRoot = root.appendingPathComponent("SystemRoot", isDirectory: true)
+    let frameworkURL = systemRoot.appendingPathComponent(
+        "System/Library/Frameworks/Foo.framework",
+        isDirectory: true
+    )
     try FileManager.default.createDirectory(
-        at: systemRoot.appendingPathComponent(
-            "System/Library/Frameworks/Foo.framework",
-            isDirectory: true
-        ),
+        at: frameworkURL,
         withIntermediateDirectories: true
     )
+    try Data().write(to: frameworkURL.appendingPathComponent("Foo", isDirectory: false))
     let outputBase = root.appendingPathComponent("Output", isDirectory: true)
     let detectedURL: URL
     switch kind {
@@ -2463,13 +2465,15 @@ private func unfinishedResumeSummaryFixture() async throws
     let root = try temporaryDirectory()
     defer { try? FileManager.default.removeItem(at: root) }
     let systemRoot = root.appendingPathComponent("RuntimeRoot", isDirectory: true)
+    let frameworkURL = systemRoot.appendingPathComponent(
+        "System/Library/Frameworks/Foo.framework",
+        isDirectory: true
+    )
     try FileManager.default.createDirectory(
-        at: systemRoot.appendingPathComponent(
-            "System/Library/Frameworks/Foo.framework",
-            isDirectory: true
-        ),
+        at: frameworkURL,
         withIntermediateDirectories: true
     )
+    try Data().write(to: frameworkURL.appendingPathComponent("Foo", isDirectory: false))
     let source = try PrivateHeaderGeneration.Source(
         platform: .macOS,
         version: "16.0"

--- a/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationExecutorTests.swift
+++ b/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationExecutorTests.swift
@@ -2058,6 +2058,71 @@ struct PrivateHeaderGenerationExecutorTests {
     }
   }
 
+  @Test func parentShellQueryRunsEligibleNestedChildrenOnly() async throws {
+    let fixture = try ExecutorFixture()
+    defer { fixture.cleanup() }
+    try fixture.createResourceOnlyFramework(
+      "Shell.framework",
+      nestedBundle: "XPCServices/LiveService.xpc"
+    )
+    let runner = RecordingRunner(contents: "nested")
+
+    let result = try await fixture.executor(
+      runner: runner,
+      runID: "run-shell-child",
+      generationID: "generation-shell-child"
+    ).run(plan: try fixture.plan(.query("Shell")))
+
+    #expect(await runner.invocationCount == 1)
+    #expect(result.generatedTargets.map(\.identifier) == [
+      "nested-bundle:Frameworks/Shell.framework/XPCServices/LiveService.xpc"
+    ])
+    let invocations = await runner.invocations
+    let invocation = try #require(invocations.first)
+    #expect(invocation.inputPath.hasSuffix("/Shell.framework/XPCServices/LiveService.xpc"))
+  }
+
+  @Test func selectionOnlyParentIdentifierIsNotAnExecutionTarget() async throws {
+    let fixture = try ExecutorFixture()
+    defer { fixture.cleanup() }
+    try fixture.createResourceOnlyFramework(
+      "Shell.framework",
+      nestedBundle: "XPCServices/LiveService.xpc"
+    )
+
+    await #expect(
+      throws: PrivateHeaderGeneration.GenerationError.unknownSelectedTargets([
+        "framework:Shell.framework"
+      ])
+    ) {
+      _ = try await fixture.executor(
+        runner: RecordingRunner(contents: "unused"),
+        runID: "run-parent-identifier",
+        generationID: "generation-parent-identifier"
+      ).run(plan: try fixture.plan(.identifiers(["framework:Shell.framework"])))
+    }
+  }
+
+  @Test func exactNestedIdentifierRunsOnlyThatExecutionTarget() async throws {
+    let fixture = try ExecutorFixture()
+    defer { fixture.cleanup() }
+    try fixture.createResourceOnlyFramework(
+      "Shell.framework",
+      nestedBundle: "XPCServices/LiveService.xpc"
+    )
+    let childID = "nested-bundle:Frameworks/Shell.framework/XPCServices/LiveService.xpc"
+    let runner = RecordingRunner(contents: "nested")
+
+    let result = try await fixture.executor(
+      runner: runner,
+      runID: "run-child-identifier",
+      generationID: "generation-child-identifier"
+    ).run(plan: try fixture.plan(.identifiers([childID])))
+
+    #expect(await runner.invocationCount == 1)
+    #expect(result.generatedTargets.map(\.identifier) == [childID])
+  }
+
   @Test func committedRunStaysSuccessfulWhenCleanupAndWarningPersistenceFail() async throws {
     let fixture = try ExecutorFixture()
     defer {
@@ -2365,19 +2430,50 @@ private struct ExecutorFixture {
   }
 
   func createFramework(_ name: String) throws {
+    let bundleURL = systemRoot.appendingPathComponent(
+      "System/Library/Frameworks/\(name)",
+      isDirectory: true
+    )
     try FileManager.default.createDirectory(
-      at: systemRoot.appendingPathComponent("System/Library/Frameworks/\(name)", isDirectory: true),
+      at: bundleURL,
       withIntermediateDirectories: true
     )
+    let executableName = bundleURL.deletingPathExtension().lastPathComponent
+    try Data().write(to: bundleURL.appendingPathComponent(executableName, isDirectory: false))
   }
 
   func createSystemBundle(_ relativePath: String) throws {
+    let bundleURL = systemRoot.appendingPathComponent(
+      "System/Library/\(relativePath)",
+      isDirectory: true
+    )
     try FileManager.default.createDirectory(
-      at: systemRoot.appendingPathComponent(
-        "System/Library/\(relativePath)",
-        isDirectory: true
-      ),
+      at: bundleURL,
       withIntermediateDirectories: true
+    )
+    let executableName = bundleURL.deletingPathExtension().lastPathComponent
+    try Data().write(to: bundleURL.appendingPathComponent(executableName, isDirectory: false))
+  }
+
+  func createResourceOnlyFramework(
+    _ name: String,
+    nestedBundle relativeNestedBundlePath: String
+  ) throws {
+    let frameworkURL = systemRoot.appendingPathComponent(
+      "System/Library/Frameworks/\(name)",
+      isDirectory: true
+    )
+    let nestedBundleURL = frameworkURL.appendingPathComponent(
+      relativeNestedBundlePath,
+      isDirectory: true
+    )
+    try FileManager.default.createDirectory(
+      at: nestedBundleURL,
+      withIntermediateDirectories: true
+    )
+    let executableName = nestedBundleURL.deletingPathExtension().lastPathComponent
+    try Data().write(
+      to: nestedBundleURL.appendingPathComponent(executableName, isDirectory: false)
     )
   }
 

--- a/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationTargetDiscoveryTests.swift
+++ b/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationTargetDiscoveryTests.swift
@@ -216,6 +216,29 @@ struct PrivateHeaderGenerationTargetDiscoveryTests {
         ])
     }
 
+    @Test func parentCacheImageDoesNotAdmitSameNamedResourceOnlyChild() throws {
+        let root = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let parent = "System/Library/Frameworks/Foo.framework"
+        try createDirectory(parent + "/XPCServices/Foo.xpc", in: root)
+
+        let catalog = try PrivateHeaderGeneration.TargetDiscovery.discover(
+            in: root,
+            sharedCacheImagePaths: [
+                "/System/Library/Frameworks/Foo.framework/Versions/A/Foo"
+            ]
+        )
+        let group = try #require(catalog.groups.first)
+
+        #expect(group.selectionCandidate.displayName == "Foo")
+        #expect(group.primaryTarget?.candidate.identifier == "framework:Foo.framework")
+        #expect(group.childTargets.isEmpty)
+        #expect(catalog.allExecutionTargets.map(\.candidate.identifier) == [
+            "framework:Foo.framework"
+        ])
+    }
+
     @Test func loadableNestedChildSurvivesResourceOnlyParent() throws {
         let root = try makeTemporaryDirectory()
         defer { try? FileManager.default.removeItem(at: root) }

--- a/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationTargetDiscoveryTests.swift
+++ b/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationTargetDiscoveryTests.swift
@@ -11,13 +11,13 @@ struct PrivateHeaderGenerationTargetDiscoveryTests {
             try? FileManager.default.removeItem(at: root)
         }
 
-        try createDirectory("System/Library/Frameworks/UIKit.framework", in: root)
-        try createDirectory("System/Library/Frameworks/AVFoundation.framework", in: root)
-        try createDirectory("System/Library/PrivateFrameworks/SafariShared.framework", in: root)
+        try createLoadableBundle("System/Library/Frameworks/UIKit.framework", in: root)
+        try createLoadableBundle("System/Library/Frameworks/AVFoundation.framework", in: root)
+        try createLoadableBundle("System/Library/PrivateFrameworks/SafariShared.framework", in: root)
         try writeFile("System/Library/Frameworks/NotAFramework.framework", in: root)
         try writeFile("System/Library/PrivateFrameworks/NotPrivateFramework.framework", in: root)
-        try createDirectory("System/Library/CoreServices/ControlCenter.app", in: root)
-        try createDirectory("System/Library/PreferenceBundles/Foo.bundle", in: root)
+        try createLoadableBundle("System/Library/CoreServices/ControlCenter.app", in: root)
+        try createLoadableBundle("System/Library/PreferenceBundles/Foo.bundle", in: root)
         try createDirectory("System/Library/Frameworks/Ignored.bundle", in: root)
         try writeFile("usr/lib/libobjc.A.dylib", in: root)
         try writeFile("usr/lib/libswiftCore.tbd", in: root)
@@ -28,7 +28,7 @@ struct PrivateHeaderGenerationTargetDiscoveryTests {
 
         let catalog = try PrivateHeaderGeneration.TargetDiscovery.discover(in: root)
 
-        #expect(catalog.targets.map(\.candidate.displayName) == [
+        #expect(catalog.groups.map(\.selectionCandidate.displayName) == [
             "AVFoundation",
             "UIKit",
             "SafariShared",
@@ -37,7 +37,7 @@ struct PrivateHeaderGenerationTargetDiscoveryTests {
             "libobjc.A.dylib",
             "libswiftCore.dylib",
         ])
-        #expect(catalog.targets.map(\.candidate.kind) == [
+        #expect(catalog.groups.map(\.selectionCandidate.kind) == [
             .framework,
             .framework,
             .privateFramework,
@@ -46,7 +46,7 @@ struct PrivateHeaderGenerationTargetDiscoveryTests {
             .usrLibDylib,
             .usrLibDylib,
         ])
-        #expect(catalog.targets.map(\.artifactRoot.rawValue) == [
+        #expect(catalog.groups.compactMap(\.primaryTarget?.artifactRoot.rawValue) == [
             "Frameworks/AVFoundation",
             "Frameworks/UIKit",
             "PrivateFrameworks/SafariShared",
@@ -55,7 +55,7 @@ struct PrivateHeaderGenerationTargetDiscoveryTests {
             "usr/lib/libobjc.A.dylib",
             "usr/lib/libswiftCore.dylib",
         ])
-        #expect(catalog.targets.map(\.inputPath) == [
+        #expect(catalog.groups.compactMap(\.primaryTarget?.inputPath) == [
             root.appendingPathComponent("System/Library/Frameworks/AVFoundation.framework").path,
             root.appendingPathComponent("System/Library/Frameworks/UIKit.framework").path,
             root.appendingPathComponent("System/Library/PrivateFrameworks/SafariShared.framework").path,
@@ -64,7 +64,7 @@ struct PrivateHeaderGenerationTargetDiscoveryTests {
             root.appendingPathComponent("usr/lib/libobjc.A.dylib").path,
             root.appendingPathComponent("usr/lib/libswiftCore.dylib").path,
         ])
-        #expect(catalog.targets.map(\.runtimeInputPath) == [
+        #expect(catalog.groups.compactMap(\.primaryTarget?.runtimeInputPath) == [
             "/System/Library/Frameworks/AVFoundation.framework",
             "/System/Library/Frameworks/UIKit.framework",
             "/System/Library/PrivateFrameworks/SafariShared.framework",
@@ -75,22 +75,260 @@ struct PrivateHeaderGenerationTargetDiscoveryTests {
         ])
     }
 
+    @Test func diskBackedFrameworkAndSystemBundlesRemainDiscoverable() throws {
+        let root = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        try createLoadableBundle("System/Library/Frameworks/Disk.framework", in: root)
+        try createLoadableBundle("System/Library/CoreServices/Disk.app", in: root)
+        try createLoadableBundle("System/Library/PreferenceBundles/Disk.bundle", in: root)
+
+        let catalog = try PrivateHeaderGeneration.TargetDiscovery.discover(in: root)
+
+        #expect(catalog.groups.map(\.selectionCandidate.displayName) == [
+            "Disk",
+            "CoreServices/Disk.app",
+            "PreferenceBundles/Disk.bundle",
+        ])
+        #expect(catalog.allExecutionTargets.count == 3)
+    }
+
+    @Test func customCFBundleExecutableOnlyAppliesWhenBundleResolvesIt() throws {
+        let root = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let diskPath = "System/Library/Frameworks/CustomDisk.framework"
+        try createDirectory(diskPath, in: root)
+        try writeBundleInfo(diskPath, executableName: "ActualExecutable", in: root)
+        try writeFile(diskPath + "/ActualExecutable", in: root)
+
+        let admitted = try PrivateHeaderGeneration.TargetDiscovery.discover(in: root)
+        #expect(admitted.groups.map(\.selectionCandidate.displayName) == ["CustomDisk"])
+
+        let cacheOnlyPath = "System/Library/Frameworks/CustomCacheOnly.framework"
+        try createDirectory(cacheOnlyPath, in: root)
+        try writeBundleInfo(cacheOnlyPath, executableName: "ActualExecutable", in: root)
+        let cacheOnly = try PrivateHeaderGeneration.TargetDiscovery.discover(
+            in: root,
+            sharedCacheImagePaths: [
+                "/System/Library/Frameworks/CustomCacheOnly.framework/ActualExecutable"
+            ]
+        )
+        #expect(cacheOnly.groups.map(\.selectionCandidate.displayName) == ["CustomDisk"])
+
+        let fallbackPath = "System/Library/Frameworks/CustomFallback.framework"
+        try createDirectory(fallbackPath, in: root)
+        try writeBundleInfo(fallbackPath, executableName: "ActualExecutable", in: root)
+        try writeFile(fallbackPath + "/CustomFallback", in: root)
+        let basenameFallback = try PrivateHeaderGeneration.TargetDiscovery.discover(in: root)
+        #expect(basenameFallback.groups.map(\.selectionCandidate.displayName) == [
+            "CustomDisk", "CustomFallback",
+        ])
+    }
+
+    @Test func cacheOnlyFrameworksAcceptOnlyHelperGeneratedVersionAliases() throws {
+        let root = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        for name in ["Flat", "Versioned", "Future"] {
+            try createDirectory("System/Library/Frameworks/\(name).framework", in: root)
+        }
+
+        let catalog = try PrivateHeaderGeneration.TargetDiscovery.discover(
+            in: root,
+            sharedCacheImagePaths: [
+                "/System/Library/Frameworks/Flat.framework/Flat",
+                "/System/Library/Frameworks/Versioned.framework/Versions/A/Versioned",
+                "/System/Library/Frameworks/Future.framework/Versions/Z9/Future",
+            ]
+        )
+
+        #expect(catalog.groups.map(\.selectionCandidate.displayName) == ["Flat", "Versioned"])
+        #expect(!catalog.groups.contains { $0.selectionCandidate.displayName == "Future" })
+        #expect(catalog.groups.allSatisfy { $0.primaryTarget != nil })
+        #expect(catalog.groups.map { $0.primaryTarget?.runtimeInputPath } == [
+            "/System/Library/Frameworks/Flat.framework",
+            "/System/Library/Frameworks/Versioned.framework",
+        ])
+    }
+
+    @Test func resourceOnlyPublicAndPrivateFrameworksAreExcluded() throws {
+        let root = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        try writeFile(
+            "System/Library/Frameworks/PublicShell.framework/en.lproj/Localizable.strings",
+            in: root
+        )
+        try writeFile(
+            "System/Library/PrivateFrameworks/PrivateShell.framework/Info.plist",
+            in: root
+        )
+
+        let catalog = try PrivateHeaderGeneration.TargetDiscovery.discover(
+            in: root,
+            sharedCacheImagePaths: [
+                "/System/Library/Frameworks/PublicShellExtra.framework/PublicShell",
+                "/System/Library/Frameworks/PublicShell.framework/Versions/A/Helpers/PublicShell",
+                "/System/Library/PrivateFrameworks/Other.framework/PrivateShell",
+            ]
+        )
+
+        #expect(catalog.groups.isEmpty)
+        #expect(catalog.allExecutionTargets.isEmpty)
+    }
+
+    @Test func resourceOnlyTopLevelAppsAndBundlesAreExcluded() throws {
+        let root = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        try writeFile("System/Library/CoreServices/Shell.app/Resources/data", in: root)
+        try writeFile("System/Library/PreferenceBundles/Shell.bundle/Resources/data", in: root)
+        try createLoadableBundle("System/Library/CoreServices/Live.app", in: root)
+        try createLoadableBundle("System/Library/PreferenceBundles/Live.bundle", in: root)
+
+        let catalog = try PrivateHeaderGeneration.TargetDiscovery.discover(in: root)
+
+        #expect(catalog.groups.map(\.selectionCandidate.displayName) == [
+            "CoreServices/Live.app",
+            "PreferenceBundles/Live.bundle",
+        ])
+    }
+
+    @Test func resourceOnlyNestedExtensionsAndServicesAreExcluded() throws {
+        let root = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let parent = "System/Library/Frameworks/Parent.framework"
+        try createLoadableBundle(parent, in: root)
+        try createLoadableBundle(parent + "/PlugIns/LiveExtension.appex", in: root)
+        try createLoadableBundle(parent + "/XPCServices/LiveService.xpc", in: root)
+        try writeFile(parent + "/PlugIns/ShellExtension.appex/Resources/data", in: root)
+        try writeFile(parent + "/XPCServices/ShellService.xpc/Resources/data", in: root)
+
+        let catalog = try PrivateHeaderGeneration.TargetDiscovery.discover(in: root)
+        let group = try #require(catalog.groups.first)
+
+        #expect(group.primaryTarget?.candidate.displayName == "Parent")
+        #expect(group.childTargets.map(\.candidate.displayName) == [
+            "Frameworks/Parent.framework/PlugIns/LiveExtension.appex",
+            "Frameworks/Parent.framework/XPCServices/LiveService.xpc",
+        ])
+    }
+
+    @Test func loadableNestedChildSurvivesResourceOnlyParent() throws {
+        let root = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let parent = "System/Library/Frameworks/Shell.framework"
+        try createDirectory(parent, in: root)
+        try createLoadableBundle(parent + "/XPCServices/LiveService.xpc", in: root)
+
+        let catalog = try PrivateHeaderGeneration.TargetDiscovery.discover(in: root)
+        let group = try #require(catalog.groups.first)
+
+        #expect(group.selectionCandidate.displayName == "Shell")
+        #expect(group.primaryTarget == nil)
+        #expect(group.childTargets.map(\.candidate.displayName) == [
+            "Frameworks/Shell.framework/XPCServices/LiveService.xpc",
+        ])
+        #expect(catalog.resolver.resolve(try PrivateHeaderGeneration.TargetQuery(commaSeparated: "Shell")) == .selected(.targets([
+            group.selectionCandidate
+        ])))
+        #expect(catalog.allExecutionTargets == group.childTargets)
+    }
+
+    @Test func brokenExecutableSymlinkDoesNotAdmitBundle() throws {
+        let root = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let bundle = root.appendingPathComponent(
+            "System/Library/Frameworks/Broken.framework",
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(at: bundle, withIntermediateDirectories: true)
+        try FileManager.default.createSymbolicLink(
+            atPath: bundle.appendingPathComponent("Broken").path,
+            withDestinationPath: "Missing"
+        )
+
+        let catalog = try PrivateHeaderGeneration.TargetDiscovery.discover(in: root)
+        #expect(catalog.groups.isEmpty)
+    }
+
+    @Test func contentsMacOSCachePathRequiresBundleResolvedExecutable() throws {
+        let root = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        try createLoadableBundle(
+            "System/Library/CoreServices/Disk.app",
+            executableRelativePath: "Contents/MacOS/Disk",
+            in: root
+        )
+        try writeBundleInfo(
+            "System/Library/CoreServices/Disk.app",
+            executableName: "Disk",
+            infoRelativePath: "Contents/Info.plist",
+            packageType: "APPL",
+            in: root
+        )
+        try createDirectory("System/Library/CoreServices/Cache.app", in: root)
+        let catalog = try PrivateHeaderGeneration.TargetDiscovery.discover(
+            in: root,
+            sharedCacheImagePaths: [
+                "/System/Library/CoreServices/Cache.app/Contents/MacOS/Cache"
+            ]
+        )
+
+        #expect(catalog.groups.map(\.selectionCandidate.displayName) == [
+            "CoreServices/Disk.app"
+        ])
+    }
+
+    @Test func cacheInventoryOrderDuplicatesAndAliasesDoNotChangeCatalog() throws {
+        let root = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        try createDirectory("System/Library/Frameworks/Cache.framework", in: root)
+
+        let aliases = [
+            "/System/Library/Frameworks/Cache.framework/Cache",
+            "/System/Library/Frameworks/Cache.framework/Versions/A/Cache",
+            "/System/Library/Frameworks/Cache.framework/Cache",
+        ]
+        let first = try PrivateHeaderGeneration.TargetDiscovery.discover(
+            in: root,
+            sharedCacheImagePaths: aliases
+        )
+        let second = try PrivateHeaderGeneration.TargetDiscovery.discover(
+            in: root,
+            sharedCacheImagePaths: Array(aliases.reversed())
+        )
+
+        #expect(first == second)
+        #expect(first.groups.count == 1)
+        #expect(first.groups[0].selectionCandidate.aliases == [
+            "Cache.framework",
+            "Frameworks/Cache.framework",
+            "/System/Library/Frameworks/Cache.framework",
+        ])
+    }
+
     @Test func preservesDistinctArtifactRootsForSiblingBundleKinds() throws {
         let root = try makeTemporaryDirectory()
         defer {
             try? FileManager.default.removeItem(at: root)
         }
 
-        try createDirectory("System/Library/CoreServices/Siri.app", in: root)
-        try createDirectory("System/Library/CoreServices/Siri.bundle", in: root)
+        try createLoadableBundle("System/Library/CoreServices/Siri.app", in: root)
+        try createLoadableBundle("System/Library/CoreServices/Siri.bundle", in: root)
 
         let catalog = try PrivateHeaderGeneration.TargetDiscovery.discover(in: root)
 
-        #expect(catalog.targets.map(\.candidate.identifier) == [
+        #expect(catalog.groups.map(\.selectionCandidate.identifier) == [
             "system-library:CoreServices/Siri.app",
             "system-library:CoreServices/Siri.bundle",
         ])
-        #expect(catalog.targets.map(\.artifactRoot.rawValue) == [
+        #expect(catalog.groups.compactMap(\.primaryTarget?.artifactRoot.rawValue) == [
             "SystemLibrary/CoreServices/Siri.app",
             "SystemLibrary/CoreServices/Siri.bundle",
         ])
@@ -102,14 +340,16 @@ struct PrivateHeaderGenerationTargetDiscoveryTests {
             try? FileManager.default.removeItem(at: root)
         }
 
-        try createDirectory("System/Library/Frameworks/UIKit.framework", in: root)
-        try createDirectory("System/Library/PrivateFrameworks/SafariShared.framework", in: root)
-        try createDirectory("System/Library/PreferenceBundles/Foo.bundle", in: root)
+        try createLoadableBundle("System/Library/Frameworks/UIKit.framework", in: root)
+        try createLoadableBundle("System/Library/PrivateFrameworks/SafariShared.framework", in: root)
+        try createLoadableBundle("System/Library/PreferenceBundles/Foo.bundle", in: root)
         try writeFile("usr/lib/libobjc.A.dylib", in: root)
 
         let catalog = try PrivateHeaderGeneration.TargetDiscovery.discover(in: root)
 
-        let framework = try #require(catalog.targets.first { $0.candidate.displayName == "UIKit" })
+        let framework = try #require(
+            catalog.groups.first { $0.selectionCandidate.displayName == "UIKit" }?.primaryTarget
+        )
         guard case .framework(let frameworkSource) = framework.source else {
             Issue.record("expected framework source metadata")
             return
@@ -118,7 +358,9 @@ struct PrivateHeaderGenerationTargetDiscoveryTests {
         #expect(frameworkSource.bundleName == "UIKit.framework")
         #expect(frameworkSource.systemLibraryRelativePath == "Frameworks/UIKit.framework")
 
-        let privateFramework = try #require(catalog.targets.first { $0.candidate.displayName == "SafariShared" })
+        let privateFramework = try #require(
+            catalog.groups.first { $0.selectionCandidate.displayName == "SafariShared" }?.primaryTarget
+        )
         guard case .framework(let privateFrameworkSource) = privateFramework.source else {
             Issue.record("expected framework source metadata")
             return
@@ -127,7 +369,9 @@ struct PrivateHeaderGenerationTargetDiscoveryTests {
         #expect(privateFrameworkSource.bundleName == "SafariShared.framework")
 
         let systemBundle = try #require(
-            catalog.targets.first { $0.candidate.displayName == "PreferenceBundles/Foo.bundle" }
+            catalog.groups.first {
+                $0.selectionCandidate.displayName == "PreferenceBundles/Foo.bundle"
+            }?.primaryTarget
         )
         guard case .systemLibraryBundle(let systemBundleSource) = systemBundle.source else {
             Issue.record("expected SystemLibrary source metadata")
@@ -137,7 +381,11 @@ struct PrivateHeaderGenerationTargetDiscoveryTests {
         #expect(systemBundleSource.bundleKind == .bundle)
         #expect(systemBundleSource.role == .topLevel)
 
-        let dylib = try #require(catalog.targets.first { $0.candidate.displayName == "libobjc.A.dylib" })
+        let dylib = try #require(
+            catalog.groups.first {
+                $0.selectionCandidate.displayName == "libobjc.A.dylib"
+            }?.primaryTarget
+        )
         guard case .usrLibDylib(let dylibSource) = dylib.source else {
             Issue.record("expected usr/lib source metadata")
             return
@@ -160,6 +408,8 @@ struct PrivateHeaderGenerationTargetDiscoveryTests {
             isDirectory: true
         )
         try FileManager.default.createDirectory(at: xpcServices, withIntermediateDirectories: true)
+        try Data().write(to: framework.appendingPathComponent("Versions/A/WebKit"))
+        try Data().write(to: xpcServices.appendingPathComponent("WebKitHelper"))
         try FileManager.default.createSymbolicLink(
             atPath: framework.appendingPathComponent("Versions/Current").path,
             withDestinationPath: "A"
@@ -186,6 +436,7 @@ struct PrivateHeaderGenerationTargetDiscoveryTests {
             isDirectory: true
         )
         try FileManager.default.createDirectory(at: bundle, withIntermediateDirectories: true)
+        try Data().write(to: bundle.appendingPathComponent("CoreGlyphs"))
         let bundleLink = root.appendingPathComponent(
             "System/Library/CoreServices/CoreGlyphs.bundle",
             isDirectory: true
@@ -200,16 +451,21 @@ struct PrivateHeaderGenerationTargetDiscoveryTests {
         )
 
         let catalog = try PrivateHeaderGeneration.TargetDiscovery.discover(in: root)
-        let frameworkTarget = try #require(catalog.targets.first { $0.candidate.displayName == "WebKit" })
+        let frameworkGroup = try #require(
+            catalog.groups.first { $0.selectionCandidate.displayName == "WebKit" }
+        )
+        let frameworkTarget = try #require(frameworkGroup.primaryTarget)
         let bundleTarget = try #require(
-            catalog.targets.first { $0.candidate.displayName == "CoreServices/CoreGlyphs.bundle" }
+            catalog.groups.first {
+                $0.selectionCandidate.displayName == "CoreServices/CoreGlyphs.bundle"
+            }?.primaryTarget
         )
 
         #expect(frameworkTarget.candidate.identifier == "framework:WebKit.framework")
         #expect(frameworkTarget.artifactRoot.rawValue == "Frameworks/WebKit")
         #expect(frameworkTarget.inputPath == frameworkLink.path)
         #expect(frameworkTarget.runtimeInputPath == "/System/Library/Frameworks/WebKit.framework")
-        #expect(frameworkTarget.childTargets.map(\.candidate.displayName) == [
+        #expect(frameworkGroup.childTargets.map(\.candidate.displayName) == [
             "Frameworks/WebKit.framework/XPCServices/WebKitHelper.xpc",
         ])
         #expect(bundleTarget.candidate.identifier == "system-library:CoreServices/CoreGlyphs.bundle")
@@ -224,7 +480,7 @@ struct PrivateHeaderGenerationTargetDiscoveryTests {
             try? FileManager.default.removeItem(at: root)
         }
 
-        try createDirectory("System/Library/CoreServices/ControlCenter.app", in: root)
+        try createLoadableBundle("System/Library/CoreServices/ControlCenter.app", in: root)
         try createDirectory("System/Library/Protected", in: root)
         let protectedDirectory = root.appendingPathComponent(
             "System/Library/Protected",
@@ -243,7 +499,11 @@ struct PrivateHeaderGenerationTargetDiscoveryTests {
 
         let catalog = try PrivateHeaderGeneration.TargetDiscovery.discover(in: root)
 
-        #expect(catalog.targets.contains { $0.candidate.displayName == "CoreServices/ControlCenter.app" })
+        #expect(
+            catalog.groups.contains {
+                $0.selectionCandidate.displayName == "CoreServices/ControlCenter.app"
+            }
+        )
     }
 
     @Test func permissionDeniedSystemLibraryEntryMetadataDoesNotAbortDiscovery() throws {
@@ -252,7 +512,7 @@ struct PrivateHeaderGenerationTargetDiscoveryTests {
             try? FileManager.default.removeItem(at: root)
         }
 
-        try createDirectory("System/Library/CoreServices/ControlCenter.app", in: root)
+        try createLoadableBundle("System/Library/CoreServices/ControlCenter.app", in: root)
         let protectedName = "Protected-\(UUID().uuidString)"
         try createDirectory("System/Library/\(protectedName)", in: root)
         let fileManager = FailingAttributesFileManager(
@@ -264,7 +524,11 @@ struct PrivateHeaderGenerationTargetDiscoveryTests {
             fileManager: fileManager
         )
 
-        #expect(catalog.targets.contains { $0.candidate.displayName == "CoreServices/ControlCenter.app" })
+        #expect(
+            catalog.groups.contains {
+                $0.selectionCandidate.displayName == "CoreServices/ControlCenter.app"
+            }
+        )
     }
 
     @Test func nestedChildrenAreDiscoveredButExcludedFromResolverCandidates() throws {
@@ -273,14 +537,29 @@ struct PrivateHeaderGenerationTargetDiscoveryTests {
             try? FileManager.default.removeItem(at: root)
         }
 
-        try createDirectory("System/Library/Frameworks/Foo.framework/XPCServices/FooHelper.xpc", in: root)
-        try createDirectory("System/Library/Frameworks/Foo.framework/PlugIns/FooExtension.appex", in: root)
-        try createDirectory("System/Library/PreferenceBundles/Prefs.bundle/XPCServices/PrefsHelper.xpc", in: root)
+        try createLoadableBundle("System/Library/Frameworks/Foo.framework", in: root)
+        try createLoadableBundle(
+            "System/Library/Frameworks/Foo.framework/XPCServices/FooHelper.xpc",
+            in: root
+        )
+        try createLoadableBundle(
+            "System/Library/Frameworks/Foo.framework/PlugIns/FooExtension.appex",
+            in: root
+        )
+        try createLoadableBundle("System/Library/PreferenceBundles/Prefs.bundle", in: root)
+        try createLoadableBundle(
+            "System/Library/PreferenceBundles/Prefs.bundle/XPCServices/PrefsHelper.xpc",
+            in: root
+        )
 
         let catalog = try PrivateHeaderGeneration.TargetDiscovery.discover(in: root)
-        let framework = try #require(catalog.targets.first { $0.candidate.displayName == "Foo" })
+        let framework = try #require(
+            catalog.groups.first { $0.selectionCandidate.displayName == "Foo" }
+        )
         let systemBundle = try #require(
-            catalog.targets.first { $0.candidate.displayName == "PreferenceBundles/Prefs.bundle" }
+            catalog.groups.first {
+                $0.selectionCandidate.displayName == "PreferenceBundles/Prefs.bundle"
+            }
         )
 
         #expect(framework.childTargets.map(\.candidate.displayName) == [
@@ -321,16 +600,22 @@ struct PrivateHeaderGenerationTargetDiscoveryTests {
             try? FileManager.default.removeItem(at: root)
         }
 
-        try createDirectory("System/Library/Frameworks/Foo.framework/XPCServices/FooHelper.xpc", in: root)
+        try createLoadableBundle("System/Library/Frameworks/Foo.framework", in: root)
+        try createLoadableBundle(
+            "System/Library/Frameworks/Foo.framework/XPCServices/FooHelper.xpc",
+            in: root
+        )
 
         let catalog = try PrivateHeaderGeneration.TargetDiscovery.discover(
             in: root,
             includeNestedChildren: false
         )
 
-        let framework = try #require(catalog.targets.first { $0.candidate.displayName == "Foo" })
+        let framework = try #require(
+            catalog.groups.first { $0.selectionCandidate.displayName == "Foo" }
+        )
         #expect(framework.childTargets.isEmpty)
-        #expect(catalog.allTargetsIncludingNestedChildren.map(\.candidate.displayName) == ["Foo"])
+        #expect(catalog.allExecutionTargets.map(\.candidate.displayName) == ["Foo"])
     }
 
     @Test func nestedContainerIOFailureIsSurfaced() throws {
@@ -339,6 +624,7 @@ struct PrivateHeaderGenerationTargetDiscoveryTests {
             try? FileManager.default.removeItem(at: root)
         }
 
+        try createLoadableBundle("System/Library/Frameworks/Foo.framework", in: root)
         try createDirectory("System/Library/Frameworks/Foo.framework/PlugIns", in: root)
         let plugInsURL = root.appendingPathComponent(
             "System/Library/Frameworks/Foo.framework/PlugIns",
@@ -365,10 +651,10 @@ struct PrivateHeaderGenerationTargetDiscoveryTests {
             try? FileManager.default.removeItem(at: root)
         }
 
-        try createDirectory("System/Library/Frameworks/UIKit.framework", in: root)
-        try createDirectory("System/Library/PrivateFrameworks/UIKitServices.framework", in: root)
-        try createDirectory("System/Library/CoreServices/ControlCenter.app", in: root)
-        try createDirectory("System/Library/PreferenceBundles/Foo.bundle", in: root)
+        try createLoadableBundle("System/Library/Frameworks/UIKit.framework", in: root)
+        try createLoadableBundle("System/Library/PrivateFrameworks/UIKitServices.framework", in: root)
+        try createLoadableBundle("System/Library/CoreServices/ControlCenter.app", in: root)
+        try createLoadableBundle("System/Library/PreferenceBundles/Foo.bundle", in: root)
         try writeFile("usr/lib/libobjc.A.dylib", in: root)
 
         let catalog = try PrivateHeaderGeneration.TargetDiscovery.discover(in: root)
@@ -478,7 +764,7 @@ struct PrivateHeaderGenerationTargetDiscoveryTests {
 
         let catalog = try PrivateHeaderGeneration.TargetDiscovery.discover(in: root)
 
-        #expect(catalog.targets.isEmpty)
+        #expect(catalog.groups.isEmpty)
         #expect(catalog.resolverCandidates.isEmpty)
     }
 
@@ -501,7 +787,7 @@ struct PrivateHeaderGenerationTargetDiscoveryTests {
                 "/usr/lib/libNotDylib.tbd",
             ]
         )
-        let dylibs = catalog.targets.filter { $0.candidate.kind == .usrLibDylib }
+        let dylibs = catalog.allExecutionTargets.filter { $0.candidate.kind == .usrLibDylib }
 
         #expect(dylibs.map(\.candidate.displayName) == [
             "libBoth.dylib",
@@ -573,6 +859,46 @@ private func createDirectory(_ relativePath: String, in root: URL) throws {
         at: root.appendingPathComponent(relativePath, isDirectory: true),
         withIntermediateDirectories: true
     )
+}
+
+private func createLoadableBundle(
+    _ relativePath: String,
+    executableName: String? = nil,
+    executableRelativePath: String? = nil,
+    in root: URL
+) throws {
+    let bundleURL = root.appendingPathComponent(relativePath, isDirectory: true)
+    try FileManager.default.createDirectory(at: bundleURL, withIntermediateDirectories: true)
+    let name = executableName ?? bundleURL.deletingPathExtension().lastPathComponent
+    let executablePath = executableRelativePath ?? name
+    try writeFile(relativePath + "/" + executablePath, in: root)
+}
+
+private func writeBundleInfo(
+    _ relativeBundlePath: String,
+    executableName: String,
+    infoRelativePath: String = "Info.plist",
+    packageType: String = "FMWK",
+    in root: URL
+) throws {
+    let data = try PropertyListSerialization.data(
+        fromPropertyList: [
+            "CFBundleExecutable": executableName,
+            "CFBundleIdentifier": "com.example.\(relativeBundlePath.replacingOccurrences(of: "/", with: "."))",
+            "CFBundlePackageType": packageType,
+        ],
+        format: .xml,
+        options: 0
+    )
+    let infoURL = root.appendingPathComponent(
+        relativeBundlePath + "/" + infoRelativePath,
+        isDirectory: false
+    )
+    try FileManager.default.createDirectory(
+        at: infoURL.deletingLastPathComponent(),
+        withIntermediateDirectories: true
+    )
+    try data.write(to: infoURL)
 }
 
 private func writeFile(_ relativePath: String, in root: URL) throws {

--- a/Tests/PrivateHeaderKitRawDumpTests/PrivateHeaderKitRawDumpTests.swift
+++ b/Tests/PrivateHeaderKitRawDumpTests/PrivateHeaderKitRawDumpTests.swift
@@ -171,6 +171,21 @@ struct PrivateHeaderKitRawDumpPathTests {
         #expect(paths.contains("/Runtime/System/Library/Frameworks/Foo.framework/Versions/A/Foo"))
         #expect(Set(paths).count == paths.count)
 
+        let nestedPaths = normalizedCacheImagePaths(
+            for: "/Runtime/System/Library/Frameworks/Foo.framework/XPCServices/Foo.xpc/Foo",
+            environment: ["PH_RUNTIME_ROOT": "/Runtime"]
+        )
+        #expect(
+            nestedPaths.contains(
+                "/System/Library/Frameworks/Foo.framework/XPCServices/Foo.xpc/Foo"
+            )
+        )
+        #expect(
+            !nestedPaths.contains(
+                "/System/Library/Frameworks/Foo.framework/Versions/A/Foo"
+            )
+        )
+
         let usrPaths = normalizedCacheImagePaths(
             for: "/Runtime/usr/lib/libobjc.A.dylib",
             environment: ["PH_RUNTIME_ROOT": "/Runtime"]


### PR DESCRIPTION
## Purpose

Prevent all-target generation from scheduling resource-only framework and bundle shells that cannot be loaded from disk or the active dyld shared cache.

Closes #52.

## Changes

- centralize bundle executable resolution and shared-cache aliases in one package-internal owner used by discovery and raw dumping
- admit framework, system-bundle, app-extension, and XPC targets only when the resolved executable is disk-backed or has an exact shared-cache image
- separate selection groups from execution targets so loadable nested services remain discoverable when their parent shell has no executable
- restrict framework version aliases to direct framework images to prevent nested bundles from matching their parent's Mach-O
- add deterministic fixtures for disk-backed, cache-only, resource-only, versioned, nested, broken-symlink, and Cryptex-backed layouts

## Testing

- `swift test` (468 tests in 40 suites)
- `scripts/test-release-scripts.sh`
- iOS Simulator compile checks for `PrivateHeaderKitCore` and `PrivateHeaderKitCoreTests`
- `git diff --check main...HEAD`
- `codex-review` against `main` (0 findings)