### PR TITLE
Harden Objective-C protocol metadata generation

### DIFF
--- a/Docs/generation.md
+++ b/Docs/generation.md
@@ -106,6 +106,17 @@ available. Failed or interrupted targets retain their last successfully
 published files. The immutable generation under `.privateheaderkit` is a
 recovery snapshot, not a visibility gate for generated headers.
 
+Objective-C header generation reads only the directly adopted protocol names
+needed by class, category, and protocol declarations. Protocol metadata reads
+are range-checked and traversal is bounded; an unreadable reference, cycle, or
+safety-limit cutoff preserves the metadata that was decoded successfully. Once
+that target is published, PrivateHeaderKit reports the precise owner and
+degradation as an `objc-metadata-warning` and persists the warning in
+`generation.sqlite`. A bounded diagnostics report records when additional
+warnings were omitted, so malformed metadata cannot grow process output without
+limit. Live warning presentation is also capped across the run; one aggregate
+warning points to the retained per-target details in the database.
+
 State, attempts, publication intent, and run diagnostics are stored in
 `generation.sqlite`, outside the published header tree. The top-level source
 link and `.privateheaderkit` tree are internal recovery artifacts; consumers

--- a/Package.resolved
+++ b/Package.resolved
@@ -58,10 +58,9 @@
     {
       "identity" : "machoobjcsection",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/MxIris-Reverse-Engineering/MachOObjCSection.git",
+      "location" : "https://github.com/lynnswap/MachOObjCSection.git",
       "state" : {
-        "revision" : "edac0dafad8693e0b09869fa7e4d13adf1ef8db7",
-        "version" : "0.8.104"
+        "revision" : "7d159a0216565edae417bf40716dd447bf295e7b"
       }
     },
     {
@@ -69,7 +68,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/lynnswap/MachOSwiftSection.git",
       "state" : {
-        "revision" : "c1e9e6eade17dc2a617326719d61f6cf9025e43f"
+        "revision" : "030963e9f69118f4c4b22a41a90a03cc51a79833"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -35,8 +35,8 @@ let package = Package(
             from: "0.51.101"
         ),
         .package(
-            url: "https://github.com/MxIris-Reverse-Engineering/MachOObjCSection.git",
-            from: "0.7.103"
+            url: "https://github.com/lynnswap/MachOObjCSection.git",
+            revision: "7d159a0216565edae417bf40716dd447bf295e7b"
         ),
         .package(
             url: "https://github.com/MxIris-Reverse-Engineering/swift-objc-dump.git",
@@ -44,7 +44,7 @@ let package = Package(
         ),
         .package(
             url: "https://github.com/lynnswap/MachOSwiftSection.git",
-            revision: "c1e9e6eade17dc2a617326719d61f6cf9025e43f"
+            revision: "030963e9f69118f4c4b22a41a90a03cc51a79833"
         ),
         .package(
             url: "https://github.com/MxIris-Reverse-Engineering/swift-demangling",
@@ -114,6 +114,7 @@ let package = Package(
             name: "PrivateHeaderKitCLI",
             dependencies: [
                 "PrivateHeaderKitCore",
+                "PrivateHeaderKitHelperProtocol",
                 "PrivateHeaderKitTooling",
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
                 .product(
@@ -180,6 +181,7 @@ let package = Package(
                     condition: .when(platforms: [.macOS, .iOS])
                 ),
                 .product(name: "MachOKit", package: "MachOKit"),
+                .product(name: "MachOObjCSection", package: "MachOObjCSection"),
                 .product(name: "ObjCDump", package: "swift-objc-dump"),
             ]
         ),
@@ -238,6 +240,7 @@ let package = Package(
             dependencies: [
                 "PrivateHeaderKitCLI",
                 "PrivateHeaderKitCore",
+                "PrivateHeaderKitHelperProtocol",
                 "PrivateHeaderKitTestSupport",
                 "PrivateHeaderKitTooling",
             ]

--- a/Sources/PrivateHeaderKitCLI/PrivateHeaderKitGenerationClient.swift
+++ b/Sources/PrivateHeaderKitCLI/PrivateHeaderKitGenerationClient.swift
@@ -1,5 +1,6 @@
 import Foundation
 import PrivateHeaderKitCore
+import PrivateHeaderKitHelperProtocol
 import PrivateHeaderKitTooling
 
 struct PrivateHeaderKitGenerationRequest: Sendable {
@@ -109,13 +110,126 @@ func runPrivateHeaderKitRawDump(
         env: invocation.environment,
         cwd: nil
     )
+    guard processResult.status == 0, !processResult.wasKilled else {
+        try? FileManager.default.removeItem(at: invocation.diagnosticsReportURL)
+        return PrivateHeaderGeneration.RawDumping.Result(
+            terminationStatus: processResult.status,
+            wasKilled: processResult.wasKilled,
+            failureSummary: processResult.lastLines.isEmpty
+                ? nil
+                : processResult.lastLines.joined(separator: "\n")
+        )
+    }
+
+    let report = try consumeRawDumpDiagnosticsReport(
+        at: invocation.diagnosticsReportURL
+    )
     return PrivateHeaderGeneration.RawDumping.Result(
         terminationStatus: processResult.status,
         wasKilled: processResult.wasKilled,
         failureSummary: processResult.lastLines.isEmpty
             ? nil
-            : processResult.lastLines.joined(separator: "\n")
+            : processResult.lastLines.joined(separator: "\n"),
+        diagnosticsReport: report
     )
+}
+
+enum PrivateHeaderKitRawDumpContractError: Error, Equatable, CustomStringConvertible {
+    case missingDiagnosticsReport(String)
+    case invalidDiagnosticsReport(path: String, reason: String)
+    case diagnosticsReportTooLarge(path: String, actual: Int, maximum: Int)
+    case diagnosticsReportCleanupFailed(path: String, reason: String)
+
+    var description: String {
+        switch self {
+        case .missingDiagnosticsReport(let path):
+            "raw helper contract failure: successful helper did not write diagnostics report at \(path)"
+        case .invalidDiagnosticsReport(let path, let reason):
+            "raw helper contract failure: invalid diagnostics report at \(path): \(reason)"
+        case .diagnosticsReportTooLarge(let path, let actual, let maximum):
+            "raw helper contract failure: diagnostics report at \(path) is \(actual) bytes; maximum is \(maximum)"
+        case .diagnosticsReportCleanupFailed(let path, let reason):
+            "raw helper contract failure: could not remove diagnostics report at \(path): \(reason)"
+        }
+    }
+}
+
+private func consumeRawDumpDiagnosticsReport(
+    at reportURL: URL,
+    fileManager: FileManager = .default
+) throws -> PrivateHeaderKitRawDumpDiagnosticsReport {
+    let path = reportURL.path
+    guard fileManager.fileExists(atPath: path) else {
+        throw PrivateHeaderKitRawDumpContractError.missingDiagnosticsReport(path)
+    }
+
+    let data: Data
+    do {
+        let values = try reportURL.resourceValues(forKeys: [
+            .isRegularFileKey,
+            .fileSizeKey,
+        ])
+        guard values.isRegularFile == true else {
+            throw PrivateHeaderKitRawDumpContractError.invalidDiagnosticsReport(
+                path: path,
+                reason: "report is not a regular file"
+            )
+        }
+        guard let fileSize = values.fileSize else {
+            throw PrivateHeaderKitRawDumpContractError.invalidDiagnosticsReport(
+                path: path,
+                reason: "report size is unavailable"
+            )
+        }
+        guard fileSize <= PrivateHeaderKitRawDumpDiagnosticsReport.maximumEncodedByteCount else {
+            throw PrivateHeaderKitRawDumpContractError.diagnosticsReportTooLarge(
+                path: path,
+                actual: fileSize,
+                maximum: PrivateHeaderKitRawDumpDiagnosticsReport.maximumEncodedByteCount
+            )
+        }
+        data = try Data(contentsOf: reportURL)
+        guard data.count <= PrivateHeaderKitRawDumpDiagnosticsReport.maximumEncodedByteCount else {
+            throw PrivateHeaderKitRawDumpContractError.diagnosticsReportTooLarge(
+                path: path,
+                actual: data.count,
+                maximum: PrivateHeaderKitRawDumpDiagnosticsReport.maximumEncodedByteCount
+            )
+        }
+    } catch let error as PrivateHeaderKitRawDumpContractError {
+        try? fileManager.removeItem(at: reportURL)
+        throw error
+    } catch {
+        try? fileManager.removeItem(at: reportURL)
+        throw PrivateHeaderKitRawDumpContractError.invalidDiagnosticsReport(
+            path: path,
+            reason: String(describing: error)
+        )
+    }
+
+    let report: PrivateHeaderKitRawDumpDiagnosticsReport
+    do {
+        report = try JSONDecoder().decode(
+            PrivateHeaderKitRawDumpDiagnosticsReport.self,
+            from: data
+        )
+    } catch {
+        try? fileManager.removeItem(at: reportURL)
+        throw PrivateHeaderKitRawDumpContractError.invalidDiagnosticsReport(
+            path: path,
+            reason: String(describing: error)
+        )
+    }
+
+    do {
+        try fileManager.removeItem(at: reportURL)
+    } catch {
+        throw PrivateHeaderKitRawDumpContractError.diagnosticsReportCleanupFailed(
+            path: path,
+            reason: String(describing: error)
+        )
+    }
+    return report
 }
 
 private func capturePrivateHeaderKitSharedCacheInventory(

--- a/Sources/PrivateHeaderKitCore/PrivateHeaderGenerationExecutor.swift
+++ b/Sources/PrivateHeaderKitCore/PrivateHeaderGenerationExecutor.swift
@@ -4,6 +4,8 @@ import PrivateHeaderKitHelperProtocol
 
 extension PrivateHeaderGeneration {
   package struct GenerationExecutor: Sendable {
+    package static let maximumPresentedObjCMetadataWarningCount = 256
+
     private struct DeliberateFault: Error, @unchecked Sendable {
       let underlying: any Error
     }
@@ -189,11 +191,47 @@ extension PrivateHeaderGeneration.GenerationExecutor {
     let completedFiles: [PrivateHeaderGeneration.ArtifactPath: URL]
     let stagedSourceDirectory: URL?
     let artifactRoot: PrivateHeaderGeneration.ArtifactPath?
+    let warnings: [PrivateHeaderGeneration.GenerationWarning]
   }
 
   fileprivate struct StagedArtifacts {
     let files: [PrivateHeaderGeneration.ArtifactPath: URL]
     let sourceDirectory: URL?
+  }
+
+  fileprivate struct ObjCMetadataWarningPresentationBudget {
+    private var retained = Set<PrivateHeaderGeneration.GenerationWarning>()
+    private(set) var omittedCount: UInt = 0
+
+    mutating func consume(
+      _ warnings: [PrivateHeaderGeneration.GenerationWarning]
+    ) -> [PrivateHeaderGeneration.GenerationWarning] {
+      var accepted: [PrivateHeaderGeneration.GenerationWarning] = []
+      for warning in warnings {
+        guard !retained.contains(warning) else { continue }
+        guard retained.count
+                < PrivateHeaderGeneration.GenerationExecutor
+                    .maximumPresentedObjCMetadataWarningCount
+        else {
+          omittedCount = omittedCount == UInt.max ? UInt.max : omittedCount + 1
+          continue
+        }
+        retained.insert(warning)
+        accepted.append(warning)
+      }
+      return accepted
+    }
+
+    var aggregateWarning: PrivateHeaderGeneration.GenerationWarning? {
+      guard omittedCount > 0 else { return nil }
+      return PrivateHeaderGeneration.GenerationWarning(
+        kind: "objc-metadata-warning",
+        relativePath: "generation.sqlite",
+        message:
+          "\(omittedCount) additional Objective-C metadata warnings were hidden from"
+          + " live output; all retained per-target details are persisted in generation.sqlite"
+      )
+    }
   }
 
   fileprivate enum PublishedTargetSource: Equatable {
@@ -331,6 +369,8 @@ extension PrivateHeaderGeneration.GenerationExecutor {
     )
     _ = try await store.beginRun(id: runID, plan: runPlan, at: dateProvider())
     progressReporter?(.runStarted(runID: runID, totalTargetCount: targetIDsToRun.count))
+    var warnings: [PrivateHeaderGeneration.GenerationWarning] = []
+    var objCMetadataWarningBudget = ObjCMetadataWarningPresentationBudget()
 
     do {
       for target in selectedTargets where !targetIDsToRun.contains(target.candidate.identifier) {
@@ -358,7 +398,6 @@ extension PrivateHeaderGeneration.GenerationExecutor {
       var completedFilesByTarget: [String: [PrivateHeaderGeneration.ArtifactPath: URL]] = [:]
       var completedArtifactDigestsByTarget:
         [String: [PrivateHeaderGeneration.ArtifactPath: String]] = [:]
-      var warnings: [PrivateHeaderGeneration.GenerationWarning] = []
       var wasCancelled = false
       var executedIndex = 0
 
@@ -459,6 +498,7 @@ extension PrivateHeaderGeneration.GenerationExecutor {
             try await store.recordPublishedTargetAttempt(
               execution.result,
               artifactDigests: replacement.artifactDigests,
+              warnings: execution.warnings,
               in: runID
             )
           } catch {
@@ -479,6 +519,11 @@ extension PrivateHeaderGeneration.GenerationExecutor {
           completedFilesByTarget[targetID] = execution.completedFiles
           completedArtifactDigestsByTarget[targetID] = replacement.artifactDigests
           generatedTargetIDs.append(targetID)
+          let presentedObjCWarnings = objCMetadataWarningBudget.consume(execution.warnings)
+          warnings.append(contentsOf: presentedObjCWarnings)
+          for warning in presentedObjCWarnings {
+            progressReporter?(.warning(warning))
+          }
           do {
             try liveArtifactStore.finalizeReplacement(replacement)
           } catch {
@@ -714,6 +759,15 @@ extension PrivateHeaderGeneration.GenerationExecutor {
             progressReporter: progressReporter
           ))
       }
+      if let aggregateWarning = objCMetadataWarningBudget.aggregateWarning {
+        let warning = await persistObjCMetadataAggregateWarning(
+          aggregateWarning,
+          runID: runID,
+          store: store
+        )
+        warnings.append(warning)
+        progressReporter?(.warning(warning))
+      }
       let summary = PrivateHeaderGeneration.RunSummary(
         runID: runID,
         status: finalSnapshot.status,
@@ -763,6 +817,8 @@ extension PrivateHeaderGeneration.GenerationExecutor {
         stateDirectory: stateDirectory,
         store: store,
         publisher: publisher,
+        accumulatedWarnings: warnings,
+        objCMetadataWarningBudget: objCMetadataWarningBudget,
         progressReporter: progressReporter
       )
     }
@@ -787,6 +843,8 @@ extension PrivateHeaderGeneration.GenerationExecutor {
     stateDirectory: URL,
     store: GenerationStore,
     publisher: ArtifactPublisher,
+    accumulatedWarnings: [PrivateHeaderGeneration.GenerationWarning],
+    objCMetadataWarningBudget: ObjCMetadataWarningPresentationBudget,
     progressReporter: ProgressReporter?
   ) async throws -> Never {
     let interruptionRequested = cancellationRequested()
@@ -817,7 +875,7 @@ extension PrivateHeaderGeneration.GenerationExecutor {
           : .failed(message: String(describing: underlyingError))
       )
     }
-    var warnings: [PrivateHeaderGeneration.GenerationWarning] = []
+    var warnings = accumulatedWarnings
     try await Self.recoverTargetReplacements(
       in: stateDirectory,
       artifactDirectory: artifactDirectory,
@@ -849,6 +907,15 @@ extension PrivateHeaderGeneration.GenerationExecutor {
           store: store,
           progressReporter: progressReporter
         ))
+    }
+    if let aggregateWarning = objCMetadataWarningBudget.aggregateWarning {
+      let warning = await persistObjCMetadataAggregateWarning(
+        aggregateWarning,
+        runID: runID,
+        store: store
+      )
+      warnings.append(warning)
+      progressReporter?(.warning(warning))
     }
     let snapshot = try await store.runSnapshot(runID)
     guard snapshot.status != .running else {
@@ -906,6 +973,28 @@ extension PrivateHeaderGeneration.GenerationExecutor {
     return warning
   }
 
+  fileprivate func persistObjCMetadataAggregateWarning(
+    _ warning: PrivateHeaderGeneration.GenerationWarning,
+    runID: PrivateHeaderGeneration.RunID,
+    store: GenerationStore
+  ) async -> PrivateHeaderGeneration.GenerationWarning {
+    do {
+      try await store.recordRunLog(
+        runID: runID,
+        kind: warning.kind,
+        relativePath: warning.relativePath,
+        message: warning.message
+      )
+      return warning
+    } catch {
+      return PrivateHeaderGeneration.GenerationWarning(
+        kind: warning.kind,
+        relativePath: warning.relativePath,
+        message: "\(warning.message); aggregate warning persistence failed: \(error)"
+      )
+    }
+  }
+
   fileprivate func executeTarget(
     _ target: PrivateHeaderGeneration.TargetDiscovery.DiscoveredTarget,
     plan: PrivateHeaderGeneration.Plan,
@@ -935,7 +1024,8 @@ extension PrivateHeaderGeneration.GenerationExecutor {
         result: Self.interruptedResult(target: target, at: dateProvider()),
         completedFiles: [:],
         stagedSourceDirectory: nil,
-        artifactRoot: nil
+        artifactRoot: nil,
+        warnings: []
       )
     } catch {
       return Self.failedExecution(
@@ -951,7 +1041,8 @@ extension PrivateHeaderGeneration.GenerationExecutor {
         result: Self.interruptedResult(target: target, at: dateProvider()),
         completedFiles: [:],
         stagedSourceDirectory: nil,
-        artifactRoot: nil
+        artifactRoot: nil,
+        warnings: []
       )
     }
     let artifactRoot = try Self.artifactRoot(for: target, layout: plan.options.layout)
@@ -988,7 +1079,11 @@ extension PrivateHeaderGeneration.GenerationExecutor {
         ),
         completedFiles: staged.files,
         stagedSourceDirectory: staged.sourceDirectory,
-        artifactRoot: artifactRoot
+        artifactRoot: artifactRoot,
+        warnings: Self.objCMetadataWarnings(
+          rawResult,
+          relativePath: artifactRoot.rawValue
+        )
       )
     }
     return Self.failedExecution(
@@ -1020,8 +1115,38 @@ extension PrivateHeaderGeneration.GenerationExecutor {
       ),
       completedFiles: [:],
       stagedSourceDirectory: nil,
-      artifactRoot: nil
+      artifactRoot: nil,
+      warnings: []
     )
+  }
+
+  fileprivate static func objCMetadataWarnings(
+    _ result: PrivateHeaderGeneration.RawDumping.Result,
+    relativePath: String
+  ) -> [PrivateHeaderGeneration.GenerationWarning] {
+    var warnings = result.diagnostics.map { diagnostic in
+      PrivateHeaderGeneration.GenerationWarning(
+        kind: "objc-metadata-warning",
+        relativePath: relativePath,
+        message: "\(diagnostic.owner): \(diagnostic.degradation)"
+      )
+    }
+    if result.omittedDiagnosticCount > 0 {
+      warnings.append(
+        PrivateHeaderGeneration.GenerationWarning(
+          kind: "objc-metadata-warning",
+          relativePath: relativePath,
+          message:
+            "Objective-C metadata diagnostics: \(result.omittedDiagnosticCount)"
+            + " additional diagnostics were omitted by the bounded helper report"
+        )
+      )
+    }
+    return Array(Set(warnings)).sorted {
+      if $0.relativePath != $1.relativePath { return $0.relativePath < $1.relativePath }
+      if $0.kind != $1.kind { return $0.kind < $1.kind }
+      return $0.message < $1.message
+    }
   }
 
   fileprivate static func interruptedResult(

--- a/Sources/PrivateHeaderKitCore/PrivateHeaderGenerationRawDumping.swift
+++ b/Sources/PrivateHeaderKitCore/PrivateHeaderGenerationRawDumping.swift
@@ -5,13 +5,24 @@ extension PrivateHeaderGeneration {
   package enum RawDumping {
     package static func makeInvocation(_ request: Request) -> Invocation {
       let helperURL = request.executionMode.helperURL(from: request.helperURLs)
+      let diagnosticsReportURL = request.stagingOutputDirectory
+        .deletingLastPathComponent()
+        .appendingPathComponent(
+        ".privateheaderkit-raw-diagnostics-\(UUID().uuidString.lowercased()).json",
+        isDirectory: false
+      )
       return Invocation(
         phaseLabel: "raw-header-dump",
         executionMode: request.executionMode,
         helperURL: helperURL,
         inputPath: request.inputPath,
         stagingOutputDirectory: request.stagingOutputDirectory,
-        command: makeCommand(helperURL: helperURL, request: request),
+        diagnosticsReportURL: diagnosticsReportURL,
+        command: makeCommand(
+          helperURL: helperURL,
+          request: request,
+          diagnosticsReportURL: diagnosticsReportURL
+        ),
         environment: makeEnvironment(for: request)
       )
     }
@@ -47,7 +58,11 @@ extension PrivateHeaderGeneration {
       )
     }
 
-    private static func makeCommand(helperURL: URL, request: Request) -> [String] {
+    private static func makeCommand(
+      helperURL: URL,
+      request: Request,
+      diagnosticsReportURL: URL
+    ) -> [String] {
       var command: [String]
       switch request.executionMode {
       case .host:
@@ -83,6 +98,7 @@ extension PrivateHeaderGeneration {
       if request.executionMode.isHost, request.options.preferRuntimeMetadata {
         command.append("-R")
       }
+      command += ["--diagnostics-report", diagnosticsReportURL.path]
       command.append(request.inputPath)
       return command
     }
@@ -224,6 +240,7 @@ extension PrivateHeaderGeneration.RawDumping {
     package let helperURL: URL
     package let inputPath: String
     package let stagingOutputDirectory: URL
+    package let diagnosticsReportURL: URL
     package let command: [String]
     package let environment: [String: String]
   }
@@ -240,15 +257,42 @@ extension PrivateHeaderGeneration.RawDumping {
     package let terminationStatus: Int32
     package let wasKilled: Bool
     package let failureSummary: String?
+    package let diagnosticsReport: PrivateHeaderKitRawDumpDiagnosticsReport
 
     package init(
       terminationStatus: Int32,
       wasKilled: Bool = false,
-      failureSummary: String? = nil
+      failureSummary: String? = nil,
+      diagnostics: [PrivateHeaderKitRawDumpDiagnostic] = [],
+      omittedDiagnosticCount: UInt = 0
     ) {
       self.terminationStatus = terminationStatus
       self.wasKilled = wasKilled
       self.failureSummary = failureSummary
+      self.diagnosticsReport = PrivateHeaderKitRawDumpDiagnosticsReport(
+        diagnostics: diagnostics,
+        omittedDiagnosticCount: omittedDiagnosticCount
+      )
+    }
+
+    package init(
+      terminationStatus: Int32,
+      wasKilled: Bool = false,
+      failureSummary: String? = nil,
+      diagnosticsReport: PrivateHeaderKitRawDumpDiagnosticsReport
+    ) {
+      self.terminationStatus = terminationStatus
+      self.wasKilled = wasKilled
+      self.failureSummary = failureSummary
+      self.diagnosticsReport = diagnosticsReport
+    }
+
+    package var diagnostics: [PrivateHeaderKitRawDumpDiagnostic] {
+      diagnosticsReport.diagnostics
+    }
+
+    package var omittedDiagnosticCount: UInt {
+      diagnosticsReport.omittedDiagnosticCount
     }
 
     package var succeeded: Bool {

--- a/Sources/PrivateHeaderKitCore/PrivateHeaderGenerationStore.swift
+++ b/Sources/PrivateHeaderKitCore/PrivateHeaderGenerationStore.swift
@@ -377,6 +377,7 @@ package actor GenerationStore {
   package func recordPublishedTargetAttempt(
     _ result: PrivateHeaderGeneration.TargetAttemptResult,
     artifactDigests: [PrivateHeaderGeneration.ArtifactPath: String],
+    warnings: [PrivateHeaderGeneration.GenerationWarning] = [],
     in runID: PrivateHeaderGeneration.RunID
   ) throws {
     guard result.status == .completed else {
@@ -386,6 +387,11 @@ package actor GenerationStore {
         to: PrivateHeaderGeneration.RunTargetStatus.completed.rawValue
       )
     }
+    for warning in warnings {
+      guard PrivateHeaderGeneration.ArtifactPath.isSafeRelativePath(warning.relativePath) else {
+        throw PrivateHeaderGeneration.StateError.invalidArtifactPath(warning.relativePath)
+      }
+    }
     try databaseQueue.write { db in
       try Self.updateRunTarget(db, result: result, in: runID)
       try Self.upsertPublishedTarget(
@@ -394,6 +400,13 @@ package actor GenerationStore {
         artifactDigests: artifactDigests,
         in: runID
       )
+      for warning in warnings {
+        try faultInjector(.beforeRunLogWrite)
+        try db.execute(
+          sql: "INSERT INTO runLogs(runID, kind, relativePath, message) VALUES (?, ?, ?, ?)",
+          arguments: [runID.rawValue, warning.kind, warning.relativePath, warning.message]
+        )
+      }
       try faultInjector(.afterRunTargetWrite)
     }
   }

--- a/Sources/PrivateHeaderKitHelperProtocol/PrivateHeaderKitHelperProtocol.swift
+++ b/Sources/PrivateHeaderKitHelperProtocol/PrivateHeaderKitHelperProtocol.swift
@@ -5,6 +5,163 @@ package enum PrivateHeaderKitHelperCommand: String, Sendable {
     case sharedCacheInventory = "__shared-cache-inventory"
 }
 
+package struct PrivateHeaderKitRawDumpDiagnostic: Codable, Hashable, Sendable {
+    package static let maximumStringUTF8Count = 2_048
+
+    package let owner: String
+    package let degradation: String
+
+    package init(owner: String, degradation: String) {
+        self.owner = Self.bounded(owner, fallback: "unknown Objective-C metadata owner")
+        self.degradation = Self.bounded(degradation, fallback: "metadata was partially decoded")
+    }
+
+    package init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let owner = try container.decode(String.self, forKey: .owner)
+        let degradation = try container.decode(String.self, forKey: .degradation)
+        guard !owner.isEmpty,
+              owner.utf8.count <= Self.maximumStringUTF8Count,
+              Self.terminalSafe(owner) == owner
+        else {
+            throw ValidationError.invalidString(field: "owner")
+        }
+        guard !degradation.isEmpty,
+              degradation.utf8.count <= Self.maximumStringUTF8Count,
+              Self.terminalSafe(degradation) == degradation
+        else {
+            throw ValidationError.invalidString(field: "degradation")
+        }
+        self.owner = owner
+        self.degradation = degradation
+    }
+
+    private static func bounded(_ value: String, fallback: String) -> String {
+        guard !value.isEmpty else { return fallback }
+        var result = ""
+        result.reserveCapacity(min(value.utf8.count, maximumStringUTF8Count))
+        var byteCount = 0
+        for scalar in value.unicodeScalars {
+            let fragment = terminalSafeFragment(scalar)
+            let fragmentByteCount = fragment.utf8.count
+            guard byteCount <= maximumStringUTF8Count - fragmentByteCount else { break }
+            result += fragment
+            byteCount += fragmentByteCount
+        }
+        return result.isEmpty ? fallback : result
+    }
+
+    private static func terminalSafe(_ value: String) -> String {
+        value.unicodeScalars.reduce(into: "") { result, scalar in
+            result += terminalSafeFragment(scalar)
+        }
+    }
+
+    private static func terminalSafeFragment(_ scalar: Unicode.Scalar) -> String {
+        switch scalar.value {
+        case 0x0a:
+            #"\n"#
+        case 0x0d:
+            #"\r"#
+        case 0x09:
+            #"\t"#
+        default:
+            switch scalar.properties.generalCategory {
+            case .control, .format, .lineSeparator, .paragraphSeparator:
+                String(format: #"\u{%04x}"#, scalar.value)
+            default:
+                String(scalar)
+            }
+        }
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case owner
+        case degradation
+    }
+
+    package enum ValidationError: Error, Equatable, Sendable {
+        case invalidString(field: String)
+    }
+}
+
+package struct PrivateHeaderKitRawDumpDiagnosticsReport: Codable, Hashable, Sendable {
+    package static let currentSchemaVersion = 1
+    package static let maximumDiagnosticCount = 256
+    package static let maximumEncodedByteCount = 4 * 1_024 * 1_024
+
+    package let schemaVersion: Int
+    package let diagnostics: [PrivateHeaderKitRawDumpDiagnostic]
+    package let omittedDiagnosticCount: UInt
+
+    package init(
+        diagnostics: [PrivateHeaderKitRawDumpDiagnostic],
+        omittedDiagnosticCount: UInt = 0
+    ) {
+        let normalized = Array(Set(diagnostics)).sorted(by: Self.areInIncreasingOrder)
+        self.schemaVersion = Self.currentSchemaVersion
+        self.diagnostics = Array(normalized.prefix(Self.maximumDiagnosticCount))
+        let existingOmittedCount = omittedDiagnosticCount
+        let newlyOmittedCount = UInt(max(0, normalized.count - Self.maximumDiagnosticCount))
+        let (combinedOmittedCount, overflow) = existingOmittedCount.addingReportingOverflow(
+            newlyOmittedCount
+        )
+        self.omittedDiagnosticCount = overflow ? UInt.max : combinedOmittedCount
+    }
+
+    package init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let schemaVersion = try container.decode(Int.self, forKey: .schemaVersion)
+        guard schemaVersion == Self.currentSchemaVersion else {
+            throw ValidationError.unsupportedSchemaVersion(
+                expected: Self.currentSchemaVersion,
+                actual: schemaVersion
+            )
+        }
+        let diagnostics = try container.decode(
+            [PrivateHeaderKitRawDumpDiagnostic].self,
+            forKey: .diagnostics
+        )
+        guard diagnostics.count <= Self.maximumDiagnosticCount else {
+            throw ValidationError.excessiveDiagnosticCount(
+                actual: diagnostics.count,
+                maximum: Self.maximumDiagnosticCount
+            )
+        }
+        let omittedDiagnosticCount = try container.decode(
+            UInt.self,
+            forKey: .omittedDiagnosticCount
+        )
+        let normalized = Array(Set(diagnostics)).sorted(by: Self.areInIncreasingOrder)
+        guard diagnostics == normalized else {
+            throw ValidationError.nonCanonicalDiagnostics
+        }
+        self.schemaVersion = schemaVersion
+        self.diagnostics = diagnostics
+        self.omittedDiagnosticCount = omittedDiagnosticCount
+    }
+
+    private static func areInIncreasingOrder(
+        _ lhs: PrivateHeaderKitRawDumpDiagnostic,
+        _ rhs: PrivateHeaderKitRawDumpDiagnostic
+    ) -> Bool {
+        if lhs.owner != rhs.owner { return lhs.owner < rhs.owner }
+        return lhs.degradation < rhs.degradation
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case schemaVersion
+        case diagnostics
+        case omittedDiagnosticCount
+    }
+
+    package enum ValidationError: Error, Equatable, Sendable {
+        case unsupportedSchemaVersion(expected: Int, actual: Int)
+        case excessiveDiagnosticCount(actual: Int, maximum: Int)
+        case nonCanonicalDiagnostics
+    }
+}
+
 package struct PrivateHeaderKitSharedCacheInventory: Codable, Equatable, Sendable {
     package static let currentSchemaVersion = 1
 

--- a/Sources/PrivateHeaderKitRawDumpCore/PrivateHeaderKitRawDumpMain.swift
+++ b/Sources/PrivateHeaderKitRawDumpCore/PrivateHeaderKitRawDumpMain.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Dispatch
 import MachOKit
-import MachOObjCSection
+@_spi(Diagnostics) import MachOObjCSection
 import MachOSwiftSection
 import ObjCDump
 import PrivateHeaderKitExecutableResolution
@@ -98,6 +98,8 @@ struct DumpOptions {
     var logSkippedClasses: Bool = false
     var profile: Bool = false
     var logSwiftEvents: Bool = false
+    var diagnosticsReportURL: URL?
+    let objcDiagnostics = RawDumpObjCDiagnosticsAccumulator()
 }
 
 public struct PrivateHeaderKitRawDumpCLI {
@@ -127,7 +129,13 @@ public struct PrivateHeaderKitRawDumpCLI {
 
         do {
             try await run(parsed: parsed)
+            try writeDiagnosticsReportIfRequested(parsed.options)
         } catch {
+            do {
+                try writeDiagnosticsReportIfRequested(parsed.options)
+            } catch {
+                fputs("privateheaderkit __raw-dump: diagnostics report error: \(error)\n", stderr)
+            }
             fputs("privateheaderkit __raw-dump: error: \(error)\n", stderr)
             exit(EXIT_FAILURE)
         }
@@ -186,6 +194,11 @@ func parseArguments(
             options.verbose = true
         case "-R":
             options.useRuntimeFallback = true
+        case "--diagnostics-report":
+            let nextIndex = index + 1
+            guard nextIndex < args.count else { return nil }
+            options.diagnosticsReportURL = URL(fileURLWithPath: args[nextIndex])
+            index += 1
         default:
             if arg.hasPrefix("-") {
                 // ignore unknown flags for compatibility
@@ -226,8 +239,15 @@ private func printUsage() {
              Require the helper process to use the expected dyld shared cache
         -D   Verbose logging
         -R   Prefer Objective-C runtime metadata (auto-enabled in simulator)
+        --diagnostics-report <path>
+             Write the versioned Objective-C metadata diagnostics report
     """
     print(text)
+}
+
+private func writeDiagnosticsReportIfRequested(_ options: DumpOptions) throws {
+    guard let reportURL = options.diagnosticsReportURL else { return }
+    try writeRawDumpDiagnosticsReport(options.objcDiagnostics.report, to: reportURL)
 }
 
 func shouldUseRuntimeFallback(environment: [String: String] = ProcessInfo.processInfo.environment) -> Bool {
@@ -1100,7 +1120,11 @@ private func collectObjCMetadata<Section: ObjCSectionRepresentable>(
     if let list = objc.protocols32 { protocolCandidates.append(contentsOf: list) }
 
     for proto in protocolCandidates {
-        if let info = protocolInfo(proto, in: machO) {
+        if let info = protocolInfo(
+            proto,
+            in: machO,
+            diagnostics: options.objcDiagnostics
+        ) {
             metadata.protocolInfos[info.name] = info
         }
     }
@@ -1114,7 +1138,11 @@ private func collectObjCMetadata<Section: ObjCSectionRepresentable>(
     if let list = objc.categories2_32 { categoryCandidates.append(contentsOf: list) }
 
     for category in categoryCandidates {
-        if let info = categoryInfo(category, in: machO) {
+        if let info = categoryInfo(
+            category,
+            in: machO,
+            diagnostics: options.objcDiagnostics
+        ) {
             let key = "\(info.className)(\(info.name))"
             metadata.categoryInfos[key] = info
         }
@@ -1406,25 +1434,37 @@ private func collectClassInfos<T: ObjCClassProtocol>(
 
 private func protocolInfo(
     _ proto: any ObjCProtocolProtocol,
-    in machO: RawMachO
+    in machO: RawMachO,
+    diagnostics: RawDumpObjCDiagnosticsAccumulator
 ) -> ObjCProtocolInfo? {
+    let options = rawDumpObjCProtocolInfoOptions(for: .protocol)
     switch machO {
     case .file(let file):
-        proto.info(in: file)
+        let result = proto.readInfo(in: file, options: options)
+        diagnostics.append(contentsOf: result.diagnostics)
+        return result.value
     case .loaded(let image):
-        proto.info(in: image)
+        let result = proto.readInfo(in: image, options: options)
+        diagnostics.append(contentsOf: result.diagnostics)
+        return result.value
     }
 }
 
 private func categoryInfo(
     _ category: any ObjCCategoryProtocol,
-    in machO: RawMachO
+    in machO: RawMachO,
+    diagnostics: RawDumpObjCDiagnosticsAccumulator
 ) -> ObjCCategoryInfo? {
+    let options = rawDumpObjCInfoOptions(for: .category)
     switch machO {
     case .file(let file):
-        category.info(in: file)
+        let result = category.readInfo(in: file, options: options)
+        diagnostics.append(contentsOf: result.diagnostics)
+        return result.value
     case .loaded(let image):
-        category.info(in: image)
+        let result = category.readInfo(in: image, options: options)
+        diagnostics.append(contentsOf: result.diagnostics)
+        return result.value
     }
 }
 
@@ -1434,8 +1474,11 @@ private func collectClassInfos<T: ObjCClassProtocol>(
     options: DumpOptions,
     classInfos: inout [String: ObjCClassInfo]
 ) {
+    let readOptions = rawDumpObjCInfoOptions(for: .class)
     for cls in classes {
-        if let info = cls.info(in: machO) {
+        let result = cls.readInfo(in: machO, options: readOptions)
+        options.objcDiagnostics.append(contentsOf: result.diagnostics)
+        if let info = result.value {
             classInfos[info.name] = info
         } else if options.verbose && options.logSkippedClasses {
             logClassInfoFailure(cls, in: machO)
@@ -1449,8 +1492,11 @@ private func collectClassInfos<T: ObjCClassProtocol>(
     options: DumpOptions,
     classInfos: inout [String: ObjCClassInfo]
 ) {
+    let readOptions = rawDumpObjCInfoOptions(for: .class)
     for cls in classes {
-        if let info = cls.info(in: machO) {
+        let result = cls.readInfo(in: machO, options: readOptions)
+        options.objcDiagnostics.append(contentsOf: result.diagnostics)
+        if let info = result.value {
             classInfos[info.name] = info
         } else if options.verbose && options.logSkippedClasses {
             logClassInfoFailure(cls, in: machO)

--- a/Sources/PrivateHeaderKitRawDumpCore/RawDumpObjCDiagnostics.swift
+++ b/Sources/PrivateHeaderKitRawDumpCore/RawDumpObjCDiagnostics.swift
@@ -1,0 +1,209 @@
+import Foundation
+@_spi(Diagnostics) import MachOObjCSection
+import PrivateHeaderKitHelperProtocol
+
+enum RawDumpObjCMetadataKind: Equatable, Sendable {
+    case `class`
+    case `protocol`
+    case category
+}
+
+enum RawDumpObjCProtocolReadPolicy: Equatable, Sendable {
+    case headerDump
+    case directProtocolNames
+}
+
+func rawDumpObjCProtocolReadPolicy(
+    for kind: RawDumpObjCMetadataKind
+) -> RawDumpObjCProtocolReadPolicy {
+    switch kind {
+    case .class, .category:
+        .headerDump
+    case .protocol:
+        .directProtocolNames
+    }
+}
+
+func rawDumpObjCInfoOptions(for kind: RawDumpObjCMetadataKind) -> ObjCInfoOptions {
+    switch rawDumpObjCProtocolReadPolicy(for: kind) {
+    case .headerDump:
+        .headerDump
+    case .directProtocolNames:
+        ObjCInfoOptions(protocolInfoOptions: .directProtocolNames)
+    }
+}
+
+func rawDumpObjCProtocolInfoOptions(
+    for kind: RawDumpObjCMetadataKind
+) -> ObjCProtocolInfoOptions {
+    switch rawDumpObjCProtocolReadPolicy(for: kind) {
+    case .headerDump, .directProtocolNames:
+        .directProtocolNames
+    }
+}
+
+final class RawDumpObjCDiagnosticsAccumulator {
+    private var retained = Set<PrivateHeaderKitRawDumpDiagnostic>()
+    private var omittedDiagnosticCount: UInt = 0
+
+    func append(contentsOf diagnostics: [ObjCProtocolDiagnostic]) {
+        for diagnostic in diagnostics {
+            let record = privateHeaderKitDiagnostic(from: diagnostic)
+            guard !retained.contains(record) else { continue }
+            guard retained.count < PrivateHeaderKitRawDumpDiagnosticsReport.maximumDiagnosticCount else {
+                omittedDiagnosticCount = omittedDiagnosticCount == UInt.max
+                    ? UInt.max
+                    : omittedDiagnosticCount + 1
+                continue
+            }
+            retained.insert(record)
+        }
+    }
+
+    var report: PrivateHeaderKitRawDumpDiagnosticsReport {
+        PrivateHeaderKitRawDumpDiagnosticsReport(
+            diagnostics: Array(retained),
+            omittedDiagnosticCount: omittedDiagnosticCount
+        )
+    }
+}
+
+func writeRawDumpDiagnosticsReport(
+    _ report: PrivateHeaderKitRawDumpDiagnosticsReport,
+    to reportURL: URL
+) throws {
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.sortedKeys]
+    let data = try encoder.encode(report)
+    guard data.count <= PrivateHeaderKitRawDumpDiagnosticsReport.maximumEncodedByteCount else {
+        throw CocoaError(.fileWriteOutOfSpace)
+    }
+    try data.write(to: reportURL, options: .atomic)
+}
+
+private func privateHeaderKitDiagnostic(
+    from diagnostic: ObjCProtocolDiagnostic
+) -> PrivateHeaderKitRawDumpDiagnostic {
+    switch diagnostic {
+    case .unreadableList(let unreadable):
+        let path = protocolPathDescription(unreadable.protocolPath)
+        return PrivateHeaderKitRawDumpDiagnostic(
+            owner: subjectDescription(unreadable.subject),
+            degradation:
+                "adopted-protocol metadata at list offset \(unreadable.listOffset)"
+                + " could not be fully read\(path): \(failureDescription(unreadable.failure))"
+        )
+    case .cycle(let cycle):
+        return PrivateHeaderKitRawDumpDiagnostic(
+            owner: subjectDescription(cycle.subject),
+            degradation:
+                "adopted-protocol traversal stopped at cycle"
+                + protocolPathDescription(cycle.protocolPath)
+        )
+    case .recursionLimit(let limit):
+        return PrivateHeaderKitRawDumpDiagnostic(
+            owner: subjectDescription(limit.subject),
+            degradation:
+                "adopted-protocol traversal stopped at the \(limit.maximumDepth)-edge safety limit"
+                + protocolPathDescription(limit.protocolPath)
+        )
+    case .invalidIdentity(let invalid):
+        return PrivateHeaderKitRawDumpDiagnostic(
+            owner: subjectDescription(invalid.subject),
+            degradation:
+                "adopted protocols were not traversed because protocol offset"
+                + " \(invalid.protocolOffset) has no stable identity"
+        )
+    }
+}
+
+private func subjectDescription(_ subject: ObjCProtocolDiagnostic.Subject) -> String {
+    switch subject {
+    case .class(let name):
+        "Objective-C class \(boundedMetadataString(name))"
+    case .protocol(let name):
+        "Objective-C protocol \(boundedMetadataString(name))"
+    case .category(let className, let name):
+        "Objective-C category \(boundedMetadataString(className))(\(boundedMetadataString(name)))"
+    }
+}
+
+private func boundedMetadataString(_ value: String) -> String {
+    PrivateHeaderKitRawDumpDiagnostic(owner: value, degradation: "unused").owner
+}
+
+private func protocolPathDescription(_ path: [String]) -> String {
+    guard !path.isEmpty else { return "" }
+    var result = " along path "
+    for name in path {
+        let safeName = boundedMetadataString(name)
+        let separator = result == " along path " ? "" : " -> "
+        guard result.utf8.count + separator.utf8.count + safeName.utf8.count
+                <= PrivateHeaderKitRawDumpDiagnostic.maximumStringUTF8Count
+        else {
+            result += " -> …"
+            break
+        }
+        result += separator + safeName
+    }
+    return result
+}
+
+private func failureDescription(
+    _ failure: ObjCProtocolDiagnostic.UnreadableList.Failure
+) -> String {
+    switch failure {
+    case .unsupportedListEncoding:
+        "list encoding is unsupported by this reader"
+    case .invalidListOffset(let offset):
+        "list offset \(offset) is not a readable nonnegative address"
+    case .invalidElementCount(let count):
+        "element count \(count) cannot be represented"
+    case .invalidSignedElementCount(let count):
+        "signed element count \(count) is negative"
+    case .excessiveElementCount(let actual, let maximum):
+        "element count \(actual) exceeds the safety limit \(maximum)"
+    case .excessiveByteCount(let actual, let maximum):
+        "table size \(actual) bytes exceeds the safety limit \(maximum)"
+    case .unresolvedListPointer:
+        "list pointer could not be rebased or canonicalized"
+    case .missingListBackingData:
+        "list pointer has no readable backing data"
+    case .unreadableFileHeader(let offset, let byteCount):
+        "file header at offset \(offset) is not readable for \(byteCount) bytes"
+    case .unreadableImageHeader(let address, let byteCount):
+        "image header at address \(address) is not readable for \(byteCount) bytes"
+    case .invalidRelativeEntrySize(let advertised, let minimum):
+        "relative entry size \(advertised) is smaller than \(minimum)"
+    case .missingRelativeImageIndex:
+        "dyld-cache image index is unavailable"
+    case .relativeEntryNotFound(let imageIndex):
+        "relative entry for cache image index \(imageIndex) was not found"
+    case .invalidRelativeListLocation:
+        "relative list location could not be mapped"
+    case .relativeImageUnavailable(let imageIndex):
+        "cache image index \(imageIndex) is unavailable"
+    case .byteCountOverflow(let elementCount, let elementSize):
+        "byte count overflowed for \(elementCount) elements of size \(elementSize)"
+    case .rangeOverflow(let startOffset, let byteCount):
+        "range overflowed from offset \(startOffset) for \(byteCount) bytes"
+    case .unreadableFileRange(let offset, let byteCount):
+        "file range at offset \(offset) is not readable for \(byteCount) bytes"
+    case .unreadableImageRange(let address, let byteCount):
+        "image range at address \(address) is not readable for \(byteCount) bytes"
+    case .unresolvedRebase(let entryIndex):
+        "entry \(entryIndex) could not be rebased"
+    case .invalidEntryOffset(let entryIndex):
+        "entry \(entryIndex) has an overflowing field offset"
+    case .invalidPointer(let entryIndex):
+        "entry \(entryIndex) does not identify a loaded protocol"
+    case .invalidIdentity(let entryIndex):
+        "entry \(entryIndex) has no stable protocol identity"
+    case .missingBackingData(let entryIndex):
+        "entry \(entryIndex) has no backing data"
+    case .unreadableFileLayout(let entryIndex, let offset, let byteCount):
+        "entry \(entryIndex) layout at file offset \(offset) is not readable for \(byteCount) bytes"
+    case .unreadableImageLayout(let entryIndex, let address, let byteCount):
+        "entry \(entryIndex) layout at image address \(address) is not readable for \(byteCount) bytes"
+    }
+}

--- a/Tests/PrivateHeaderKitCLITests/PrivateHeaderKitCLITests.swift
+++ b/Tests/PrivateHeaderKitCLITests/PrivateHeaderKitCLITests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import PrivateHeaderKitHelperProtocol
 import Testing
 
 #if canImport(Darwin)
@@ -603,6 +604,14 @@ struct PrivateHeaderKitCLIExecutionTests {
             try Data("// generated\n".utf8).write(
                 to: headerDirectory.appendingPathComponent("Generated.h")
             )
+            guard let reportIndex = command.firstIndex(of: "--diagnostics-report"),
+                  reportIndex + 1 < command.count
+            else {
+                throw ToolingError.message("raw dump command is missing its diagnostics report")
+            }
+            try Data(
+                #"{"schemaVersion":1,"diagnostics":[],"omittedDiagnosticCount":0}"#.utf8
+            ).write(to: URL(fileURLWithPath: command[reportIndex + 1]), options: .atomic)
             return StreamingCommandResult(status: 0, wasKilled: false, lastLines: [])
         }
 
@@ -662,6 +671,99 @@ struct PrivateHeaderKitCLIExecutionTests {
         #expect(result.terminationStatus == 19)
         #expect(!result.wasKilled)
         #expect(result.failureSummary == "helper-warning\nfatal-tail")
+        #expect(!FileManager.default.fileExists(atPath: invocation.diagnosticsReportURL.path))
+    }
+
+    @Test func successfulRawDumpRequiresConsumesAndReturnsDiagnosticsReport() async throws {
+        let root = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let stage = root.appendingPathComponent("stage", isDirectory: true)
+        try FileManager.default.createDirectory(at: stage, withIntermediateDirectories: true)
+        let invocation = PrivateHeaderGeneration.RawDumping.makeInvocation(
+            try .init(
+                helperURLs: .init(host: root.appendingPathComponent("helper"), simulator: root),
+                executionMode: .host,
+                inputPath: "/System/Library/Frameworks/AppKit.framework",
+                stagingOutputDirectory: stage
+            )
+        )
+        let runner = RecordingCommandRunner()
+        await runner.setStreamingHandler { command, _, _ in
+            guard let reportIndex = command.firstIndex(of: "--diagnostics-report") else {
+                throw ToolingError.message("missing diagnostics report argument")
+            }
+            try Data(
+                #"{"schemaVersion":1,"diagnostics":[{"owner":"Objective-C protocol P","degradation":"list was truncated"}],"omittedDiagnosticCount":2}"#.utf8
+            ).write(to: URL(fileURLWithPath: command[reportIndex + 1]), options: .atomic)
+            return StreamingCommandResult(status: 0, wasKilled: false, lastLines: [])
+        }
+
+        let result = try await runPrivateHeaderKitRawDump(invocation, processRunner: runner)
+
+        #expect(result.diagnostics.count == 1)
+        #expect(result.diagnostics.first?.owner == "Objective-C protocol P")
+        #expect(result.omittedDiagnosticCount == 2)
+        #expect(!FileManager.default.fileExists(atPath: invocation.diagnosticsReportURL.path))
+    }
+
+    @Test func successfulRawDumpRejectsMissingOrMalformedDiagnosticsReport() async throws {
+        let root = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let stage = root.appendingPathComponent("stage", isDirectory: true)
+        try FileManager.default.createDirectory(at: stage, withIntermediateDirectories: true)
+
+        for malformed in [false, true] {
+            let invocation = PrivateHeaderGeneration.RawDumping.makeInvocation(
+                try .init(
+                    helperURLs: .init(
+                        host: root.appendingPathComponent("helper"),
+                        simulator: root
+                    ),
+                    executionMode: .host,
+                    inputPath: "/System/Library/Frameworks/AppKit.framework",
+                    stagingOutputDirectory: stage
+                )
+            )
+            let runner = RecordingCommandRunner()
+            if malformed {
+                await runner.setStreamingHandler { _, _, _ in
+                    try Data("not-json".utf8).write(to: invocation.diagnosticsReportURL)
+                    return StreamingCommandResult(status: 0, wasKilled: false, lastLines: [])
+                }
+            }
+
+            await #expect(throws: PrivateHeaderKitRawDumpContractError.self) {
+                _ = try await runPrivateHeaderKitRawDump(invocation, processRunner: runner)
+            }
+            #expect(!FileManager.default.fileExists(atPath: invocation.diagnosticsReportURL.path))
+        }
+    }
+
+    @Test func successfulRawDumpRejectsOversizedDiagnosticsBeforeDecode() async throws {
+        let root = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let stage = root.appendingPathComponent("stage", isDirectory: true)
+        try FileManager.default.createDirectory(at: stage, withIntermediateDirectories: true)
+        let invocation = PrivateHeaderGeneration.RawDumping.makeInvocation(
+            try .init(
+                helperURLs: .init(host: root.appendingPathComponent("helper"), simulator: root),
+                executionMode: .host,
+                inputPath: "/System/Library/Frameworks/AppKit.framework",
+                stagingOutputDirectory: stage
+            )
+        )
+        let runner = RecordingCommandRunner()
+        await runner.setStreamingHandler { _, _, _ in
+            try Data(
+                count: PrivateHeaderKitRawDumpDiagnosticsReport.maximumEncodedByteCount + 1
+            ).write(to: invocation.diagnosticsReportURL)
+            return StreamingCommandResult(status: 0, wasKilled: false, lastLines: [])
+        }
+
+        await #expect(throws: PrivateHeaderKitRawDumpContractError.self) {
+            _ = try await runPrivateHeaderKitRawDump(invocation, processRunner: runner)
+        }
+        #expect(!FileManager.default.fileExists(atPath: invocation.diagnosticsReportURL.path))
     }
 
     @Test func signalCoordinatorWaitsForOperationCleanupBeforeReturningSignalStatus() async {
@@ -1716,7 +1818,13 @@ private struct BufferedRawDumpProbeRunner: CommandRunning {
         env: [String: String]?,
         cwd: URL?
     ) async throws -> StreamingCommandResult {
-        StreamingCommandResult(
+        if let reportIndex = command.firstIndex(of: "--diagnostics-report") {
+            try Data("not-json".utf8).write(
+                to: URL(fileURLWithPath: command[reportIndex + 1]),
+                options: .atomic
+            )
+        }
+        return StreamingCommandResult(
             status: 19,
             wasKilled: false,
             lastLines: ["helper-warning", "fatal-tail"]

--- a/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationExecutorTests.swift
+++ b/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationExecutorTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import GRDB
 import PrivateHeaderKitHelperProtocol
 import Testing
 
@@ -264,6 +265,252 @@ struct PrivateHeaderGenerationExecutorTests {
     #expect(
       try await store.targetSnapshot(targetID: "framework:Foo.framework")?.lastSuccessfulRunID
         == result.runID)
+  }
+
+  @Test func successfulTargetPublishesAndPersistsObjectiveCMetadataWarnings() async throws {
+    let fixture = try ExecutorFixture()
+    defer { fixture.cleanup() }
+    try fixture.createFramework("Foo.framework")
+    let rawResult = PrivateHeaderGeneration.RawDumping.Result(
+      terminationStatus: 0,
+      diagnostics: [
+        .init(owner: "Objective-C protocol Z", degradation: "cycle was cut"),
+        .init(owner: "Objective-C class A", degradation: "list entry was unreadable"),
+        .init(owner: "Objective-C protocol Z", degradation: "cycle was cut"),
+      ],
+      omittedDiagnosticCount: 2
+    )
+    let executor = fixture.executor(
+      runner: RecordingRunner(contents: "generated", result: rawResult),
+      runID: "run-objc-warning",
+      generationID: "generation-objc-warning"
+    )
+
+    let result = try await executor.run(plan: try fixture.plan(.query("Foo")))
+
+    #expect(result.targetCounts.completed == 1)
+    #expect(result.warnings.count == 3)
+    #expect(result.warnings.allSatisfy { $0.kind == "objc-metadata-warning" })
+    #expect(result.warnings.map(\.message) == result.warnings.map(\.message).sorted())
+    #expect(try fixture.readLiveHeader() == "generated")
+    let persisted = try DatabaseQueue(path: fixture.databaseURL.path).read { db in
+      try Row.fetchAll(
+        db,
+        sql: "SELECT kind, relativePath, message FROM runLogs WHERE runID = ? ORDER BY message",
+        arguments: [result.runID.rawValue]
+      )
+    }
+    #expect(persisted.count == result.warnings.count)
+    #expect(persisted.map { $0["kind"] as String } == result.warnings.map(\.kind))
+    #expect(persisted.map { $0["message"] as String } == result.warnings.map(\.message))
+  }
+
+  @Test func failedTargetDoesNotPublishOrPersistObjectiveCMetadataWarnings() async throws {
+    let fixture = try ExecutorFixture()
+    defer { fixture.cleanup() }
+    try fixture.createFramework("Foo.framework")
+    let executor = fixture.executor(
+      runner: RecordingRunner(
+        contents: "partial",
+        result: .init(
+          terminationStatus: 1,
+          failureSummary: "helper failed",
+          diagnostics: [
+            .init(owner: "Objective-C class A", degradation: "list entry was unreadable")
+          ]
+        )
+      ),
+      runID: "run-objc-failure",
+      generationID: "generation-objc-failure"
+    )
+
+    await #expect(throws: PrivateHeaderGeneration.GenerationError.self) {
+      _ = try await executor.run(plan: try fixture.plan(.query("Foo")))
+    }
+
+    #expect(!FileManager.default.fileExists(atPath: fixture.liveHeaderURL(framework: "Foo").path))
+    let persistedCount = try await DatabaseQueue(path: fixture.databaseURL.path).read { db in
+      try Int.fetchOne(
+        db,
+        sql: "SELECT COUNT(*) FROM runLogs WHERE kind = 'objc-metadata-warning'"
+      ) ?? 0
+    }
+    #expect(persistedCount == 0)
+  }
+
+  @Test func objectiveCMetadataWarningPresentationIsBoundedAcrossTheRun() async throws {
+    let fixture = try ExecutorFixture()
+    defer { fixture.cleanup() }
+    try fixture.createFramework("Foo.framework")
+    try fixture.createFramework("Bar.framework")
+    let diagnosticCountPerTarget = 200
+    let diagnostics = (0..<diagnosticCountPerTarget).map { index in
+      PrivateHeaderKitRawDumpDiagnostic(
+        owner: "Objective-C protocol P\(String(format: "%03d", index))",
+        degradation: "cycle was cut"
+      )
+    }
+    let runner = RecordingRunner(
+      contents: "generated",
+      result: .init(
+        terminationStatus: 0,
+        diagnostics: diagnostics,
+        omittedDiagnosticCount: 3
+      )
+    )
+    let progress = ExecutorProgressRecorder()
+    let result = try await fixture.executor(
+      runner: runner,
+      runID: "run-objc-budget",
+      generationID: "generation-objc-budget"
+    ).run(
+      plan: try fixture.plan(
+        .identifiers(["framework:Foo.framework", "framework:Bar.framework"])
+      ),
+      progressReporter: { progress.record($0) }
+    )
+
+    let maximumPresented =
+      PrivateHeaderGeneration.GenerationExecutor.maximumPresentedObjCMetadataWarningCount
+    #expect(result.targetCounts.completed == 2)
+    #expect(result.warnings.count == maximumPresented + 1)
+    let aggregate = try #require(result.warnings.last)
+    #expect(aggregate.relativePath == "generation.sqlite")
+    #expect(
+      aggregate.message.contains(
+        "\(diagnosticCountPerTarget * 2 + 2 - maximumPresented) additional"
+      )
+    )
+    let liveWarnings: [PrivateHeaderGeneration.GenerationWarning] =
+      progress.events.compactMap { event in
+      guard case .warning(let warning) = event else { return nil }
+      return warning
+    }
+    #expect(liveWarnings == result.warnings)
+
+    let persistedCount = try await DatabaseQueue(path: fixture.databaseURL.path).read { db in
+      try Int.fetchOne(
+        db,
+        sql: "SELECT COUNT(*) FROM runLogs WHERE kind = 'objc-metadata-warning'"
+      ) ?? 0
+    }
+    #expect(persistedCount == diagnosticCountPerTarget * 2 + 2 + 1)
+  }
+
+  @Test func objectiveCWarningPersistenceFaultRollsBackTargetAndLiveReplacement() async throws {
+    let fixture = try ExecutorFixture()
+    defer { fixture.cleanup() }
+    try fixture.createFramework("Foo.framework")
+    let executor = fixture.executor(
+      runner: RecordingRunner(
+        contents: "generated",
+        result: .init(
+          terminationStatus: 0,
+          diagnostics: [
+            .init(owner: "Objective-C class A", degradation: "list entry was unreadable")
+          ]
+        )
+      ),
+      runID: "run-objc-warning-fault",
+      generationID: "generation-objc-warning-fault",
+      storeFaultInjector: { point in
+        if point == .beforeRunLogWrite { throw InjectedFault.stop }
+      }
+    )
+
+    await #expect(throws: InjectedFault.self) {
+      _ = try await executor.run(plan: try fixture.plan(.query("Foo")))
+    }
+
+    #expect(!FileManager.default.fileExists(atPath: fixture.liveHeaderURL(framework: "Foo").path))
+    let store = try GenerationStore(
+      databaseURL: fixture.databaseURL,
+      toolCompatibilityIdentity: "test"
+    )
+    let snapshot = try await store.runSnapshot(.init(rawValue: "run-objc-warning-fault"))
+    #expect(snapshot.status == .running)
+    #expect(snapshot.targets.first?.status == .running)
+    let persistedCount = try await DatabaseQueue(path: fixture.databaseURL.path).read { db in
+      try Int.fetchOne(
+        db,
+        sql: "SELECT COUNT(*) FROM runLogs WHERE kind = 'objc-metadata-warning'"
+      ) ?? 0
+    }
+    #expect(persistedCount == 0)
+  }
+
+  @Test func infrastructureFailureKeepsObjectiveCWarningPresentationBoundedAndAggregated()
+    async throws
+  {
+    let fixture = try ExecutorFixture()
+    defer { fixture.cleanup() }
+    for framework in ["Alpha.framework", "Beta.framework", "Zeta.framework"] {
+      try fixture.createFramework(framework)
+    }
+    let diagnosticCountPerCompletedTarget = 200
+    let diagnostics = (0..<diagnosticCountPerCompletedTarget).map { index in
+      PrivateHeaderKitRawDumpDiagnostic(
+        owner: "Objective-C protocol P\(String(format: "%03d", index))",
+        degradation: "cycle was cut"
+      )
+    }
+    let progress = ExecutorProgressRecorder()
+    let executor = fixture.executor(
+      runner: RecordingRunner(
+        contents: "generated",
+        result: .init(terminationStatus: 0, diagnostics: diagnostics),
+        hiddenPayloadFramework: "Zeta.framework"
+      ),
+      runID: "run-objc-budget-failure",
+      generationID: "generation-objc-budget-failure"
+    )
+
+    let summary: PrivateHeaderGeneration.RunSummary
+    do {
+      _ = try await executor.run(
+        plan: try fixture.plan(
+          .identifiers([
+            "framework:Alpha.framework",
+            "framework:Beta.framework",
+            "framework:Zeta.framework",
+          ])
+        ),
+        progressReporter: { progress.record($0) }
+      )
+      Issue.record("hidden raw payload unexpectedly completed")
+      return
+    } catch let PrivateHeaderGeneration.GenerationError.infrastructureFailed(failure) {
+      summary = failure.summary
+    }
+
+    let maximumPresented =
+      PrivateHeaderGeneration.GenerationExecutor.maximumPresentedObjCMetadataWarningCount
+    #expect(summary.warnings.count == maximumPresented + 1)
+    #expect(
+      summary.warnings.last?.message.contains(
+        "\(diagnosticCountPerCompletedTarget * 2 - maximumPresented) additional"
+      ) == true
+    )
+    let liveWarnings: [PrivateHeaderGeneration.GenerationWarning] =
+      progress.events.compactMap { event in
+      guard case .warning(let warning) = event else { return nil }
+      return warning
+    }
+    #expect(liveWarnings == summary.warnings)
+    #expect(try fixture.readLiveHeader(framework: "Alpha") == "generated")
+    #expect(try fixture.readLiveHeader(framework: "Beta") == "generated")
+    #expect(
+      !FileManager.default.fileExists(
+        atPath: fixture.liveHeaderURL(framework: "Zeta").path
+      )
+    )
+    let persistedCount = try await DatabaseQueue(path: fixture.databaseURL.path).read { db in
+      try Int.fetchOne(
+        db,
+        sql: "SELECT COUNT(*) FROM runLogs WHERE kind = 'objc-metadata-warning'"
+      ) ?? 0
+    }
+    #expect(persistedCount == diagnosticCountPerCompletedTarget * 2 + 1)
   }
 
   @Test func completedTargetIsVisibleWhenItsFinishedEventIsReported() async throws {

--- a/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationRawDumpingTests.swift
+++ b/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationRawDumpingTests.swift
@@ -26,10 +26,15 @@ struct PrivateHeaderGenerationRawDumpingTests {
 
     #expect(invocation.helperURL == helperURLs.host)
     #expect(
+      invocation.diagnosticsReportURL.deletingLastPathComponent()
+        == stageDirectory.deletingLastPathComponent()
+    )
+    #expect(
       invocation.command == [
         "/opt/privateheaderkit/bin/privateheaderkit", "__raw-dump", "-o", stageDirectory.path,
         "-b", "-h", "-s", "-c", "--expected-cache-uuid",
-        cacheUUID.uuidString.lowercased(), "-D", "-R",
+        cacheUUID.uuidString.lowercased(), "-D", "-R", "--diagnostics-report",
+        invocation.diagnosticsReportURL.path,
         "/System/Library/PrivateFrameworks/Foo.framework",
       ])
     #expect(invocation.environment == ["PH_PROFILE": "1"])
@@ -58,6 +63,7 @@ struct PrivateHeaderGenerationRawDumpingTests {
       invocation.command == [
         "xcrun", "simctl", "spawn", "SIM-001", "/opt/privateheaderkit/bin/privateheaderkit-sim",
         "__raw-dump", "-o", stageDirectory.path, "-b", "-h",
+        "--diagnostics-report", invocation.diagnosticsReportURL.path,
         "/System/Library/Frameworks/UIKit.framework",
       ])
     #expect(

--- a/Tests/PrivateHeaderKitHelperProtocolTests/PrivateHeaderKitHelperProtocolTests.swift
+++ b/Tests/PrivateHeaderKitHelperProtocolTests/PrivateHeaderKitHelperProtocolTests.swift
@@ -5,6 +5,174 @@ import Testing
 
 @Suite
 struct PrivateHeaderKitHelperProtocolTests {
+    @Test func rawDumpDiagnosticsZeroReportRoundTrips() throws {
+        let report = PrivateHeaderKitRawDumpDiagnosticsReport(diagnostics: [])
+        let data = try JSONEncoder().encode(report)
+        let decoded = try JSONDecoder().decode(
+            PrivateHeaderKitRawDumpDiagnosticsReport.self,
+            from: data
+        )
+
+        #expect(decoded.schemaVersion == 1)
+        #expect(decoded.diagnostics.isEmpty)
+        #expect(decoded.omittedDiagnosticCount == 0)
+    }
+
+    @Test func rawDumpDiagnosticsSortsDeduplicatesAndCapsRecords() {
+        let diagnostics = (0...PrivateHeaderKitRawDumpDiagnosticsReport.maximumDiagnosticCount)
+            .reversed()
+            .map {
+                PrivateHeaderKitRawDumpDiagnostic(
+                    owner: "owner-\(String(format: "%03d", $0))",
+                    degradation: "degraded"
+                )
+            }
+        let report = PrivateHeaderKitRawDumpDiagnosticsReport(
+            diagnostics: diagnostics + [diagnostics[0]],
+            omittedDiagnosticCount: 2
+        )
+
+        #expect(
+            report.diagnostics.count
+                == PrivateHeaderKitRawDumpDiagnosticsReport.maximumDiagnosticCount
+        )
+        #expect(report.diagnostics.first?.owner == "owner-000")
+        #expect(report.diagnostics.last?.owner == "owner-255")
+        #expect(report.omittedDiagnosticCount == 3)
+    }
+
+    @Test func rawDumpDiagnosticsVisiblyEscapesControlAndFormatScalars() throws {
+        let diagnostic = PrivateHeaderKitRawDumpDiagnostic(
+            owner: "line\nowner\u{061c}",
+            degradation: "tab\tvalue"
+        )
+
+        #expect(diagnostic.owner == #"line\nowner\u{061c}"#)
+        #expect(diagnostic.degradation == #"tab\tvalue"#)
+        let decoded = try JSONDecoder().decode(
+            PrivateHeaderKitRawDumpDiagnosticsReport.self,
+            from: JSONEncoder().encode(
+                PrivateHeaderKitRawDumpDiagnosticsReport(diagnostics: [diagnostic])
+            )
+        )
+        #expect(decoded.diagnostics == [diagnostic])
+    }
+
+    @Test func escapeHeavyMaximumReportFitsEncodedContract() throws {
+        let field = String(repeating: #"\"#, count: 2_048)
+        let diagnostics = (0..<PrivateHeaderKitRawDumpDiagnosticsReport.maximumDiagnosticCount)
+            .map { index in
+                PrivateHeaderKitRawDumpDiagnostic(
+                    owner: field,
+                    degradation: "\(index)-\(field)"
+                )
+            }
+        let data = try JSONEncoder().encode(
+            PrivateHeaderKitRawDumpDiagnosticsReport(diagnostics: diagnostics)
+        )
+
+        #expect(data.count <= PrivateHeaderKitRawDumpDiagnosticsReport.maximumEncodedByteCount)
+    }
+
+    @Test func rawDumpDiagnosticsRejectsWrongVersionMalformedAndNoncanonicalPayloads() {
+        let payloads = [
+            #"{"schemaVersion":2,"diagnostics":[],"omittedDiagnosticCount":0}"#,
+            "not-json",
+            #"{"schemaVersion":1,"diagnostics":[{"owner":"b","degradation":"x"},{"owner":"a","degradation":"x"}],"omittedDiagnosticCount":0}"#,
+            #"{"schemaVersion":1,"diagnostics":[{"owner":"line\nowner","degradation":"x"}],"omittedDiagnosticCount":0}"#,
+            #"{"schemaVersion":1,"diagnostics":[],"omittedDiagnosticCount":-1}"#,
+        ]
+
+        for payload in payloads {
+            #expect(throws: (any Error).self) {
+                _ = try JSONDecoder().decode(
+                    PrivateHeaderKitRawDumpDiagnosticsReport.self,
+                    from: Data(payload.utf8)
+                )
+            }
+        }
+    }
+
+    @Test func rawDumpDiagnosticsDecoderRejectsExcessiveRecordCount() throws {
+        let records = (0...PrivateHeaderKitRawDumpDiagnosticsReport.maximumDiagnosticCount)
+            .map { index in
+                "{\"owner\":\"owner-\(String(format: "%03d", index))\",\"degradation\":\"x\"}"
+            }
+            .joined(separator: ",")
+        let data = Data(
+            """
+            {"schemaVersion":1,"diagnostics":[\(records)],"omittedDiagnosticCount":0}
+            """.utf8
+        )
+
+        #expect(throws: PrivateHeaderKitRawDumpDiagnosticsReport.ValidationError.self) {
+            _ = try JSONDecoder().decode(
+                PrivateHeaderKitRawDumpDiagnosticsReport.self,
+                from: data
+            )
+        }
+    }
+
+    @Test func rawDumpDiagnosticsDecoderRejectsNegativeOmittedCount() {
+        let data = Data(
+            #"{"schemaVersion":1,"diagnostics":[],"omittedDiagnosticCount":-1}"#.utf8
+        )
+
+        #expect(throws: DecodingError.self) {
+            _ = try JSONDecoder().decode(
+                PrivateHeaderKitRawDumpDiagnosticsReport.self,
+                from: data
+            )
+        }
+    }
+
+    @Test func rawDumpDiagnosticsOmittedCountSaturates() {
+        let report = PrivateHeaderKitRawDumpDiagnosticsReport(
+            diagnostics: (0...PrivateHeaderKitRawDumpDiagnosticsReport.maximumDiagnosticCount).map { index in
+                PrivateHeaderKitRawDumpDiagnostic(owner: "\(index)", degradation: "x")
+            },
+            omittedDiagnosticCount: UInt.max
+        )
+
+        #expect(report.omittedDiagnosticCount == UInt.max)
+    }
+
+    @Test func resolvedGraphPinsObjectiveCReaderForkExactly() throws {
+        let packageRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let data = try Data(
+            contentsOf: packageRoot.appendingPathComponent("Package.resolved")
+        )
+        let document = try #require(
+            JSONSerialization.jsonObject(with: data) as? [String: Any]
+        )
+        let pins = try #require(document["pins"] as? [[String: Any]])
+        let pin = try #require(pins.first { $0["identity"] as? String == "machoobjcsection" })
+        let state = try #require(pin["state"] as? [String: Any])
+
+        #expect(pin["location"] as? String == "https://github.com/lynnswap/MachOObjCSection.git")
+        #expect(state["revision"] as? String == "7d159a0216565edae417bf40716dd447bf295e7b")
+        #expect(state["version"] == nil)
+
+        let swiftSectionPin = try #require(
+            pins.first { $0["identity"] as? String == "machoswiftsection" }
+        )
+        let swiftSectionState = try #require(
+            swiftSectionPin["state"] as? [String: Any]
+        )
+        #expect(
+            swiftSectionPin["location"] as? String
+                == "https://github.com/lynnswap/MachOSwiftSection.git"
+        )
+        #expect(
+            swiftSectionState["revision"] as? String
+                == "030963e9f69118f4c4b22a41a90a03cc51a79833"
+        )
+        #expect(swiftSectionState["version"] == nil)
+    }
+
     @Test func inventoryNormalizesImagePathMembershipAndRoundTrips() throws {
         let cacheUUID = UUID(uuidString: "11111111-2222-3333-4444-555555555555")!
         let inventory = try PrivateHeaderKitSharedCacheInventory(

--- a/Tests/PrivateHeaderKitRawDumpTests/PrivateHeaderKitRawDumpTests.swift
+++ b/Tests/PrivateHeaderKitRawDumpTests/PrivateHeaderKitRawDumpTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import MachOKit
+@_spi(Core) @_spi(Diagnostics) @testable import MachOObjCSection
 import PrivateHeaderKitHelperProtocol
 import Testing
 #if canImport(PrivateHeaderKitRawDumpRuntimeObjC)
@@ -42,6 +43,7 @@ struct PrivateHeaderKitRawDumpArgumentTests {
             "--expected-cache-uuid", "11111111-2222-3333-4444-555555555555",
             "-D",
             "-R",
+            "--diagnostics-report", "/tmp/report.json",
             "/tmp/input"
         ]
 
@@ -59,6 +61,7 @@ struct PrivateHeaderKitRawDumpArgumentTests {
         #expect(parsed?.options.expectedCacheUUID == UUID(uuidString: "11111111-2222-3333-4444-555555555555"))
         #expect(parsed?.options.verbose == true)
         #expect(parsed?.options.useRuntimeFallback == true)
+        #expect(parsed?.options.diagnosticsReportURL?.path == "/tmp/report.json")
     }
 
     @Test func parseArgumentsIgnoresUnknownFlags() {
@@ -102,6 +105,154 @@ struct PrivateHeaderKitRawDumpArgumentTests {
         #expect(didPrint == true)
     }
 }
+
+@Suite
+struct PrivateHeaderKitRawDumpObjCPolicyTests {
+    @Test func headerOwnersUseBoundedDirectProtocolNames() {
+        #expect(rawDumpObjCProtocolReadPolicy(for: .class) == .headerDump)
+        #expect(rawDumpObjCProtocolReadPolicy(for: .category) == .headerDump)
+        assertDirectProtocolNames(rawDumpObjCInfoOptions(for: .class).protocolInfoOptions)
+        assertDirectProtocolNames(rawDumpObjCInfoOptions(for: .category).protocolInfoOptions)
+    }
+
+    @Test func topLevelProtocolsUseBoundedDirectProtocolNames() {
+        #expect(rawDumpObjCProtocolReadPolicy(for: .protocol) == .directProtocolNames)
+        assertDirectProtocolNames(rawDumpObjCProtocolInfoOptions(for: .protocol))
+    }
+
+    @Test func typedDiagnosticsAreBoundedFormattedAndWrittenThroughTheWireCodec() throws {
+#if canImport(Darwin)
+        let fixture = try InvalidIdentityProtocolFixture(count: 257)
+        let accumulator = RawDumpObjCDiagnosticsAccumulator()
+        for objcProtocol in fixture.protocols {
+            accumulator.append(contentsOf: objcProtocol.readInfo(in: fixture.machO).diagnostics)
+        }
+        let report = accumulator.report
+        #expect(
+            report.diagnostics.count
+                == PrivateHeaderKitRawDumpDiagnosticsReport.maximumDiagnosticCount
+        )
+        #expect(report.omittedDiagnosticCount == 1)
+        #expect(report.diagnostics.allSatisfy { $0.owner.hasPrefix("Objective-C protocol") })
+        #expect(
+            report.diagnostics.allSatisfy {
+                $0.degradation.contains("has no stable identity")
+            }
+        )
+
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "PrivateHeaderKitRawDumpDiagnosticTests-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let reportURL = root.appendingPathComponent("diagnostics.json")
+        try writeRawDumpDiagnosticsReport(report, to: reportURL)
+        let decoded = try JSONDecoder().decode(
+            PrivateHeaderKitRawDumpDiagnosticsReport.self,
+            from: Data(contentsOf: reportURL)
+        )
+        #expect(decoded == report)
+#endif
+    }
+
+    private func assertDirectProtocolNames(_ options: ObjCProtocolInfoOptions) {
+        switch options.traversal {
+        case .depth(let depth):
+            #expect(depth == 1)
+        case .recursive:
+            Issue.record("raw header dumping must not recursively expand adopted protocols")
+        }
+        switch options.referencedProtocolInfo {
+        case .nameOnly:
+            break
+        case .full:
+            Issue.record("raw header dumping only needs adopted protocol names")
+        }
+    }
+}
+
+#if canImport(Darwin)
+private final class InvalidIdentityProtocolFixture {
+    let machO: MachOFile
+    let protocols: [ObjCProtocol64]
+    private let url: URL
+
+    init(count: Int) throws {
+        let fileSize = 0x20_000
+        let vmAddress: UInt64 = 0x1_0000_0000
+        let nameBaseOffset = 0x1_000
+        let nameStride = 0x40
+        var data = Data(count: fileSize)
+
+        var header = mach_header_64()
+        header.magic = UInt32(MH_MAGIC_64)
+        header.cputype = CPU_TYPE_ARM64
+        header.cpusubtype = CPU_SUBTYPE_ARM64_ALL
+        header.filetype = UInt32(MH_DYLIB)
+        header.ncmds = 1
+        header.sizeofcmds = UInt32(MemoryLayout<segment_command_64>.size)
+        data.storeValue(header, at: 0)
+
+        var segment = segment_command_64()
+        segment.cmd = UInt32(LC_SEGMENT_64)
+        segment.cmdsize = UInt32(MemoryLayout<segment_command_64>.size)
+        segment.vmaddr = vmAddress
+        segment.vmsize = UInt64(fileSize)
+        segment.filesize = UInt64(fileSize)
+        segment.maxprot = VM_PROT_READ
+        segment.initprot = VM_PROT_READ
+        data.storeValue(segment, at: MemoryLayout<mach_header_64>.size)
+
+        var protocols: [ObjCProtocol64] = []
+        protocols.reserveCapacity(count)
+        for index in 0..<count {
+            let nameOffset = nameBaseOffset + index * nameStride
+            data.storeCString("P\(String(format: "%03d", index))", at: nameOffset)
+            let layout = ObjCProtocol64.Layout(
+                isa: 0,
+                mangledName: vmAddress + UInt64(nameOffset),
+                protocols: 0,
+                instanceMethods: 0,
+                classMethods: 0,
+                optionalInstanceMethods: 0,
+                optionalClassMethods: 0,
+                instanceProperties: 0,
+                size: UInt32(MemoryLayout<ObjCProtocol64.Layout>.size),
+                flags: 0,
+                _extendedMethodTypes: 0,
+                _demangledName: 0,
+                _classProperties: 0
+            )
+            protocols.append(ObjCProtocol64(layout: layout, offset: -(index + 1)))
+        }
+
+        url = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "PrivateHeaderKitInvalidIdentityProtocol-\(UUID().uuidString)"
+        )
+        try data.write(to: url)
+        machO = try MachOFile(url: url)
+        self.protocols = protocols
+    }
+
+    deinit {
+        try? FileManager.default.removeItem(at: url)
+    }
+}
+
+private extension Data {
+    mutating func storeValue<Value>(_ value: Value, at offset: Int) {
+        Swift.withUnsafeBytes(of: value) { bytes in
+            replaceSubrange(offset..<(offset + bytes.count), with: bytes)
+        }
+    }
+
+    mutating func storeCString(_ value: String, at offset: Int) {
+        let bytes = Array(value.utf8) + [0]
+        replaceSubrange(offset..<(offset + bytes.count), with: bytes)
+    }
+}
+#endif
 
 @Suite
 struct PrivateHeaderKitRawDumpEnvironmentTests {


### PR DESCRIPTION
## Purpose

Prevent malformed or cyclic Objective-C protocol metadata from terminating iOS 27 header generation. Closes #54.

## Changes

- Pin the protocol-reader fix from `lynnswap/MachOObjCSection@7d159a0` and the matching PrivateHeaderKit-only `MachOSwiftSection@030963e9` dependency cohort.
- Replace recursive header-generation reads with bounded `.headerDump` / `.directProtocolNames` policies while preserving partial class, category, and protocol metadata.
- Add checked protocol-list reads, path-scoped cycle detection, and a hard traversal ceiling in the forked parser.
- Carry typed parser degradations through a versioned, size-bounded helper sidecar.
- Persist per-target `objc-metadata-warning` rows atomically with successful publication, while bounding live run output and reporting omitted details.
- Document the generation behavior and the temporary fork cohort.

The fork branches are intentionally temporary and have no upstream PR. Keep them available until equivalent official releases exist, then return both package URLs and requirements to the official release cohort.

## Testing

- `swift test`: 488 tests / 41 suites passed.
- iOS Simulator compile: `PrivateHeaderKitCore` and `PrivateHeaderKitCoreTests` passed.
- Release `privateheaderkit-raw-helper` build passed.
- `swift package show-dependencies --format json`: warning-free; both exact fork SHAs resolved.
- MachOObjCSection safety suite: 31 tests passed; non-baseline suite total 66 passed; release, iOS Simulator, and watchOS/arm64_32 builds passed.
- MachOSwiftSection: 1,359 tests / 253 suites passed.
- Isolated iOS 27.0 (24A5390f) smoke:
  - MatterSupport: completed; headers published; one persisted metadata warning.
  - MetricKit: completed; headers published; one persisted metadata warning.
  - SensorKit public and private framework selections: six targets each completed; headers published; 55 bounded warnings persisted in each run.
  - No helper signal termination and no diagnostics sidecar residue.
- `git diff --check` passed.
- Base-`main` codex-review completed with zero findings.

## Screenshots

Not applicable.