### PR TITLE
Recover deleted publication output

### DIFF
--- a/Docs/generation.md
+++ b/Docs/generation.md
@@ -140,6 +140,11 @@ State, attempts, publication intent, and run diagnostics are stored in
 link and `.privateheaderkit` tree are internal recovery artifacts; consumers
 should not use them instead of the printed `Headers` directory.
 
+If the printed header directory or top-level source link is removed while the
+authenticated current generation remains available, the next run recreates
+the managed link and restores the missing published files before deciding
+whether to continue or restart.
+
 ## Continue or Restart
 
 - `--resume` continues the latest compatible plan and runs only unfinished or

--- a/Sources/PrivateHeaderKitCore/PrivateHeaderGenerationArtifactPublisher.swift
+++ b/Sources/PrivateHeaderKitCore/PrivateHeaderGenerationArtifactPublisher.swift
@@ -829,29 +829,34 @@ package struct ArtifactPublisher: Sendable {
     case .managed:
       return
     case .absent:
-      let temporary = artifactBaseDirectory.appendingPathComponent(
-        ".privateheaderkit-link-\(UUID().uuidString.lowercased())",
-        isDirectory: false
-      )
-      try createSymbolicLink(at: temporary, destination: stableLinkDestination)
-      do {
-        try atomicRename(from: temporary, to: stableURL)
-      } catch {
-        let renameError = error
-        do {
-          try FileManager.default.removeItem(at: temporary)
-        } catch {
-          throw PublisherError.unexpectedItem(
-            path: temporary.path,
-            description:
-              "stable pointer switch failed with \(renameError), and temporary link cleanup failed: \(error)"
-          )
-        }
-        throw renameError
+      try installStablePointer { source, destination in
+        try atomicRename(from: source, to: destination)
       }
-      try syncDirectory(artifactBaseDirectory)
     case .legacyDirectory:
       try swapLegacyDirectoryForStableLink()
+    }
+  }
+
+  package func restoreStablePointer(
+    to generationID: PrivateHeaderGeneration.GenerationID
+  ) throws {
+    guard try readCurrentGenerationID() == generationID else {
+      throw PublisherError.markerMismatch(
+        "current generation changed before stable pointer restoration"
+      )
+    }
+    _ = try validateGeneration(at: generationURL(generationID), expectedID: generationID)
+    guard try stablePathState() == .absent else {
+      throw PublisherError.markerMismatch(
+        "stable path became occupied before pointer restoration"
+      )
+    }
+    try installStablePointer { source, destination in
+      do {
+        try ManagedFileSystem.atomicRenameExclusively(from: source, to: destination)
+      } catch let error as ManagedFileSystem.Failure {
+        throw Self.mapManagedFileSystemFailure(error)
+      }
     }
   }
 
