### PR TITLE
Resolve loaded Objective-C member lists

### DIFF
--- a/Docs/generation.md
+++ b/Docs/generation.md
@@ -121,13 +121,19 @@ recovery snapshot, not a visibility gate for generated headers.
 Objective-C header generation reads only the directly adopted protocol names
 needed by class, category, and protocol declarations. Protocol metadata reads
 are range-checked and traversal is bounded; an unreadable reference, cycle, or
-safety-limit cutoff preserves the metadata that was decoded successfully. Once
-that target is published, PrivateHeaderKit reports the precise owner and
-degradation as an `objc-metadata-warning` and persists the warning in
-`generation.sqlite`. A bounded diagnostics report records when additional
-warnings were omitted, so malformed metadata cannot grow process output without
-limit. Live warning presentation is also capped across the run; one aggregate
-warning points to the retained per-target details in the database.
+safety-limit cutoff preserves the metadata that was decoded successfully.
+Loaded-image reads of relative method/property list-of-lists consult each
+entry's runtime loaded state, while file-backed reads inspect every structurally
+valid entry. Both preserve outer-table order and validate the outer table and
+each nonempty inner member table before decoding; an empty inner list does not
+require an otherwise unused entry size. One malformed loaded list preserves its
+valid siblings and produces a typed member-list degradation; unloaded lists are
+skipped without warning. Once that target is published, PrivateHeaderKit reports
+the precise owner and degradation as an `objc-metadata-warning` and persists the
+warning in `generation.sqlite`. A bounded diagnostics report records when
+additional warnings were omitted, so malformed metadata cannot grow process
+output without limit. Live warning presentation is also capped across the run;
+one aggregate warning points to the retained per-target details in the database.
 
 State, attempts, publication intent, and run diagnostics are stored in
 `generation.sqlite`, outside the published header tree. The top-level source

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "46f56e073efe772f4ef044857815f960f8513ae7804562a02e1634a09a228d2f",
+  "originHash" : "960c1304bba8fbed955189c62569a0296b9685043bd012a0c38de087a55397f3",
   "pins" : [
     {
       "identity" : "associatedobject",
@@ -60,7 +60,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/lynnswap/MachOObjCSection.git",
       "state" : {
-        "revision" : "e8fdf4edc8f91aa46ef50f85932c1cb7690885af"
+        "revision" : "932bff230815e39901e825e419db588377edee5c"
       }
     },
     {
@@ -68,7 +68,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/lynnswap/MachOSwiftSection.git",
       "state" : {
-        "revision" : "11a75142e0a0965363cff9e897719838dc975319"
+        "revision" : "8970e899efb13f355c2b8769e67e35ba39e07004"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "b5d21bf8cc51affcac549b040c61d57f99923f497defea5b65257319b20283c4",
+  "originHash" : "4e40eaf21e28cc816e3fd5e679657c20bc72ecbaa5c4c9f5936661ec56f96f49",
   "pins" : [
     {
       "identity" : "associatedobject",
@@ -60,7 +60,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/lynnswap/MachOObjCSection.git",
       "state" : {
-        "revision" : "7d159a0216565edae417bf40716dd447bf295e7b"
+        "revision" : "ecc84fb790509fb71f4c1f0bd2fb6e4bac6069df"
       }
     },
     {
@@ -68,7 +68,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/lynnswap/MachOSwiftSection.git",
       "state" : {
-        "revision" : "030963e9f69118f4c4b22a41a90a03cc51a79833"
+        "revision" : "a198b44edbd0630fd931e3583cdac7d962ea39ae"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "4e40eaf21e28cc816e3fd5e679657c20bc72ecbaa5c4c9f5936661ec56f96f49",
+  "originHash" : "46f56e073efe772f4ef044857815f960f8513ae7804562a02e1634a09a228d2f",
   "pins" : [
     {
       "identity" : "associatedobject",
@@ -60,7 +60,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/lynnswap/MachOObjCSection.git",
       "state" : {
-        "revision" : "ecc84fb790509fb71f4c1f0bd2fb6e4bac6069df"
+        "revision" : "e8fdf4edc8f91aa46ef50f85932c1cb7690885af"
       }
     },
     {
@@ -68,7 +68,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/lynnswap/MachOSwiftSection.git",
       "state" : {
-        "revision" : "a198b44edbd0630fd931e3583cdac7d962ea39ae"
+        "revision" : "11a75142e0a0965363cff9e897719838dc975319"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -37,7 +37,7 @@ let package = Package(
         ),
         .package(
             url: "https://github.com/lynnswap/MachOObjCSection.git",
-            revision: "e8fdf4edc8f91aa46ef50f85932c1cb7690885af"
+            revision: "932bff230815e39901e825e419db588377edee5c"
         ),
         .package(
             url: "https://github.com/MxIris-Reverse-Engineering/swift-objc-dump.git",
@@ -45,7 +45,7 @@ let package = Package(
         ),
         .package(
             url: "https://github.com/lynnswap/MachOSwiftSection.git",
-            revision: "11a75142e0a0965363cff9e897719838dc975319"
+            revision: "8970e899efb13f355c2b8769e67e35ba39e07004"
         ),
         .package(
             url: "https://github.com/MxIris-Reverse-Engineering/swift-demangling",

--- a/Package.swift
+++ b/Package.swift
@@ -37,7 +37,7 @@ let package = Package(
         ),
         .package(
             url: "https://github.com/lynnswap/MachOObjCSection.git",
-            revision: "ecc84fb790509fb71f4c1f0bd2fb6e4bac6069df"
+            revision: "e8fdf4edc8f91aa46ef50f85932c1cb7690885af"
         ),
         .package(
             url: "https://github.com/MxIris-Reverse-Engineering/swift-objc-dump.git",
@@ -45,7 +45,7 @@ let package = Package(
         ),
         .package(
             url: "https://github.com/lynnswap/MachOSwiftSection.git",
-            revision: "a198b44edbd0630fd931e3583cdac7d962ea39ae"
+            revision: "11a75142e0a0965363cff9e897719838dc975319"
         ),
         .package(
             url: "https://github.com/MxIris-Reverse-Engineering/swift-demangling",

--- a/Package.swift
+++ b/Package.swift
@@ -37,7 +37,7 @@ let package = Package(
         ),
         .package(
             url: "https://github.com/lynnswap/MachOObjCSection.git",
-            revision: "7d159a0216565edae417bf40716dd447bf295e7b"
+            revision: "ecc84fb790509fb71f4c1f0bd2fb6e4bac6069df"
         ),
         .package(
             url: "https://github.com/MxIris-Reverse-Engineering/swift-objc-dump.git",
@@ -45,7 +45,7 @@ let package = Package(
         ),
         .package(
             url: "https://github.com/lynnswap/MachOSwiftSection.git",
-            revision: "030963e9f69118f4c4b22a41a90a03cc51a79833"
+            revision: "a198b44edbd0630fd931e3583cdac7d962ea39ae"
         ),
         .package(
             url: "https://github.com/MxIris-Reverse-Engineering/swift-demangling",

--- a/Sources/PrivateHeaderKitRawDumpCore/PrivateHeaderKitRawDumpMain.swift
+++ b/Sources/PrivateHeaderKitRawDumpCore/PrivateHeaderKitRawDumpMain.swift
@@ -1478,6 +1478,7 @@ private func collectClassInfos<T: ObjCClassProtocol>(
     for cls in classes {
         let result = cls.readInfo(in: machO, options: readOptions)
         options.objcDiagnostics.append(contentsOf: result.diagnostics)
+        options.objcDiagnostics.append(contentsOf: result.memberListDiagnostics)
         if let info = result.value {
             classInfos[info.name] = info
         } else if options.verbose && options.logSkippedClasses {
@@ -1496,6 +1497,7 @@ private func collectClassInfos<T: ObjCClassProtocol>(
     for cls in classes {
         let result = cls.readInfo(in: machO, options: readOptions)
         options.objcDiagnostics.append(contentsOf: result.diagnostics)
+        options.objcDiagnostics.append(contentsOf: result.memberListDiagnostics)
         if let info = result.value {
             classInfos[info.name] = info
         } else if options.verbose && options.logSkippedClasses {

--- a/Sources/PrivateHeaderKitRawDumpCore/RawDumpObjCDiagnostics.swift
+++ b/Sources/PrivateHeaderKitRawDumpCore/RawDumpObjCDiagnostics.swift
@@ -175,10 +175,6 @@ private func failureDescription(
         "image header at address \(address) is not readable for \(byteCount) bytes"
     case .invalidRelativeEntrySize(let advertised, let minimum):
         "relative entry size \(advertised) is smaller than \(minimum)"
-    case .missingRelativeImageIndex:
-        "dyld-cache image index is unavailable"
-    case .relativeEntryNotFound(let imageIndex):
-        "relative entry for cache image index \(imageIndex) was not found"
     case .invalidRelativeListLocation:
         "relative list location could not be mapped"
     case .relativeImageUnavailable(let imageIndex):

--- a/Sources/PrivateHeaderKitRawDumpCore/RawDumpObjCDiagnostics.swift
+++ b/Sources/PrivateHeaderKitRawDumpCore/RawDumpObjCDiagnostics.swift
@@ -48,16 +48,25 @@ final class RawDumpObjCDiagnosticsAccumulator {
 
     func append(contentsOf diagnostics: [ObjCProtocolDiagnostic]) {
         for diagnostic in diagnostics {
-            let record = privateHeaderKitDiagnostic(from: diagnostic)
-            guard !retained.contains(record) else { continue }
-            guard retained.count < PrivateHeaderKitRawDumpDiagnosticsReport.maximumDiagnosticCount else {
-                omittedDiagnosticCount = omittedDiagnosticCount == UInt.max
-                    ? UInt.max
-                    : omittedDiagnosticCount + 1
-                continue
-            }
-            retained.insert(record)
+            append(privateHeaderKitDiagnostic(from: diagnostic))
         }
+    }
+
+    func append(contentsOf diagnostics: [ObjCMemberListDiagnostic]) {
+        for diagnostic in diagnostics {
+            append(privateHeaderKitDiagnostic(from: diagnostic))
+        }
+    }
+
+    private func append(_ record: PrivateHeaderKitRawDumpDiagnostic) {
+        guard !retained.contains(record) else { return }
+        guard retained.count < PrivateHeaderKitRawDumpDiagnosticsReport.maximumDiagnosticCount else {
+            omittedDiagnosticCount = omittedDiagnosticCount == UInt.max
+                ? UInt.max
+                : omittedDiagnosticCount + 1
+            return
+        }
+        retained.insert(record)
     }
 
     var report: PrivateHeaderKitRawDumpDiagnosticsReport {
@@ -114,6 +123,54 @@ private func privateHeaderKitDiagnostic(
                 "adopted protocols were not traversed because protocol offset"
                 + " \(invalid.protocolOffset) has no stable identity"
         )
+    }
+}
+
+private func privateHeaderKitDiagnostic(
+    from diagnostic: ObjCMemberListDiagnostic
+) -> PrivateHeaderKitRawDumpDiagnostic {
+    rawDumpMemberListDiagnostic(
+        className: diagnostic.className,
+        kind: diagnostic.kind,
+        outerListOffset: diagnostic.outerListOffset,
+        location: diagnostic.location,
+        failure: diagnostic.failure
+    )
+}
+
+func rawDumpMemberListDiagnostic(
+    className: String,
+    kind: ObjCMemberListDiagnostic.Kind,
+    outerListOffset: Int,
+    location: ObjCMemberListDiagnostic.Location,
+    failure: ObjCMemberListDiagnostic.Failure
+) -> PrivateHeaderKitRawDumpDiagnostic {
+    PrivateHeaderKitRawDumpDiagnostic(
+        owner: "Objective-C class \(boundedMetadataString(className))",
+        degradation:
+            "\(memberKindDescription(kind)) metadata at relative list offset \(outerListOffset)"
+            + memberLocationDescription(location)
+            + " could not be fully read: \(failureDescription(failure))"
+    )
+}
+
+private func memberKindDescription(_ kind: ObjCMemberListDiagnostic.Kind) -> String {
+    switch kind {
+    case .instanceMethod: "instance-method"
+    case .classMethod: "class-method"
+    case .instanceProperty: "instance-property"
+    case .classProperty: "class-property"
+    }
+}
+
+private func memberLocationDescription(
+    _ location: ObjCMemberListDiagnostic.Location
+) -> String {
+    switch location {
+    case .table:
+        return ""
+    case let .entry(index, imageIndex, offset):
+        return " entry \(index) (cache image index \(imageIndex), offset \(offset))"
     }
 }
 
@@ -201,5 +258,52 @@ private func failureDescription(
         "entry \(entryIndex) layout at file offset \(offset) is not readable for \(byteCount) bytes"
     case .unreadableImageLayout(let entryIndex, let address, let byteCount):
         "entry \(entryIndex) layout at image address \(address) is not readable for \(byteCount) bytes"
+    }
+}
+
+private func failureDescription(
+    _ failure: ObjCMemberListDiagnostic.Failure
+) -> String {
+    switch failure {
+    case .unsupportedListEncoding:
+        "list encoding is unsupported by this reader"
+    case .invalidListOffset(let offset):
+        "list offset \(offset) is not a readable nonnegative address"
+    case .invalidElementCount(let count):
+        "element count \(count) cannot be represented"
+    case .invalidSignedElementCount(let count):
+        "signed element count \(count) is negative"
+    case .excessiveElementCount(let actual, let maximum):
+        "element count \(actual) exceeds the safety limit \(maximum)"
+    case .excessiveByteCount(let actual, let maximum):
+        "table size \(actual) bytes exceeds the safety limit \(maximum)"
+    case .invalidRelativeEntrySize(let advertised, let minimum):
+        "relative entry size \(advertised) is smaller than \(minimum)"
+    case .invalidListEntrySize(let advertised, let expected):
+        "member entry size \(advertised) does not match expected size \(expected)"
+    case .misalignedListOffset(let offset, let alignment):
+        "member list offset \(offset) is not aligned to \(alignment) bytes"
+    case .misalignedListAddress(let address, let alignment):
+        "member list address \(address) is not aligned to \(alignment) bytes"
+    case .unresolvedListPointer:
+        "list pointer could not be rebased or canonicalized"
+    case .missingListBackingData:
+        "list pointer has no readable backing data"
+    case .unreadableFileHeader(let offset, let byteCount):
+        "file header at offset \(offset) is not readable for \(byteCount) bytes"
+    case .unreadableImageHeader(let address, let byteCount):
+        "image header at address \(address) is not readable for \(byteCount) bytes"
+    case .invalidRelativeListLocation:
+        "relative list location could not be mapped"
+    case .relativeImageUnavailable(let imageIndex):
+        "cache image index \(imageIndex) is unavailable"
+    case .byteCountOverflow(let elementCount, let elementSize):
+        "byte count overflowed for \(elementCount) elements of size \(elementSize)"
+    case .rangeOverflow(let startOffset, let byteCount):
+        "range overflowed from offset \(startOffset) for \(byteCount) bytes"
+    case .unreadableFileRange(let offset, let byteCount):
+        "file range at offset \(offset) is not readable for \(byteCount) bytes"
+    case .unreadableImageRange(let address, let byteCount):
+        "image range at address \(address) is not readable for \(byteCount) bytes"
     }
 }

--- a/Tests/PrivateHeaderKitHelperProtocolTests/PrivateHeaderKitHelperProtocolTests.swift
+++ b/Tests/PrivateHeaderKitHelperProtocolTests/PrivateHeaderKitHelperProtocolTests.swift
@@ -153,7 +153,7 @@ struct PrivateHeaderKitHelperProtocolTests {
         let state = try #require(pin["state"] as? [String: Any])
 
         #expect(pin["location"] as? String == "https://github.com/lynnswap/MachOObjCSection.git")
-        #expect(state["revision"] as? String == "e8fdf4edc8f91aa46ef50f85932c1cb7690885af")
+        #expect(state["revision"] as? String == "932bff230815e39901e825e419db588377edee5c")
         #expect(state["version"] == nil)
 
         let swiftSectionPin = try #require(
@@ -168,7 +168,7 @@ struct PrivateHeaderKitHelperProtocolTests {
         )
         #expect(
             swiftSectionState["revision"] as? String
-                == "11a75142e0a0965363cff9e897719838dc975319"
+                == "8970e899efb13f355c2b8769e67e35ba39e07004"
         )
         #expect(swiftSectionState["version"] == nil)
     }

--- a/Tests/PrivateHeaderKitHelperProtocolTests/PrivateHeaderKitHelperProtocolTests.swift
+++ b/Tests/PrivateHeaderKitHelperProtocolTests/PrivateHeaderKitHelperProtocolTests.swift
@@ -153,7 +153,7 @@ struct PrivateHeaderKitHelperProtocolTests {
         let state = try #require(pin["state"] as? [String: Any])
 
         #expect(pin["location"] as? String == "https://github.com/lynnswap/MachOObjCSection.git")
-        #expect(state["revision"] as? String == "7d159a0216565edae417bf40716dd447bf295e7b")
+        #expect(state["revision"] as? String == "ecc84fb790509fb71f4c1f0bd2fb6e4bac6069df")
         #expect(state["version"] == nil)
 
         let swiftSectionPin = try #require(
@@ -168,7 +168,7 @@ struct PrivateHeaderKitHelperProtocolTests {
         )
         #expect(
             swiftSectionState["revision"] as? String
-                == "030963e9f69118f4c4b22a41a90a03cc51a79833"
+                == "a198b44edbd0630fd931e3583cdac7d962ea39ae"
         )
         #expect(swiftSectionState["version"] == nil)
     }

--- a/Tests/PrivateHeaderKitHelperProtocolTests/PrivateHeaderKitHelperProtocolTests.swift
+++ b/Tests/PrivateHeaderKitHelperProtocolTests/PrivateHeaderKitHelperProtocolTests.swift
@@ -153,7 +153,7 @@ struct PrivateHeaderKitHelperProtocolTests {
         let state = try #require(pin["state"] as? [String: Any])
 
         #expect(pin["location"] as? String == "https://github.com/lynnswap/MachOObjCSection.git")
-        #expect(state["revision"] as? String == "ecc84fb790509fb71f4c1f0bd2fb6e4bac6069df")
+        #expect(state["revision"] as? String == "e8fdf4edc8f91aa46ef50f85932c1cb7690885af")
         #expect(state["version"] == nil)
 
         let swiftSectionPin = try #require(
@@ -168,7 +168,7 @@ struct PrivateHeaderKitHelperProtocolTests {
         )
         #expect(
             swiftSectionState["revision"] as? String
-                == "a198b44edbd0630fd931e3583cdac7d962ea39ae"
+                == "11a75142e0a0965363cff9e897719838dc975319"
         )
         #expect(swiftSectionState["version"] == nil)
     }

--- a/Tests/PrivateHeaderKitRawDumpTests/ObjCMemberListDiagnosticsTests.swift
+++ b/Tests/PrivateHeaderKitRawDumpTests/ObjCMemberListDiagnosticsTests.swift
@@ -1,0 +1,341 @@
+import Foundation
+import MachOKit
+@_spi(Core) @_spi(Diagnostics) import MachOObjCSection
+import PrivateHeaderKitHelperProtocol
+import Testing
+@testable import PrivateHeaderKitRawDumpCore
+
+struct ObjCMemberListDiagnosticsTests {
+    @Test func wholeTableFailureKeepsMemberKindAndOuterOffset() {
+        let record = rawDumpMemberListDiagnostic(
+            className: "Owner",
+            kind: .classMethod,
+            outerListOffset: 120,
+            location: .table,
+            failure: .excessiveElementCount(actual: 65_537, maximum: 65_536)
+        )
+
+        #expect(record.owner == "Objective-C class Owner")
+        #expect(
+            record.degradation
+                == "class-method metadata at relative list offset 120"
+                    + " could not be fully read: element count 65537"
+                    + " exceeds the safety limit 65536"
+        )
+    }
+
+    @Test func entryFailureIncludesImageIndexOffsetAndTerminalSafeOwner() {
+        let record = rawDumpMemberListDiagnostic(
+            className: "Owner\nName",
+            kind: .instanceProperty,
+            outerListOffset: 240,
+            location: .entry(index: 2, imageIndex: 1194, offset: 272),
+            failure: .misalignedListAddress(address: 4_097, requiredAlignment: 8)
+        )
+
+        #expect(record.owner == #"Objective-C class Owner\nName"#)
+        #expect(
+            record.degradation
+                == "instance-property metadata at relative list offset 240"
+                    + " entry 2 (cache image index 1194, offset 272)"
+                    + " could not be fully read: member list address 4097"
+                    + " is not aligned to 8 bytes"
+        )
+    }
+
+    @Test func memberAndProtocolDiagnosticsShareBoundedWireReport() throws {
+        let fixture = try InvalidMemberListFixture(
+            memberDiagnosticCount: PrivateHeaderKitRawDumpDiagnosticsReport.maximumDiagnosticCount
+        )
+        let accumulator = RawDumpObjCDiagnosticsAccumulator()
+        let protocolDiagnostics = fixture.objcProtocol.readInfo(
+            in: fixture.machO
+        ).diagnostics
+        #expect(protocolDiagnostics.count == 1)
+        accumulator.append(contentsOf: protocolDiagnostics)
+        accumulator.append(contentsOf: protocolDiagnostics)
+
+        let memberDiagnostics = fixture.objcClass.readInfo(
+            in: fixture.machO
+        ).memberListDiagnostics
+        #expect(
+            memberDiagnostics.count
+                == PrivateHeaderKitRawDumpDiagnosticsReport.maximumDiagnosticCount
+        )
+        accumulator.append(contentsOf: memberDiagnostics)
+
+        let report = accumulator.report
+        #expect(
+            report.diagnostics.count
+                == PrivateHeaderKitRawDumpDiagnosticsReport.maximumDiagnosticCount
+        )
+        #expect(report.omittedDiagnosticCount == 1)
+        #expect(
+            report.diagnostics.count {
+                $0.owner.hasPrefix("Objective-C protocol")
+            } == 1
+        )
+        #expect(
+            report.diagnostics.count {
+                $0.owner.hasPrefix("Objective-C class")
+            } == PrivateHeaderKitRawDumpDiagnosticsReport.maximumDiagnosticCount - 1
+        )
+
+        let encoded = try JSONEncoder().encode(report)
+        let decoded = try JSONDecoder().decode(
+            PrivateHeaderKitRawDumpDiagnosticsReport.self,
+            from: encoded
+        )
+        #expect(decoded == report)
+    }
+}
+
+private final class InvalidMemberListFixture {
+    let machO: MachOFile
+    let objcClass: ObjCClass64
+    let objcProtocol: ObjCProtocol64
+    private let url: URL
+
+    init(memberDiagnosticCount: Int) throws {
+        let fileSize = 0x4000
+        let vmAddress: UInt64 = 0x1_0000_0000
+        let classOffset = 0x400
+        let metaClassOffset = 0x480
+        let classROOffset = 0x500
+        let metaClassROOffset = 0x580
+        let memberListOffset = 0x800
+        let classNameOffset = 0x1800
+        let protocolNameOffset = 0x1840
+        let outerStride = MemoryLayout<RelativeListListEntry.Layout>.size
+        var data = Data(count: fileSize)
+
+        var header = mach_header_64()
+        header.magic = UInt32(MH_MAGIC_64)
+        header.cputype = CPU_TYPE_ARM64
+        header.cpusubtype = CPU_SUBTYPE_ARM64_ALL
+        header.filetype = UInt32(MH_DYLIB)
+        header.ncmds = 1
+        header.sizeofcmds = UInt32(MemoryLayout<segment_command_64>.size)
+        data.storeValue(header, at: 0)
+
+        var segment = segment_command_64()
+        segment.cmd = UInt32(LC_SEGMENT_64)
+        segment.cmdsize = UInt32(MemoryLayout<segment_command_64>.size)
+        segment.vmaddr = vmAddress
+        segment.vmsize = UInt64(fileSize)
+        segment.filesize = UInt64(fileSize)
+        segment.maxprot = VM_PROT_READ
+        segment.initprot = VM_PROT_READ
+        data.storeValue(segment, at: MemoryLayout<mach_header_64>.size)
+
+        func address(_ offset: Int) -> UInt64 {
+            vmAddress + UInt64(offset)
+        }
+
+        data.storeCString("MemberOwner", at: classNameOffset)
+        data.storeCString("ProtocolOwner", at: protocolNameOffset)
+        data.storeValue(
+            RawEntrySizeListHeader(
+                entsizeAndFlags: UInt32(outerStride),
+                count: UInt32(memberDiagnosticCount)
+            ),
+            at: memberListOffset
+        )
+        for index in 0..<memberDiagnosticCount {
+            let entryOffset = memberListOffset
+                + MemoryLayout<EntrySizeListHeader>.size
+                + index * outerStride
+            var entry = RelativeListListEntry.Layout()
+            entry.imageIndex = 0
+            entry.listOffset = Int64(fileSize + 0x100 + index * 8 - entryOffset)
+            data.storeValue(entry, at: entryOffset)
+        }
+
+        data.storeValue(
+            RawClassROData64(
+                flags: 0,
+                instanceStart: 0,
+                instanceSize: 0,
+                _reserved: 0,
+                ivarLayout: 0,
+                name: address(classNameOffset),
+                baseMethods: address(memberListOffset) | 1,
+                baseProtocols: 0,
+                ivars: 0,
+                weakIvarLayout: 0,
+                baseProperties: 0
+            ),
+            at: classROOffset
+        )
+        data.storeValue(
+            RawClassROData64(
+                flags: 0,
+                instanceStart: 0,
+                instanceSize: 0,
+                _reserved: 0,
+                ivarLayout: 0,
+                name: address(classNameOffset),
+                baseMethods: 0,
+                baseProtocols: 0,
+                ivars: 0,
+                weakIvarLayout: 0,
+                baseProperties: 0
+            ),
+            at: metaClassROOffset
+        )
+
+        data.storeValue(
+            RawClass64(
+                isa: address(metaClassOffset),
+                superclass: 0,
+                methodCacheBuckets: 0,
+                methodCacheProperties: 0,
+                dataVMAddrAndFastFlags: address(classROOffset),
+                swiftClassFlags: 0
+            ),
+            at: classOffset
+        )
+        data.storeValue(
+            RawClass64(
+                isa: address(metaClassOffset),
+                superclass: 0,
+                methodCacheBuckets: 0,
+                methodCacheProperties: 0,
+                dataVMAddrAndFastFlags: address(metaClassROOffset),
+                swiftClassFlags: 0
+            ),
+            at: metaClassOffset
+        )
+
+        let classLayout = data.loadValue(
+            ObjCClass64.Layout.self,
+            at: classOffset
+        )
+        let protocolLayout = data.loadValue(
+            ObjCProtocol64.Layout.self,
+            from: RawProtocol64(
+                isa: 0,
+                mangledName: address(protocolNameOffset),
+                protocols: 0,
+                instanceMethods: 0,
+                classMethods: 0,
+                optionalInstanceMethods: 0,
+                optionalClassMethods: 0,
+                instanceProperties: 0,
+                size: UInt32(MemoryLayout<ObjCProtocol64.Layout>.size),
+                flags: 0,
+                extendedMethodTypes: 0,
+                demangledName: 0,
+                classProperties: 0
+            )
+        )
+
+        url = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "PrivateHeaderKitInvalidMemberList-\(UUID().uuidString)"
+        )
+        try data.write(to: url)
+        machO = try MachOFile(url: url)
+        objcClass = ObjCClass64(layout: classLayout, offset: classOffset)
+        objcProtocol = ObjCProtocol64(layout: protocolLayout, offset: -1)
+    }
+
+    deinit {
+        try? FileManager.default.removeItem(at: url)
+    }
+}
+
+private struct RawEntrySizeListHeader {
+    let entsizeAndFlags: UInt32
+    let count: UInt32
+}
+
+private struct RawClassROData64 {
+    let flags: UInt32
+    let instanceStart: UInt32
+    let instanceSize: UInt32
+    let reserved: UInt32
+    let ivarLayout: UInt64
+    let name: UInt64
+    let baseMethods: UInt64
+    let baseProtocols: UInt64
+    let ivars: UInt64
+    let weakIvarLayout: UInt64
+    let baseProperties: UInt64
+
+    init(
+        flags: UInt32,
+        instanceStart: UInt32,
+        instanceSize: UInt32,
+        _reserved: UInt32,
+        ivarLayout: UInt64,
+        name: UInt64,
+        baseMethods: UInt64,
+        baseProtocols: UInt64,
+        ivars: UInt64,
+        weakIvarLayout: UInt64,
+        baseProperties: UInt64
+    ) {
+        self.flags = flags
+        self.instanceStart = instanceStart
+        self.instanceSize = instanceSize
+        self.reserved = _reserved
+        self.ivarLayout = ivarLayout
+        self.name = name
+        self.baseMethods = baseMethods
+        self.baseProtocols = baseProtocols
+        self.ivars = ivars
+        self.weakIvarLayout = weakIvarLayout
+        self.baseProperties = baseProperties
+    }
+}
+
+private struct RawClass64 {
+    let isa: UInt64
+    let superclass: UInt64
+    let methodCacheBuckets: UInt64
+    let methodCacheProperties: UInt64
+    let dataVMAddrAndFastFlags: UInt64
+    let swiftClassFlags: UInt32
+}
+
+private struct RawProtocol64 {
+    let isa: UInt64
+    let mangledName: UInt64
+    let protocols: UInt64
+    let instanceMethods: UInt64
+    let classMethods: UInt64
+    let optionalInstanceMethods: UInt64
+    let optionalClassMethods: UInt64
+    let instanceProperties: UInt64
+    let size: UInt32
+    let flags: UInt32
+    let extendedMethodTypes: UInt64
+    let demangledName: UInt64
+    let classProperties: UInt64
+}
+
+private extension Data {
+    func loadValue<Value>(_ type: Value.Type, at offset: Int) -> Value {
+        self[offset..<(offset + MemoryLayout<Value>.size)].withUnsafeBytes {
+            $0.loadUnaligned(as: type)
+        }
+    }
+
+    func loadValue<Value, Raw>(_ type: Value.Type, from raw: Raw) -> Value {
+        precondition(MemoryLayout<Value>.size == MemoryLayout<Raw>.size)
+        return Swift.withUnsafeBytes(of: raw) {
+            $0.loadUnaligned(as: type)
+        }
+    }
+
+    mutating func storeValue<Value>(_ value: Value, at offset: Int) {
+        Swift.withUnsafeBytes(of: value) { bytes in
+            replaceSubrange(offset..<(offset + bytes.count), with: bytes)
+        }
+    }
+
+    mutating func storeCString(_ value: String, at offset: Int) {
+        let bytes = Array(value.utf8) + [0]
+        replaceSubrange(offset..<(offset + bytes.count), with: bytes)
+    }
+}


### PR DESCRIPTION
## Purpose

Fix #65 by resolving every loaded entry in Objective-C relative method and property list-of-lists, instead of selecting only the class owner's first entry and silently dropping the rest.

This branch descends from #66. Merge order is #63, #64, #66, then this PR.

## Changes

- advance the exact MachOObjCSection/MachOSwiftSection cohort to the plural member-list resolver
- preserve outer-table order, duplicate image indices, valid siblings beside malformed entries, and file-backed all-entry semantics
- treat zero-count member lists as valid even when their unused entry size is zero or flags-only
- collect typed instance/class method/property diagnostics through the existing bounded Objective-C warning report
- document the loaded-image and file-backed contracts
- add consumer-level synthetic Mach-O coverage for public `readInfo`, shared dedup/cap/omitted accounting, and JSON wire round trips

Supporting revisions:

- MachOObjCSection: `932bff230815e39901e825e419db588377edee5c`
- MachOSwiftSection: `8970e899efb13f355c2b8769e67e35ba39e07004`

## Testing

- MachOObjCSection: 41 protocol-safety tests, 9 member-list tests, 35 Swift Testing tests, and release target build
- MachOSwiftSection: 1,359 tests in 253 suites with remote dependencies
- PrivateHeaderKit: 508 tests in 41 suites
- release script contract tests
- iOS simulator Core/CoreTests builds
- watchOS simulator Core/CoreTests/simulator-helper builds
- watchOS 27 CoreFoundation + Foundation fresh generation: 2 generated, 0 failed, 0 Objective-C metadata warnings
- `NSRunLoop`: 42 instance methods, matching the runtime (baseline: 8)
- `NSProgress`: recovered `installState`, `installPhase`, `installPhaseString`, and `ls_expectedFinalInstallPhase`
- Codex review: no findings across the dependency cohort and integration diff

Note: the release test bundle compiles, but direct `swift test -c release` execution still hits the package's pre-existing test-runner routing issue where `--test-bundle-path` reaches the `privateheaderkit` CLI.