### PR TITLE
Resolve loaded Objective-C relative protocol lists

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "b5d21bf8cc51affcac549b040c61d57f99923f497defea5b65257319b20283c4",
+  "originHash" : "4e40eaf21e28cc816e3fd5e679657c20bc72ecbaa5c4c9f5936661ec56f96f49",
   "pins" : [
     {
       "identity" : "associatedobject",
@@ -60,7 +60,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/lynnswap/MachOObjCSection.git",
       "state" : {
-        "revision" : "7d159a0216565edae417bf40716dd447bf295e7b"
+        "revision" : "ecc84fb790509fb71f4c1f0bd2fb6e4bac6069df"
       }
     },
     {
@@ -68,7 +68,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/lynnswap/MachOSwiftSection.git",
       "state" : {
-        "revision" : "030963e9f69118f4c4b22a41a90a03cc51a79833"
+        "revision" : "a198b44edbd0630fd931e3583cdac7d962ea39ae"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "4e40eaf21e28cc816e3fd5e679657c20bc72ecbaa5c4c9f5936661ec56f96f49",
+  "originHash" : "46f56e073efe772f4ef044857815f960f8513ae7804562a02e1634a09a228d2f",
   "pins" : [
     {
       "identity" : "associatedobject",
@@ -60,7 +60,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/lynnswap/MachOObjCSection.git",
       "state" : {
-        "revision" : "ecc84fb790509fb71f4c1f0bd2fb6e4bac6069df"
+        "revision" : "e8fdf4edc8f91aa46ef50f85932c1cb7690885af"
       }
     },
     {
@@ -68,7 +68,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/lynnswap/MachOSwiftSection.git",
       "state" : {
-        "revision" : "a198b44edbd0630fd931e3583cdac7d962ea39ae"
+        "revision" : "11a75142e0a0965363cff9e897719838dc975319"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -37,7 +37,7 @@ let package = Package(
         ),
         .package(
             url: "https://github.com/lynnswap/MachOObjCSection.git",
-            revision: "ecc84fb790509fb71f4c1f0bd2fb6e4bac6069df"
+            revision: "e8fdf4edc8f91aa46ef50f85932c1cb7690885af"
         ),
         .package(
             url: "https://github.com/MxIris-Reverse-Engineering/swift-objc-dump.git",
@@ -45,7 +45,7 @@ let package = Package(
         ),
         .package(
             url: "https://github.com/lynnswap/MachOSwiftSection.git",
-            revision: "a198b44edbd0630fd931e3583cdac7d962ea39ae"
+            revision: "11a75142e0a0965363cff9e897719838dc975319"
         ),
         .package(
             url: "https://github.com/MxIris-Reverse-Engineering/swift-demangling",

--- a/Package.swift
+++ b/Package.swift
@@ -37,7 +37,7 @@ let package = Package(
         ),
         .package(
             url: "https://github.com/lynnswap/MachOObjCSection.git",
-            revision: "7d159a0216565edae417bf40716dd447bf295e7b"
+            revision: "ecc84fb790509fb71f4c1f0bd2fb6e4bac6069df"
         ),
         .package(
             url: "https://github.com/MxIris-Reverse-Engineering/swift-objc-dump.git",
@@ -45,7 +45,7 @@ let package = Package(
         ),
         .package(
             url: "https://github.com/lynnswap/MachOSwiftSection.git",
-            revision: "030963e9f69118f4c4b22a41a90a03cc51a79833"
+            revision: "a198b44edbd0630fd931e3583cdac7d962ea39ae"
         ),
         .package(
             url: "https://github.com/MxIris-Reverse-Engineering/swift-demangling",

--- a/Sources/PrivateHeaderKitRawDumpCore/RawDumpObjCDiagnostics.swift
+++ b/Sources/PrivateHeaderKitRawDumpCore/RawDumpObjCDiagnostics.swift
@@ -175,10 +175,6 @@ private func failureDescription(
         "image header at address \(address) is not readable for \(byteCount) bytes"
     case .invalidRelativeEntrySize(let advertised, let minimum):
         "relative entry size \(advertised) is smaller than \(minimum)"
-    case .missingRelativeImageIndex:
-        "dyld-cache image index is unavailable"
-    case .relativeEntryNotFound(let imageIndex):
-        "relative entry for cache image index \(imageIndex) was not found"
     case .invalidRelativeListLocation:
         "relative list location could not be mapped"
     case .relativeImageUnavailable(let imageIndex):

--- a/Tests/PrivateHeaderKitHelperProtocolTests/PrivateHeaderKitHelperProtocolTests.swift
+++ b/Tests/PrivateHeaderKitHelperProtocolTests/PrivateHeaderKitHelperProtocolTests.swift
@@ -153,7 +153,7 @@ struct PrivateHeaderKitHelperProtocolTests {
         let state = try #require(pin["state"] as? [String: Any])
 
         #expect(pin["location"] as? String == "https://github.com/lynnswap/MachOObjCSection.git")
-        #expect(state["revision"] as? String == "7d159a0216565edae417bf40716dd447bf295e7b")
+        #expect(state["revision"] as? String == "ecc84fb790509fb71f4c1f0bd2fb6e4bac6069df")
         #expect(state["version"] == nil)
 
         let swiftSectionPin = try #require(
@@ -168,7 +168,7 @@ struct PrivateHeaderKitHelperProtocolTests {
         )
         #expect(
             swiftSectionState["revision"] as? String
-                == "030963e9f69118f4c4b22a41a90a03cc51a79833"
+                == "a198b44edbd0630fd931e3583cdac7d962ea39ae"
         )
         #expect(swiftSectionState["version"] == nil)
     }

--- a/Tests/PrivateHeaderKitHelperProtocolTests/PrivateHeaderKitHelperProtocolTests.swift
+++ b/Tests/PrivateHeaderKitHelperProtocolTests/PrivateHeaderKitHelperProtocolTests.swift
@@ -153,7 +153,7 @@ struct PrivateHeaderKitHelperProtocolTests {
         let state = try #require(pin["state"] as? [String: Any])
 
         #expect(pin["location"] as? String == "https://github.com/lynnswap/MachOObjCSection.git")
-        #expect(state["revision"] as? String == "ecc84fb790509fb71f4c1f0bd2fb6e4bac6069df")
+        #expect(state["revision"] as? String == "e8fdf4edc8f91aa46ef50f85932c1cb7690885af")
         #expect(state["version"] == nil)
 
         let swiftSectionPin = try #require(
@@ -168,7 +168,7 @@ struct PrivateHeaderKitHelperProtocolTests {
         )
         #expect(
             swiftSectionState["revision"] as? String
-                == "a198b44edbd0630fd931e3583cdac7d962ea39ae"
+                == "11a75142e0a0965363cff9e897719838dc975319"
         )
         #expect(swiftSectionState["version"] == nil)
     }


### PR DESCRIPTION
## Purpose

Read Objective-C relative protocol list-of-lists with the runtime's actual ordered, per-entry loaded-state semantics instead of requiring one entry for the class owner's image index.

Closes #62.

## Dependency order

This branch descends from the head of #63. Merge #63 first; once it lands, this PR narrows to the #62 cohort advance and diagnostic adaptation.

## Changes

- Advance MachOObjCSection to `e8fdf4e`.
  - Model protocol-list resolution as distinct absent, whole-table failure, and ordered per-entry outcomes.
  - Resolve every file/debug-tool entry in outer-table order.
  - For loaded images, check each entry's RW header loaded state before touching its list.
  - Silently skip unloaded entries while preserving loaded siblings and per-entry typed failures.
  - Remove the invalid owner-index failure cases.
- Advance the matching MachOSwiftSection cohort to `11a7514`.
- Update `Package.resolved` and the exact-pin contract test.
- Remove PrivateHeaderKit formatting branches for the deleted diagnostic cases.

## Testing

- MachOObjCSection:
  - `ObjCProtocolSafetyTests`: 41 tests passed
  - Remaining safe suites: 76 tests passed
  - Release build passed
  - iOS device and simulator builds passed
  - watchOS simulator and arm64_32 device builds passed
  - Codex review: 0 findings
- MachOSwiftSection:
  - Remote graph resolves one MachOObjCSection identity at `e8fdf4e`
  - `swift test --skip IntegrationTests --quiet`: 1,359 tests / 253 suites passed after rebuilding the ad-hoc-signed fixture
  - Codex review: 0 findings
- PrivateHeaderKit:
  - Exact-pin test passed
  - `swift test`: 505 tests / 40 suites passed
  - `scripts/test-release-scripts.sh` passed
  - iOS Core/CoreTests compile checks passed
  - watchOS Core/CoreTests/simulator-helper compile checks passed
  - Codex review: 0 findings
- watchOS 27.0 Accounts smoke:
  - Generated 1 target and 140 headers
  - `ACAccountStore.h` was published
  - 0 Objective-C metadata warnings
  - 0 persisted `relative entry for cache image index` warnings
  - No new helper crash report

## Screenshots

N/A — metadata reader and dependency-cohort change.