### PR TITLE
Group interactive sources by platform

### DIFF
--- a/Sources/PrivateHeaderKitCLI/PrivateHeaderKitInteractive.swift
+++ b/Sources/PrivateHeaderKitCLI/PrivateHeaderKitInteractive.swift
@@ -18,9 +18,12 @@ struct PrivateHeaderKitInteractiveSource: Equatable, Sendable {
     let build: String?
     let systemRoot: String?
 
+    var versionAndBuildDisplayName: String {
+        build.map { "\(version) (\($0))" } ?? version
+    }
+
     var displayName: String {
-        let base = "\(platform.rawValue) \(version)"
-        return build.map { "\(base) (\($0))" } ?? base
+        "\(platform.rawValue) \(versionAndBuildDisplayName)"
     }
 }
 
@@ -308,8 +311,14 @@ private func renderInteractiveSourceScreen(
     outputLogger("Generate private headers from an installed runtime or this Mac.")
     outputLogger("")
     outputLogger("Step 1 of 3: Source")
+    var previousPlatform: PrivateHeaderKitGenerateCommand.Platform?
     for (index, source) in sources.enumerated() {
-        outputLogger("  [\(index + 1)] \(source.displayName)")
+        if source.platform != previousPlatform {
+            outputLogger("")
+            outputLogger(source.platform.rawValue)
+            previousPlatform = source.platform
+        }
+        outputLogger("  [\(index + 1)] \(source.versionAndBuildDisplayName)")
     }
     outputLogger("")
     outputLogger("Press Escape to cancel.")

--- a/Tests/PrivateHeaderKitCLITests/PrivateHeaderKitCLITests.swift
+++ b/Tests/PrivateHeaderKitCLITests/PrivateHeaderKitCLITests.swift
@@ -957,6 +957,70 @@ struct PrivateHeaderKitCLIExecutionTests {
         #expect(status == 130)
     }
 
+    @Test func interactiveSourceScreenGroupsSourcesByPlatform() async {
+        let input = ScriptedInput(["\u{001B}"])
+        let output = ThreadSafeStrings()
+
+        let status = await runPrivateHeaderKitCommand(
+            ["privateheaderkit"],
+            currentExecutableURL: URL(fileURLWithPath: "/cohort/privateheaderkit"),
+            interactiveSourceProvider: {
+                [
+                    PrivateHeaderKitInteractiveSource(
+                        platform: .iOS,
+                        version: "18.0",
+                        build: "22A3351",
+                        systemRoot: nil
+                    ),
+                    PrivateHeaderKitInteractiveSource(
+                        platform: .iOS,
+                        version: "27.0",
+                        build: "24A5390f",
+                        systemRoot: nil
+                    ),
+                    PrivateHeaderKitInteractiveSource(
+                        platform: .watchOS,
+                        version: "27.0",
+                        build: "24R5325f",
+                        systemRoot: nil
+                    ),
+                    PrivateHeaderKitInteractiveSource(
+                        platform: .macOS,
+                        version: "26.6.1",
+                        build: "25G76",
+                        systemRoot: "/"
+                    ),
+                ]
+            },
+            interactiveScreenClearer: {},
+            inputReader: { try await input.readLine() },
+            outputLogger: output.append,
+            errorLogger: output.append
+        )
+
+        #expect(status == 1)
+        #expect(output.text == """
+            PrivateHeaderKit
+            Generate private headers from an installed runtime or this Mac.
+
+            Step 1 of 3: Source
+
+            iOS
+              [1] 18.0 (22A3351)
+              [2] 27.0 (24A5390f)
+
+            watchOS
+              [3] 27.0 (24R5325f)
+
+            macOS
+              [4] 26.6.1 (25G76)
+
+            Press Escape to cancel.
+            Select source:
+            Cancelled.
+            """)
+    }
+
     @Test func interactiveRunUsesOneScriptedActorAndFreshCoreDecision() async throws {
         let root = try temporaryDirectory()
         defer { try? FileManager.default.removeItem(at: root) }


### PR DESCRIPTION
## Purpose

Make the interactive source picker easier to scan by separating installed sources into platform sections.

## Changes

- Add iOS, watchOS, and macOS section headings to the Step 1 source screen.
- Keep one global selection index across sections.
- Keep full platform-qualified source labels on subsequent screens.
- Add an exact-output regression test for the grouped source picker.

## Validation

- `swift test --filter PrivateHeaderKitCLIExecutionTests.interactiveSourceScreenGroupsSourcesByPlatform`
- `swift test` (505 tests in 40 suites)
- `git diff --check`
- `codex-review` against `main`: clean, 0 findings