### PR TITLE
Run simulator runtime fallback on the main actor

### DIFF
--- a/Sources/PrivateHeaderKitRawDumpCore/PrivateHeaderKitRawDumpMain.swift
+++ b/Sources/PrivateHeaderKitRawDumpCore/PrivateHeaderKitRawDumpMain.swift
@@ -449,7 +449,7 @@ private func dumpImage(
     }
 
     let objcStart = profileNowNanoseconds(enabled: options.profile)
-    try dumpObjC(
+    try await dumpObjC(
         machO: machO,
         imagePath: originalPath,
         outputDir: outputDir,
@@ -1012,7 +1012,7 @@ private func dumpObjC(
     outputDir: URL,
     options: DumpOptions,
     fileManager: FileManager
-) throws {
+) async throws {
     var metadata = switch machO {
     case .file(let file):
         collectObjCMetadata(from: file.objc, in: machO, options: options)
@@ -1022,7 +1022,11 @@ private func dumpObjC(
 
 #if canImport(ObjectiveC)
     if options.useRuntimeFallback {
-        let runtimeInfos = runtimeClassInfos(for: imagePath, options: options)
+        let runtimeInfos = await runtimeClassInfos(
+            for: imagePath,
+            onlyOneClass: options.onlyOneClass,
+            verbose: options.verbose
+        )
         if options.verbose, !runtimeInfos.isEmpty {
             fputs(
                 "privateheaderkit __raw-dump: runtime fallback added \(runtimeInfos.count) classes for \(imagePath)\n",
@@ -1262,15 +1266,16 @@ private func runtimeProtocolInfo(
     )
 }
 
+@MainActor
 private func runtimeClassInfo(
     for cls: AnyClass,
     runtimeOriginName: String,
     imagePath: String,
-    options: DumpOptions
+    verbose: Bool
 ) -> ObjCClassInfo? {
     var failedStage: NSString?
     guard let snapshot = PHRuntimeObjCInspector.snapshot(for: cls, failedStage: &failedStage) else {
-        if options.verbose {
+        if verbose {
             let stage = (failedStage as String?) ?? "unknown"
             fputs(
                 "privateheaderkit __raw-dump: runtime fallback skip class \(runtimeOriginName) image=\(imagePath) stage=\(stage)\n",
@@ -1298,68 +1303,108 @@ private func runtimeClassInfo(
     )
 }
 
-private func runtimeClassInfos(for imagePath: String, options: DumpOptions) -> [ObjCClassInfo] {
-    guard options.useRuntimeFallback else { return [] }
+@MainActor
+func withLoadedRuntimeImage<Result: Sendable>(
+    at path: String,
+    open: @MainActor @Sendable (String) -> UnsafeMutableRawPointer? = {
+        dlopen($0, RTLD_LAZY)
+    },
+    close: @MainActor @Sendable (UnsafeMutableRawPointer) -> Void = {
+        _ = dlclose($0)
+    },
+    inspect: @MainActor @Sendable (UnsafeMutableRawPointer) throws -> Result
+) rethrows -> Result? {
+    guard let handle = open(path) else { return nil }
+    defer { close(handle) }
+    return try inspect(handle)
+}
+
+@MainActor
+private func runtimeClassInfos(
+    for imagePath: String,
+    onlyOneClass: String?,
+    verbose: Bool
+) -> [ObjCClassInfo] {
     let targetPaths = runtimeFallbackTargetImagePaths(for: imagePath)
     let resolvedPath = resolveRuntimeURL(URL(fileURLWithPath: imagePath)).path
-    guard let handle = dlopen(resolvedPath, RTLD_LAZY) else {
-        if options.verbose {
+    guard let infos = withLoadedRuntimeImage(
+        at: resolvedPath,
+        inspect: { _ in
+            var count: UInt32 = 0
+            guard let namesPtr = objc_copyClassNamesForImage(resolvedPath, &count) else {
+                if verbose {
+                    fputs(
+                        "privateheaderkit __raw-dump: runtime fallback objc_copyClassNamesForImage returned nil for \(resolvedPath)\n",
+                        stderr
+                    )
+                }
+                return runtimeClassInfosByImageName(
+                    targetPaths: targetPaths,
+                    imagePath: imagePath,
+                    onlyOneClass: onlyOneClass,
+                    verbose: verbose
+                )
+            }
+            defer { free(namesPtr) }
+
+            if count == 0 {
+                if verbose {
+                    fputs(
+                        "privateheaderkit __raw-dump: runtime fallback objc_copyClassNamesForImage returned 0 classes for \(resolvedPath)\n",
+                        stderr
+                    )
+                }
+                return runtimeClassInfosByImageName(
+                    targetPaths: targetPaths,
+                    imagePath: imagePath,
+                    onlyOneClass: onlyOneClass,
+                    verbose: verbose
+                )
+            }
+
+            let names = UnsafeBufferPointer(start: namesPtr, count: Int(count))
+            var infos: [ObjCClassInfo] = []
+            infos.reserveCapacity(Int(count))
+
+            for namePtr in names {
+                let name = String(cString: namePtr)
+                if let onlyOneClass, onlyOneClass != name { continue }
+                if let cls = NSClassFromString(name) ?? (objc_getClass(name) as? AnyClass) {
+                    if let info = runtimeClassInfo(
+                        for: cls,
+                        runtimeOriginName: name,
+                        imagePath: imagePath,
+                        verbose: verbose
+                    ) {
+                        infos.append(info)
+                    }
+                }
+            }
+            if infos.isEmpty {
+                return runtimeClassInfosByImageName(
+                    targetPaths: targetPaths,
+                    imagePath: imagePath,
+                    onlyOneClass: onlyOneClass,
+                    verbose: verbose
+                )
+            }
+            return infos
+        }
+    ) else {
+        if verbose {
             fputs("privateheaderkit __raw-dump: runtime dlopen failed for \(resolvedPath)\n", stderr)
         }
         return []
     }
-    defer { dlclose(handle) }
-
-    var count: UInt32 = 0
-    guard let namesPtr = objc_copyClassNamesForImage(resolvedPath, &count) else {
-        if options.verbose {
-            fputs(
-                "privateheaderkit __raw-dump: runtime fallback objc_copyClassNamesForImage returned nil for \(resolvedPath)\n",
-                stderr
-            )
-        }
-        return runtimeClassInfosByImageName(targetPaths: targetPaths, imagePath: imagePath, options: options)
-    }
-    defer { free(namesPtr) }
-
-    if count == 0 {
-        if options.verbose {
-            fputs(
-                "privateheaderkit __raw-dump: runtime fallback objc_copyClassNamesForImage returned 0 classes for \(resolvedPath)\n",
-                stderr
-            )
-        }
-        return runtimeClassInfosByImageName(targetPaths: targetPaths, imagePath: imagePath, options: options)
-    }
-
-    let names = UnsafeBufferPointer(start: namesPtr, count: Int(count))
-    var infos: [ObjCClassInfo] = []
-    infos.reserveCapacity(Int(count))
-
-    for namePtr in names {
-        let name = String(cString: namePtr)
-        if let only = options.onlyOneClass, only != name { continue }
-        if let cls = NSClassFromString(name) ?? (objc_getClass(name) as? AnyClass) {
-            if let info = runtimeClassInfo(
-                for: cls,
-                runtimeOriginName: name,
-                imagePath: imagePath,
-                options: options
-            ) {
-                infos.append(info)
-            }
-        }
-    }
-    if infos.isEmpty {
-        return runtimeClassInfosByImageName(targetPaths: targetPaths, imagePath: imagePath, options: options)
-    }
     return infos
 }
 
+@MainActor
 private func runtimeClassInfosByImageName(
     targetPaths: Set<String>,
     imagePath: String,
-    options: DumpOptions
+    onlyOneClass: String?,
+    verbose: Bool
 ) -> [ObjCClassInfo] {
     let initialCount = objc_getClassList(nil, 0)
     if initialCount <= 0 { return [] }
@@ -1382,18 +1427,18 @@ private func runtimeClassInfosByImageName(
         if !targetPaths.contains(normalizedImage) { continue }
 
         let name = String(cString: class_getName(cls))
-        if let only = options.onlyOneClass, only != name { continue }
+        if let onlyOneClass, onlyOneClass != name { continue }
         if let info = runtimeClassInfo(
             for: cls,
             runtimeOriginName: name,
             imagePath: imagePath,
-            options: options
+            verbose: verbose
         ) {
             infos.append(info)
         }
     }
 
-    if options.verbose, !infos.isEmpty {
+    if verbose, !infos.isEmpty {
         fputs(
             "privateheaderkit __raw-dump: runtime fallback class_getImageName matched \(infos.count) classes for \(imagePath)\n",
             stderr

--- a/Tests/PrivateHeaderKitRawDumpTests/PrivateHeaderKitRawDumpTests.swift
+++ b/Tests/PrivateHeaderKitRawDumpTests/PrivateHeaderKitRawDumpTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Dispatch
 import MachOKit
 @_spi(Core) @_spi(Diagnostics) @testable import MachOObjCSection
 import PrivateHeaderKitHelperProtocol
@@ -952,5 +953,105 @@ struct PrivateHeaderKitRawDumpRuntimeInspectorTests {
         #expect(snapshot?.objcRuntimeName == "NSObject")
         #expect(snapshot?.superclassObjCRuntimeName == nil)
     }
+
+    @Test func loadedRuntimeImageLifecycleHopsToMainActorInOrder() async {
+        let probe = await RuntimeImageLifecycleProbe()
+
+        let result = await Task.detached {
+            await withLoadedRuntimeImage(
+                at: "/fixture/Runtime.framework/Runtime",
+                open: { path in probe.open(path) },
+                close: { handle in probe.close(handle) },
+                inspect: { handle in probe.inspect(handle) }
+            )
+        }.value
+
+        #expect(result == "inspected")
+        let observations = await probe.finish()
+        #expect(observations.map(\.stage) == ["open", "inspect", "close"])
+        #expect(observations.allSatisfy { $0.isMainThread })
+        #expect(observations.allSatisfy { $0.isMainQueue })
+    }
+
+    @Test @MainActor
+    func loadedRuntimeImageLifecycleClosesWhenInspectionThrows() {
+        let probe = RuntimeImageLifecycleProbe()
+
+        #expect(throws: RuntimeImageLifecycleError.self) {
+            try withLoadedRuntimeImage(
+                at: "/fixture/Runtime.framework/Runtime",
+                open: { path in probe.open(path) },
+                close: { handle in probe.close(handle) },
+                inspect: { handle in try probe.inspectThrowing(handle) }
+            )
+        }
+
+        let observations = probe.finish()
+        #expect(observations.map(\.stage) == ["open", "inspect", "close"])
+        #expect(observations.allSatisfy { $0.isMainThread })
+        #expect(observations.allSatisfy { $0.isMainQueue })
+    }
     #endif
 }
+
+#if canImport(ObjectiveC) && canImport(PrivateHeaderKitRawDumpRuntimeObjC)
+private struct RuntimeImageLifecycleObservation: Equatable, Sendable {
+    let stage: String
+    let isMainThread: Bool
+    let isMainQueue: Bool
+}
+
+private enum RuntimeImageLifecycleError: Error {
+    case expected
+}
+
+@MainActor
+private final class RuntimeImageLifecycleProbe {
+    private let queueKey = DispatchSpecificKey<UInt8>()
+    private let handle = UnsafeMutableRawPointer(bitPattern: 0x1)!
+    private var observations: [RuntimeImageLifecycleObservation] = []
+
+    init() {
+        DispatchQueue.main.setSpecific(key: queueKey, value: 1)
+    }
+
+    func open(_ path: String) -> UnsafeMutableRawPointer? {
+        #expect(path == "/fixture/Runtime.framework/Runtime")
+        record("open")
+        return handle
+    }
+
+    func inspect(_ handle: UnsafeMutableRawPointer) -> String {
+        #expect(handle == self.handle)
+        record("inspect")
+        return "inspected"
+    }
+
+    func inspectThrowing(_ handle: UnsafeMutableRawPointer) throws -> String {
+        #expect(handle == self.handle)
+        record("inspect")
+        throw RuntimeImageLifecycleError.expected
+    }
+
+    func close(_ handle: UnsafeMutableRawPointer) {
+        #expect(handle == self.handle)
+        record("close")
+    }
+
+    func finish() -> [RuntimeImageLifecycleObservation] {
+        DispatchQueue.main.setSpecific(key: queueKey, value: nil)
+        return observations
+    }
+
+    private func record(_ stage: String) {
+        MainActor.preconditionIsolated()
+        observations.append(
+            RuntimeImageLifecycleObservation(
+                stage: stage,
+                isMainThread: Thread.isMainThread,
+                isMainQueue: DispatchQueue.getSpecific(key: queueKey) == 1
+            )
+        )
+    }
+}
+#endif


### PR DESCRIPTION
## Purpose

Prevent simulator frameworks that require main-queue initialization from crashing the raw-dump helper during Objective-C runtime fallback.

Closes #61.

## Changes

- Make the Objective-C dump path asynchronous and move only the runtime fallback lifecycle onto `MainActor`.
- Keep `dlopen`, Objective-C runtime inspection, fallback enumeration, and `dlclose` in one non-suspending main-actor scope.
- Pass only Sendable runtime selection values across the actor boundary.
- Add deterministic coverage for detached callers, main-queue ownership, lifecycle ordering, and throwing inspection cleanup.

## Testing

- `swift test` — 507 tests in 40 suites passed
- `scripts/test-release-scripts.sh`
- iOS simulator compile checks for `PrivateHeaderKitCore` and `PrivateHeaderKitCoreTests`
- watchOS simulator compile checks for `PrivateHeaderKitCore`, `PrivateHeaderKitCoreTests`, and `privateheaderkit-sim-helper`
- watchOS 27.0 Carousel fresh dump — Generated 1 target and 4,696 headers with no new helper crash report
- Codex review — 0 findings

## Screenshots

N/A — CLI/runtime ownership change.