@@ -1679,6 +1684,32 @@ extension ArtifactPublisher {
     #endif
     try syncDirectory(artifactBaseDirectory)
     try syncDirectory(legacyBackupsURL)
+  }
+
+  fileprivate func installStablePointer(
+    using renamePointer: (URL, URL) throws -> Void
+  ) throws {
+    let temporary = artifactBaseDirectory.appendingPathComponent(
+      ".privateheaderkit-link-\(UUID().uuidString.lowercased())",
+      isDirectory: false
+    )
+    try createSymbolicLink(at: temporary, destination: stableLinkDestination)
+    do {
+      try renamePointer(temporary, stableURL)
+    } catch {
+      let renameError = error
+      do {
+        try FileManager.default.removeItem(at: temporary)
+      } catch {
+        throw PublisherError.unexpectedItem(
+          path: temporary.path,
+          description:
+            "stable pointer publication failed with \(renameError), and temporary link cleanup failed: \(error)"
+        )
+      }
+      throw renameError
+    }
+    try syncDirectory(artifactBaseDirectory)
   }
 
   fileprivate func createSymbolicLink(at url: URL, destination: String) throws {

--- a/Sources/PrivateHeaderKitCore/PrivateHeaderGenerationExecutor.swift
+++ b/Sources/PrivateHeaderKitCore/PrivateHeaderGenerationExecutor.swift
@@ -1456,6 +1456,9 @@ extension PrivateHeaderGeneration.GenerationExecutor {
         terminalReason: terminalReason
       )
       switch action {
+      case .restoreStablePointer(let generationID):
+        try publisher.restoreStablePointer(to: generationID)
+        continue
       case .completeStablePointer:
         try publisher.ensureStablePointer()
         continue

--- a/Sources/PrivateHeaderKitCore/PrivateHeaderGenerationState.swift
+++ b/Sources/PrivateHeaderKitCore/PrivateHeaderGenerationState.swift
@@ -357,6 +357,7 @@ extension PrivateHeaderGeneration {
     case none
     case recognized(GenerationID?)
     case discardGeneration(GenerationID)
+    case restoreStablePointer(GenerationID)
     case completeStablePointer(GenerationID)
     case rolledForward(GenerationID)
   }

--- a/Sources/PrivateHeaderKitCore/PrivateHeaderGenerationStore.swift
+++ b/Sources/PrivateHeaderKitCore/PrivateHeaderGenerationStore.swift
@@ -660,11 +660,7 @@ package actor GenerationStore {
       }
 
       if intent.state == .committed {
-        guard publication.currentGenerationID == intent.generationID,
-          let marker = publication.currentMarker,
-          marker.planFingerprint == intent.planFingerprint,
-          marker.artifactChecksum == intent.artifactChecksum
-        else {
+        guard Self.currentPublicationMatchesCommittedIntent(publication, intent: intent) else {
           throw PrivateHeaderGeneration.StateError.corruptPublication(
             "committed generation \(intent.generationID.rawValue) does not match current publication"
           )
@@ -674,7 +670,7 @@ package actor GenerationStore {
         case .managed:
           action = .none
         case .absent:
-          action = .completeStablePointer(intent.generationID)
+          action = .restoreStablePointer(intent.generationID)
         case .legacyDirectory:
           throw PrivateHeaderGeneration.StateError.corruptPublication(
             "committed generation \(intent.generationID.rawValue) conflicts with an unmanaged stable publication"
@@ -689,16 +685,31 @@ package actor GenerationStore {
             "aborted generation \(intent.generationID.rawValue) does not preserve its previous current generation"
           )
         }
+        let stableRecoveryAction: PrivateHeaderGeneration.RecoveryAction?
         switch (intent.previousGenerationID, publication.stablePathState) {
         case (nil, .absent), (nil, .legacyDirectory):
-          break
+          stableRecoveryAction = nil
         case (.some, .managed):
           guard publication.currentMarker != nil else {
             throw PrivateHeaderGeneration.StateError.corruptPublication(
               "aborted generation \(intent.generationID.rawValue) has no marker for its previous current generation"
             )
           }
-        case (nil, .managed), (.some, .absent), (.some, .legacyDirectory):
+          stableRecoveryAction = nil
+        case (.some(let previousGenerationID), .absent):
+          guard
+            let previousIntent = try Self.fetchPublicationIntentIfPresent(
+              db,
+              generationID: previousGenerationID
+            ),
+            Self.currentPublicationMatchesCommittedIntent(publication, intent: previousIntent)
+          else {
+            throw PrivateHeaderGeneration.StateError.corruptPublication(
+              "aborted generation \(intent.generationID.rawValue) has no authenticated committed previous generation"
+            )
+          }
+          stableRecoveryAction = .restoreStablePointer(previousGenerationID)
+        case (nil, .managed), (.some, .legacyDirectory):
           throw PrivateHeaderGeneration.StateError.corruptPublication(
             "aborted generation \(intent.generationID.rawValue) has inconsistent stable publication state"
           )
@@ -707,7 +718,7 @@ package actor GenerationStore {
         if publication.validGenerationIDs.contains(intent.generationID) {
           return .discardGeneration(intent.generationID)
         }
-        return .recognized(publication.currentGenerationID)
+        return stableRecoveryAction ?? .recognized(publication.currentGenerationID)
       }
 
       guard publication.validGenerationIDs.contains(intent.generationID) else {
@@ -1566,6 +1577,21 @@ extension GenerationStore {
       return nil
     }
     return try fetchPublicationIntent(db, generationID: PrivateHeaderGeneration.GenerationID(id))
+  }
+
+  fileprivate static func currentPublicationMatchesCommittedIntent(
+    _ publication: PrivateHeaderGeneration.PublicationSnapshot,
+    intent: PrivateHeaderGeneration.PublicationIntent
+  ) -> Bool {
+    guard intent.state == .committed,
+      publication.currentGenerationID == intent.generationID,
+      let marker = publication.currentMarker
+    else {
+      return false
+    }
+    return marker.generationID == intent.generationID
+      && marker.planFingerprint == intent.planFingerprint
+      && marker.artifactChecksum == intent.artifactChecksum
   }
 
   fileprivate static func fetchPublicationIntentIfPresent(

--- a/Sources/PrivateHeaderKitCore/PrivateHeaderGenerationStore.swift
+++ b/Sources/PrivateHeaderKitCore/PrivateHeaderGenerationStore.swift
@@ -661,7 +661,6 @@ package actor GenerationStore {
 
       if intent.state == .committed {
         guard publication.currentGenerationID == intent.generationID,
-          publication.stablePathState == .managed,
           let marker = publication.currentMarker,
           marker.planFingerprint == intent.planFingerprint,
           marker.artifactChecksum == intent.artifactChecksum
@@ -670,8 +669,19 @@ package actor GenerationStore {
             "committed generation \(intent.generationID.rawValue) does not match current publication"
           )
         }
+        let action: PrivateHeaderGeneration.RecoveryAction
+        switch publication.stablePathState {
+        case .managed:
+          action = .none
+        case .absent:
+          action = .completeStablePointer(intent.generationID)
+        case .legacyDirectory:
+          throw PrivateHeaderGeneration.StateError.corruptPublication(
+            "committed generation \(intent.generationID.rawValue) conflicts with an unmanaged stable publication"
+          )
+        }
         try Self.interruptDanglingRuns(db, at: date)
-        return .none
+        return action
       }
       if intent.state == .aborted {
         guard publication.currentGenerationID == intent.previousGenerationID else {

--- a/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationArtifactPublisherTests.swift
+++ b/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationArtifactPublisherTests.swift
@@ -34,6 +34,39 @@ struct PrivateHeaderGenerationArtifactPublisherTests {
         encoding: .utf8) == "new")
   }
 
+  @Test func stablePointerRestorationRejectsAnOccupiedDestination() throws {
+    let fixture = try PublisherFixture()
+    defer { fixture.cleanup() }
+    let generationID = PrivateHeaderGeneration.GenerationID(rawValue: "generation-current")
+    try fixture.publish(
+      fixture.prepare(
+        generationID: generationID,
+        targetID: "framework:Foo",
+        relativePath: "Frameworks/Foo/Foo.h",
+        contents: "current"
+      )
+    )
+    try FileManager.default.removeItem(at: fixture.publisher.stableURL)
+    try FileManager.default.createDirectory(
+      at: fixture.publisher.stableURL,
+      withIntermediateDirectories: false
+    )
+    let userFile = fixture.publisher.stableURL.appendingPathComponent("user.txt")
+    try Data("keep".utf8).write(to: userFile)
+
+    #expect(throws: ArtifactPublisher.PublisherError.self) {
+      try fixture.publisher.restoreStablePointer(to: generationID)
+    }
+
+    #expect(try String(contentsOf: userFile, encoding: .utf8) == "keep")
+    #expect(try fixture.publisher.inspect().stablePathState == .legacyDirectory)
+    #expect(
+      !FileManager.default.fileExists(
+        atPath: fixture.publisher.managedRoot.appendingPathComponent("legacy-backups").path
+      )
+    )
+  }
+
   @Test func legacyFreshMigrationPreservesOpaqueContentAndRetainsOriginalTree() throws {
     let fixture = try PublisherFixture()
     defer { fixture.cleanup() }

--- a/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationExecutorTests.swift
+++ b/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationExecutorTests.swift
@@ -971,6 +971,65 @@ struct PrivateHeaderGenerationExecutorTests {
     )
   }
 
+  @Test func freshRunRepairsDeletedOutputAfterAbortedPublication() async throws {
+    let fixture = try ExecutorFixture()
+    defer { fixture.cleanup() }
+    try fixture.createFramework("Foo.framework")
+    _ = try await fixture.executor(
+      runner: RecordingRunner(contents: "old"),
+      runID: "run-old",
+      generationID: "generation-old"
+    ).run(plan: try fixture.plan(.query("Foo")))
+    let mutation = FileMutationRecorder()
+    let draftURL = fixture.outputBase
+      .appendingPathComponent(".privateheaderkit/\(fixture.sourceLabel)/staging", isDirectory: true)
+      .appendingPathComponent("generation-aborted.draft", isDirectory: true)
+    do {
+      _ = try await fixture.executor(
+        runner: RecordingRunner(contents: "unpublished"),
+        runID: "run-aborted",
+        generationID: "generation-aborted",
+        publicationFaultInjector: { point in
+          guard point == .afterPrepared else { return }
+          mutation.run {
+            try FileManager.default.removeItem(at: draftURL)
+          }
+        }
+      ).run(plan: try fixture.plan(.query("Foo"), resumeBehavior: .fresh))
+      Issue.record("missing prepared generation unexpectedly committed")
+    } catch let PrivateHeaderGeneration.GenerationError.infrastructureFailed(failure) {
+      #expect(failure.message.contains("missing marker"))
+    }
+    #expect(mutation.message == nil)
+    let store = try GenerationStore(
+      databaseURL: fixture.databaseURL,
+      toolCompatibilityIdentity: "test"
+    )
+    #expect(
+      try await store.publicationIntent(generationID: .init(rawValue: "generation-aborted"))?
+        .state == .aborted
+    )
+    try FileManager.default.removeItem(at: fixture.stableURL)
+    try FileManager.default.removeItem(at: fixture.liveURL)
+    let runner = RecordingRunner(contents: "regenerated")
+    let executor = fixture.executor(
+      runner: runner,
+      runID: "run-regenerated",
+      generationID: "generation-regenerated"
+    )
+    let preparedPlan = try await executor.prepare(try fixture.plan(.query("Foo")))
+
+    _ = try await executor.availableResumeSummary(for: preparedPlan)
+    #expect(try fixture.publisher().inspect().stablePathState == .managed)
+
+    let result = try await executor.run(preparedPlan.withResumeBehavior(.fresh))
+
+    #expect(await runner.invocationCount == 1)
+    #expect(result.targetCounts.completed == 1)
+    #expect(try fixture.readLiveHeader() == "regenerated")
+    #expect(try fixture.readStableHeader() == "regenerated")
+  }
+
   @Test func nextSnapshotUsesCanonicalBytesForCoveredTargetAfterLiveMutation() async throws {
     let fixture = try ExecutorFixture()
     defer { fixture.cleanup() }

--- a/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationExecutorTests.swift
+++ b/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationExecutorTests.swift
@@ -907,6 +907,70 @@ struct PrivateHeaderGenerationExecutorTests {
     #expect(try fixture.readStableHeader() == "first")
   }
 
+  @Test func resumeSummaryRepairsDeletedPublishedOutput() async throws {
+    let fixture = try ExecutorFixture()
+    defer { fixture.cleanup() }
+    try fixture.createFramework("Foo.framework")
+    let plan = try fixture.plan(.query("Foo"))
+    _ = try await fixture.executor(
+      runner: RecordingRunner(contents: "first"),
+      runID: "run-first",
+      generationID: "generation-first"
+    ).run(plan: plan)
+    try FileManager.default.removeItem(at: fixture.stableURL)
+    try FileManager.default.removeItem(at: fixture.liveURL)
+    let runner = RecordingRunner(contents: "unexpected")
+    let executor = fixture.executor(
+      runner: runner,
+      runID: "run-resumed",
+      generationID: "generation-resumed"
+    )
+    let preparedPlan = try await executor.prepare(plan)
+
+    #expect(try await executor.availableResumeSummary(for: preparedPlan) == nil)
+    #expect(try fixture.publisher().inspect().stablePathState == .managed)
+    #expect(try fixture.readLiveHeader() == "first")
+    #expect(try fixture.readStableHeader() == "first")
+
+    let result = try await executor.run(preparedPlan)
+
+    #expect(await runner.invocationCount == 0)
+    #expect(result.targetCounts.skipped == 1)
+    #expect(
+      try fixture.publisher().inspect().currentGenerationID
+        == .init(rawValue: "generation-first")
+    )
+  }
+
+  @Test func freshRunRepairsDeletedPublishedOutputBeforeRegenerating() async throws {
+    let fixture = try ExecutorFixture()
+    defer { fixture.cleanup() }
+    try fixture.createFramework("Foo.framework")
+    _ = try await fixture.executor(
+      runner: RecordingRunner(contents: "first"),
+      runID: "run-first",
+      generationID: "generation-first"
+    ).run(plan: try fixture.plan(.query("Foo")))
+    try FileManager.default.removeItem(at: fixture.stableURL)
+    try FileManager.default.removeItem(at: fixture.liveURL)
+    let runner = RecordingRunner(contents: "regenerated")
+
+    let result = try await fixture.executor(
+      runner: runner,
+      runID: "run-regenerated",
+      generationID: "generation-regenerated"
+    ).run(plan: try fixture.plan(.query("Foo"), resumeBehavior: .fresh))
+
+    #expect(await runner.invocationCount == 1)
+    #expect(result.targetCounts.completed == 1)
+    #expect(try fixture.readLiveHeader() == "regenerated")
+    #expect(try fixture.readStableHeader() == "regenerated")
+    #expect(
+      try fixture.publisher().inspect().currentGenerationID
+        == .init(rawValue: "generation-regenerated")
+    )
+  }
+
   @Test func nextSnapshotUsesCanonicalBytesForCoveredTargetAfterLiveMutation() async throws {
     let fixture = try ExecutorFixture()
     defer { fixture.cleanup() }

--- a/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationStoreTests.swift
+++ b/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationStoreTests.swift
@@ -129,6 +129,28 @@ struct PrivateHeaderGenerationStoreTests {
     )
   }
 
+  @Test func committedIntentRepairsMissingStablePointer() async throws {
+    let fixture = try StoreFixture()
+    defer { fixture.cleanup() }
+    let ids = try await fixture.prepareCompletedPublication()
+    try await fixture.store.markPointerPublished(ids.generationID)
+    _ = try await fixture.store.completePublication(ids.generationID, at: fixture.date)
+
+    let action = try await fixture.store.recover(
+      using: .init(
+        currentGenerationID: ids.generationID,
+        stablePathState: .absent,
+        markers: [ids.generationID: fixture.marker(ids.generationID)]
+      ),
+      at: fixture.date
+    )
+
+    #expect(action == .completeStablePointer(ids.generationID))
+    #expect(
+      try await fixture.store.publicationIntent(generationID: ids.generationID)?.state == .committed
+    )
+  }
+
   @Test func publishedTargetAttemptBecomesImmediatelyResumable() async throws {
     let fixture = try StoreFixture()
     defer { fixture.cleanup() }
@@ -189,6 +211,25 @@ struct PrivateHeaderGenerationStoreTests {
           currentGenerationID: ids.generationID,
           stablePathState: .managed,
           markers: [ids.generationID: mismatched]
+        ),
+        at: fixture.date
+      )
+    }
+  }
+
+  @Test func committedIntentRejectsUnmanagedStableDirectory() async throws {
+    let fixture = try StoreFixture()
+    defer { fixture.cleanup() }
+    let ids = try await fixture.prepareCompletedPublication()
+    try await fixture.store.markPointerPublished(ids.generationID)
+    _ = try await fixture.store.completePublication(ids.generationID, at: fixture.date)
+
+    await #expect(throws: PrivateHeaderGeneration.StateError.self) {
+      _ = try await fixture.store.recover(
+        using: .init(
+          currentGenerationID: ids.generationID,
+          stablePathState: .legacyDirectory,
+          markers: [ids.generationID: fixture.marker(ids.generationID)]
         ),
         at: fixture.date
       )

--- a/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationStoreTests.swift
+++ b/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationStoreTests.swift
@@ -145,9 +145,46 @@ struct PrivateHeaderGenerationStoreTests {
       at: fixture.date
     )
 
-    #expect(action == .completeStablePointer(ids.generationID))
+    #expect(action == .restoreStablePointer(ids.generationID))
     #expect(
       try await fixture.store.publicationIntent(generationID: ids.generationID)?.state == .committed
+    )
+  }
+
+  @Test func abortedIntentRepairsMissingStablePointerForCommittedPreviousGeneration()
+    async throws
+  {
+    let fixture = try StoreFixture()
+    defer { fixture.cleanup() }
+    let previousGenerationID = PrivateHeaderGeneration.GenerationID(rawValue: "generation-old")
+    let previous = try await fixture.prepareCompletedPublication(
+      runID: .init(rawValue: "run-old"),
+      generationID: previousGenerationID
+    )
+    try await fixture.store.markPointerPublished(previous.generationID)
+    _ = try await fixture.store.completePublication(previous.generationID, at: fixture.date)
+    let aborted = try await fixture.prepareCompletedPublication(
+      previousGenerationID: previousGenerationID,
+      runID: .init(rawValue: "run-aborted"),
+      generationID: .init(rawValue: "generation-aborted")
+    )
+    let publication = PrivateHeaderGeneration.PublicationSnapshot(
+      currentGenerationID: previousGenerationID,
+      stablePathState: .absent,
+      markers: [previousGenerationID: fixture.marker(previousGenerationID)]
+    )
+
+    #expect(
+      try await fixture.store.recover(using: publication, at: fixture.date)
+        == .discardGeneration(aborted.generationID)
+    )
+    #expect(
+      try await fixture.store.recover(using: publication, at: fixture.date)
+        == .restoreStablePointer(previousGenerationID)
+    )
+    #expect(
+      try await fixture.store.publicationIntent(generationID: aborted.generationID)?.state
+        == .aborted
     )
   }
 
