### PR TITLE
Pin MachOSwiftSection null indirect pointer fix

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "e8bb12fd2d1ae7de9f72d308066e7e00ee8f5f8253bfaa2c8c7786ad495d8f12",
+  "originHash" : "b5d21bf8cc51affcac549b040c61d57f99923f497defea5b65257319b20283c4",
   "pins" : [
     {
       "identity" : "associatedobject",
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/MxIris-Reverse-Engineering/MachOKit.git",
       "state" : {
-        "revision" : "5223d0958aa5aa810e8f77b6c6763f019254a322",
-        "version" : "0.52.100"
+        "revision" : "fec9503cdf3d595ef8cf4abac1602e299a8c3be4",
+        "version" : "0.52.101"
       }
     },
     {
@@ -67,10 +67,9 @@
     {
       "identity" : "machoswiftsection",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/MxIris-Reverse-Engineering/MachOSwiftSection.git",
+      "location" : "https://github.com/lynnswap/MachOSwiftSection.git",
       "state" : {
-        "revision" : "9389a5a1a50998e1a1619dd52b428c1f114112f7",
-        "version" : "0.15.1"
+        "revision" : "c1e9e6eade17dc2a617326719d61f6cf9025e43f"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -43,8 +43,8 @@ let package = Package(
             from: "0.8.100"
         ),
         .package(
-            url: "https://github.com/MxIris-Reverse-Engineering/MachOSwiftSection.git",
-            "0.15.1" ..< "0.16.0"
+            url: "https://github.com/lynnswap/MachOSwiftSection.git",
+            revision: "c1e9e6eade17dc2a617326719d61f6cf9025e43f"
         ),
         .package(
             url: "https://github.com/MxIris-Reverse-Engineering/swift-demangling",


### PR DESCRIPTION
## Purpose

Prevent `FoundationModels.framework` Swift interface generation from terminating the simulator helper with `SIGSEGV` when an indirect symbolic-reference slot contains zero.

Closes #53.

## Changes

- pin `MachOSwiftSection` to fork commit [`c1e9e6ea`](https://github.com/lynnswap/MachOSwiftSection/commit/c1e9e6eade17dc2a617326719d61f6cf9025e43f)
- update the resolved dependency cohort to MachOKit 0.52.101 while retaining MachOObjCSection 0.8.104 and every unrelated pin
- keep the fix in the pointer abstraction: optional zero slots resolve as `.element(nil)` and non-optional zero slots throw `ReadingError.invalidAddress(0)` through the unconditional protocol witnesses

This is intentionally a temporary full-revision fork pin. No upstream PR was opened. Keep the fork branch reachable until PrivateHeaderKit returns to the official URL and a fixed 0.15.x SemVer range.

## Testing

- fork: `swift test --skip IntegrationTests --quiet` (1,359 tests in 253 suites)
- fork: existing CI filter runs 9 `MetadataReaderDemanglingTests` in debug and release
- PrivateHeaderKit: `swift test --force-resolved-versions` (468 tests in 40 suites)
- `scripts/test-release-scripts.sh`
- iOS Simulator compile checks for `PrivateHeaderKitCore` and `PrivateHeaderKitCoreTests`
- isolated iOS 27.0 `24A5390f` smoke: `FoundationModels` completed with 34 headers and a 2,716-line / 176,735-byte `FoundationModels.swiftinterface`
- `codex-review` against `main` (0 findings)