### PR TITLE
Recover watchOS canonical Objective-C protocol conformances

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "b5d21bf8cc51affcac549b040c61d57f99923f497defea5b65257319b20283c4",
+  "originHash" : "4e40eaf21e28cc816e3fd5e679657c20bc72ecbaa5c4c9f5936661ec56f96f49",
   "pins" : [
     {
       "identity" : "associatedobject",
@@ -60,7 +60,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/lynnswap/MachOObjCSection.git",
       "state" : {
-        "revision" : "7d159a0216565edae417bf40716dd447bf295e7b"
+        "revision" : "ecc84fb790509fb71f4c1f0bd2fb6e4bac6069df"
       }
     },
     {
@@ -68,7 +68,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/lynnswap/MachOSwiftSection.git",
       "state" : {
-        "revision" : "030963e9f69118f4c4b22a41a90a03cc51a79833"
+        "revision" : "a198b44edbd0630fd931e3583cdac7d962ea39ae"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -37,7 +37,7 @@ let package = Package(
         ),
         .package(
             url: "https://github.com/lynnswap/MachOObjCSection.git",
-            revision: "7d159a0216565edae417bf40716dd447bf295e7b"
+            revision: "ecc84fb790509fb71f4c1f0bd2fb6e4bac6069df"
         ),
         .package(
             url: "https://github.com/MxIris-Reverse-Engineering/swift-objc-dump.git",
@@ -45,7 +45,7 @@ let package = Package(
         ),
         .package(
             url: "https://github.com/lynnswap/MachOSwiftSection.git",
-            revision: "030963e9f69118f4c4b22a41a90a03cc51a79833"
+            revision: "a198b44edbd0630fd931e3583cdac7d962ea39ae"
         ),
         .package(
             url: "https://github.com/MxIris-Reverse-Engineering/swift-demangling",

--- a/Tests/PrivateHeaderKitHelperProtocolTests/PrivateHeaderKitHelperProtocolTests.swift
+++ b/Tests/PrivateHeaderKitHelperProtocolTests/PrivateHeaderKitHelperProtocolTests.swift
@@ -153,7 +153,7 @@ struct PrivateHeaderKitHelperProtocolTests {
         let state = try #require(pin["state"] as? [String: Any])
 
         #expect(pin["location"] as? String == "https://github.com/lynnswap/MachOObjCSection.git")
-        #expect(state["revision"] as? String == "7d159a0216565edae417bf40716dd447bf295e7b")
+        #expect(state["revision"] as? String == "ecc84fb790509fb71f4c1f0bd2fb6e4bac6069df")
         #expect(state["version"] == nil)
 
         let swiftSectionPin = try #require(
@@ -168,7 +168,7 @@ struct PrivateHeaderKitHelperProtocolTests {
         )
         #expect(
             swiftSectionState["revision"] as? String
-                == "030963e9f69118f4c4b22a41a90a03cc51a79833"
+                == "a198b44edbd0630fd931e3583cdac7d962ea39ae"
         )
         #expect(swiftSectionState["version"] == nil)
     }


### PR DESCRIPTION
## Purpose

Recover direct Objective-C protocol conformances that watchOS 27 canonicalizes into cache-wide `__OBJC_RW` storage outside every Mach-O image.

Closes #60.

## Changes

- Advance the temporary MachOObjCSection fork cohort to `ecc84fb`.
  - Validate out-of-image protocol pointers against the Objective-C runtime's exact registered `Protocol *` set.
  - Recover only `.nameOnly` references used by header generation.
  - Preserve raw mangled names, public raw-reader behavior, full-read degradation, and malformed-pointer diagnostics.
- Advance the matching MachOSwiftSection cohort to `a198b44` so SwiftPM resolves one MachOObjCSection revision.
- Update `Package.resolved` and the exact-pin contract test.

## Testing

- MachOObjCSection:
  - `swift test --filter ObjCProtocolSafetyTests`: 36 tests passed.
  - Remaining non-host-fixture suites: 71 tests passed.
  - Release build passed.
  - iOS Simulator arm64/x86_64 builds passed.
  - watchOS Simulator arm64 and watchOS device arm64_32 builds passed.
  - Codex review: 0 findings.
- MachOSwiftSection:
  - Dependency graph resolves one MachOObjCSection identity at `ecc84fb`.
  - `swift test --skip IntegrationTests --quiet`: 1,359 tests / 253 suites passed after rebuilding the ad-hoc-signed fixture.
  - Codex review: 0 findings.
- PrivateHeaderKit:
  - `swift test`: 505 tests / 40 suites passed.
  - `scripts/test-release-scripts.sh` passed.
  - iOS Core and CoreTests compile checks passed.
  - watchOS Core, CoreTests, and simulator-helper compile checks passed.
  - Codex review: 0 findings.
- watchOS 27.0 (`24R5325f`) AVFAudio smoke:
  - 1 target generated, 0 failed.
  - `AVAudioBuffer : NSObject <NSCopying, NSMutableCopying>`.
  - `AVAudioFormat : NSObject <NSSecureCoding>`.
  - 0 Objective-C metadata warnings and 0 `has no backing data` rows.

## Screenshots

Not applicable.