@@ -793,12 +830,12 @@ private final class StoreFixture: @unchecked Sendable {
 
   func prepareCompletedPublication(
     previousGenerationID: PrivateHeaderGeneration.GenerationID? = nil,
-    targetIDs: [String] = ["framework:Foo"]
+    targetIDs: [String] = ["framework:Foo"],
+    runID: PrivateHeaderGeneration.RunID = .init(rawValue: "run-publication"),
+    generationID: PrivateHeaderGeneration.GenerationID = .init(rawValue: "generation-new")
   ) async throws -> (
     runID: PrivateHeaderGeneration.RunID, generationID: PrivateHeaderGeneration.GenerationID
   ) {
-    let runID = PrivateHeaderGeneration.RunID(rawValue: "run-publication")
-    let generationID = PrivateHeaderGeneration.GenerationID(rawValue: "generation-new")
     _ = try await store.beginRun(id: runID, plan: plan(targetIDs: targetIDs), at: date)
     for targetID in targetIDs {
       try await store.beginTargetAttempt(


### PR DESCRIPTION
## Purpose

Allow users to remove generated headers and the top-level source link, then rerun PrivateHeaderKit without the remaining committed state being misclassified as corrupt.

## Changes

- Recreate an absent managed stable pointer only when the current generation and authenticated marker match committed database state.
- Recover the authenticated previous committed generation when the latest publication intent was aborted.
- Use a dedicated exclusive restoration path so a concurrently occupied destination fails without moving user files or invoking legacy migration.
- Continue to reject mismatched generations, marker mismatches, and conflicting unmanaged directories.
- Restore missing live output through the existing publication hydration path before resume/restart selection.
- Document the recovery behavior and add store plus end-to-end coverage for resume inspection, aborted publications, and `--fresh` regeneration.

## Testing

- `swift test` — 517 tests in 41 suites passed.
- iOS Simulator compile checks for `PrivateHeaderKitCore` and `PrivateHeaderKitCoreTests` passed.
- watchOS Simulator compile checks for `PrivateHeaderKitCore`, `PrivateHeaderKitCoreTests`, and `privateheaderkit-sim-helper` passed.
- Branch-wide `codex-review` against pinned `main` (`2a24e86c8654018a88be8c9af431fd584e319e42`) — 0 findings.
