### PR TITLE
Publish generated headers under readable platform paths

### DIFF
--- a/Docs/generation.md
+++ b/Docs/generation.md
@@ -93,14 +93,16 @@ Platform directories use the displayed Apple platform name: `iOS`, `watchOS`,
 or `macOS`. Release directories include the exact build when it is available:
 
 ```text
-iOS/26.4 (23E244)/
-iOS/27.0 beta (24A5390f)/
+iOS/26.4_23E244/
+iOS/27.0_beta_24A5390f/
 ```
 
-PrivateHeaderKit does not infer a beta number because installed runtime metadata
-does not provide one. A beta-shaped Apple build identifier is accepted only
-when the source runtime's seed metadata agrees; disagreement or unreadable
-metadata stops generation instead of publishing under a guessed name.
+Release directory fields use underscores so paths do not require shell quoting.
+PrivateHeaderKit derives the `beta` field from the source runtime's seed
+metadata, not from the build suffix; this keeps lowercase-suffixed public
+releases out of the beta namespace. Installed metadata does not provide a beta
+number, so the build disambiguates beta sources. Missing or unreadable metadata
+stops generation instead of publishing under a guessed name.
 
 The complete output base is:
 

--- a/Docs/generation.md
+++ b/Docs/generation.md
@@ -86,11 +86,21 @@ for the command's generated reference.
 Consumers should use only the concrete directory printed as `Headers`:
 
 ```text
-<output-base>/generated-headers/<source-storage-id>/
+<output-base>/generated-headers/<platform>/<release-directory>/
 ```
 
-The storage ID is versioned and owned by PrivateHeaderKit. Do not construct it
-from the displayed source name.
+Platform directories use the displayed Apple platform name: `iOS`, `watchOS`,
+or `macOS`. Release directories include the exact build when it is available:
+
+```text
+iOS/26.4 (23E244)/
+iOS/27.0 beta (24A5390f)/
+```
+
+PrivateHeaderKit does not infer a beta number because installed runtime metadata
+does not provide one. A beta-shaped Apple build identifier is accepted only
+when the source runtime's seed metadata agrees; disagreement or unreadable
+metadata stops generation instead of publishing under a guessed name.
 
 The complete output base is:
 
@@ -98,11 +108,12 @@ The complete output base is:
 <output-base>/
   <source-storage-id> -> .privateheaderkit/<source-storage-id>/current
   generated-headers/
-    <source-storage-id>/
-      Frameworks/...
-      PrivateFrameworks/...
-      SystemLibrary/...
-      usr/lib/...
+    <platform>/
+      <release-directory>/
+        Frameworks/...
+        PrivateFrameworks/...
+        SystemLibrary/...
+        usr/lib/...
   .privateheaderkit/
     <source-storage-id>/
       current -> generations/<generation-id>
@@ -139,6 +150,14 @@ State, attempts, publication intent, and run diagnostics are stored in
 `generation.sqlite`, outside the published header tree. The top-level source
 link and `.privateheaderkit` tree are internal recovery artifacts; consumers
 should not use them instead of the printed `Headers` directory.
+
+PrivateHeaderKit automatically relocates its previous managed live directory,
+`generated-headers/<source-storage-id>`, to the platform/release layout while
+holding the same source lease. The whole directory is renamed atomically so
+completed targets from an interrupted run remain resumable. If both the old
+and new directories exist, PrivateHeaderKit leaves both unchanged and stops;
+it never guesses how to merge or overwrite them. Unrelated siblings under
+`generated-headers` are not part of this relocation.
 
 ## Continue or Restart
 

--- a/Docs/troubleshooting.md
+++ b/Docs/troubleshooting.md
@@ -61,6 +61,14 @@ an unmanaged output directory.
 See [Generation, Output, and Resume Behavior](generation.md#legacy-output) for
 the migration contract.
 
+## Both generated-header layouts exist
+
+PrivateHeaderKit does not merge
+`generated-headers/<source-storage-id>` with the corresponding
+`generated-headers/<platform>/<release-directory>`. Move one complete directory
+aside after deciding which tree to keep, then rerun the command. Both paths are
+left unchanged when this conflict is detected.
+
 ## An install or update failed
 
 Read the first reported validation or filesystem error. Download, build,

--- a/README.ja.md
+++ b/README.ja.md
@@ -26,7 +26,7 @@ privateheaderkit
 source を選び、全 target または個別の framework、bundle、dylib 名を指定します。
 デフォルトでは `~/PrivateHeaderKit` に生成し、実際の出力先を `Headers` として表示します。
 生成した header は platform と正確な source ごとに整理されます。たとえば
-`generated-headers/iOS/27.0 beta (24A5390f)` です。
+`generated-headers/iOS/27.0_beta_24A5390f` です。
 
 installer が shell profile を勝手に編集することはありません。
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -25,6 +25,8 @@ privateheaderkit
 
 source を選び、全 target または個別の framework、bundle、dylib 名を指定します。
 デフォルトでは `~/PrivateHeaderKit` に生成し、実際の出力先を `Headers` として表示します。
+生成した header は platform と正確な source ごとに整理されます。たとえば
+`generated-headers/iOS/27.0 beta (24A5390f)` です。
 
 installer が shell profile を勝手に編集することはありません。
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Choose a source, then generate all targets or enter specific framework, bundle,
 or dylib names. PrivateHeaderKit writes to `~/PrivateHeaderKit` by default and
 prints the exact `Headers` directory for the generated files.
 Generated headers are grouped by platform and exact source, for example
-`generated-headers/iOS/27.0 beta (24A5390f)`.
+`generated-headers/iOS/27.0_beta_24A5390f`.
 
 The installer does not edit shell profiles.
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ privateheaderkit
 Choose a source, then generate all targets or enter specific framework, bundle,
 or dylib names. PrivateHeaderKit writes to `~/PrivateHeaderKit` by default and
 prints the exact `Headers` directory for the generated files.
+Generated headers are grouped by platform and exact source, for example
+`generated-headers/iOS/27.0 beta (24A5390f)`.
 
 The installer does not edit shell profiles.
 

--- a/Sources/PrivateHeaderKitCLI/PrivateHeaderKitArguments.swift
+++ b/Sources/PrivateHeaderKitCLI/PrivateHeaderKitArguments.swift
@@ -81,7 +81,7 @@ struct PrivateHeaderKitGenerationArguments: ParsableArguments {
             throw ValidationError("Argument '--sim-helper <sim-helper>' must not be empty")
         }
         try validatePrivateHeaderKitTargetQuery(targetQuery)
-        _ = try PrivateHeaderGeneration.Source(
+        try PrivateHeaderGeneration.Source.validateIdentity(
             platform: platform.corePlatform,
             version: sourceVersion,
             build: build

--- a/Sources/PrivateHeaderKitCLI/PrivateHeaderKitCommand.swift
+++ b/Sources/PrivateHeaderKitCLI/PrivateHeaderKitCommand.swift
@@ -1095,8 +1095,10 @@ func resolvePrivateHeaderKitSimulator(
         in: canonicalDirectoryURL(path: runtime.runtimeRoot),
         layout: .simulator
     )
-    try PrivateHeaderGeneration.Source.validateReleaseMetadata(
-        build: runtime.build,
+    _ = try PrivateHeaderGeneration.Source(
+        platform: command.platform.corePlatform,
+        version: runtime.version,
+        build: runtime.build.isEmpty ? nil : runtime.build,
         metadataIsSeed: metadataIsSeed
     )
     let device = try await Simctl.resolveDevice(
@@ -1114,26 +1116,42 @@ func resolvePrivateHeaderKitSimulator(
 func discoverPrivateHeaderKitInteractiveSources() async throws
     -> [PrivateHeaderKitInteractiveSource]
 {
-    try await discoverPrivateHeaderKitInteractiveSources(runner: ProcessRunner())
+    try await discoverPrivateHeaderKitInteractiveSources(
+        runner: ProcessRunner(),
+        releaseMetadataResolver: resolvePrivateHeaderKitReleaseMetadata
+    )
 }
 
 func discoverPrivateHeaderKitInteractiveSources(
-    runner: CommandRunning
+    runner: CommandRunning,
+    releaseMetadataResolver: PrivateHeaderKitReleaseMetadataResolver =
+        resolvePrivateHeaderKitReleaseMetadata
 ) async throws -> [PrivateHeaderKitInteractiveSource] {
     var sources = try await (Simctl.listRuntimesIfAvailable(runner: runner) ?? []).map {
-        PrivateHeaderKitInteractiveSource(
+        let metadataIsSeed = try releaseMetadataResolver(
+            canonicalDirectoryURL(path: $0.runtimeRoot),
+            .simulator
+        )
+        return PrivateHeaderKitInteractiveSource(
             platform: .init(simulatorPlatform: $0.platform),
             version: $0.version,
             build: $0.build.isEmpty ? nil : $0.build,
+            metadataIsSeed: metadataIsSeed,
             systemRoot: nil
         )
     }
-    sources.append(try await currentMacOSInteractiveSource(runner: runner))
+    sources.append(
+        try await currentMacOSInteractiveSource(
+            runner: runner,
+            releaseMetadataResolver: releaseMetadataResolver
+        )
+    )
     return sources
 }
 
 private func currentMacOSInteractiveSource(
-    runner: CommandRunning
+    runner: CommandRunning,
+    releaseMetadataResolver: PrivateHeaderKitReleaseMetadataResolver
 ) async throws -> PrivateHeaderKitInteractiveSource {
     let version = try await runner.runCapture(
         ["/usr/bin/sw_vers", "-productVersion"],
@@ -1145,10 +1163,15 @@ private func currentMacOSInteractiveSource(
         env: nil,
         cwd: nil
     ).trimmingCharacters(in: .whitespacesAndNewlines)
+    let metadataIsSeed = try releaseMetadataResolver(
+        URL(fileURLWithPath: "/", isDirectory: true),
+        .macOS
+    )
     return PrivateHeaderKitInteractiveSource(
         platform: .macOS,
         version: version,
         build: build.isEmpty ? nil : build,
+        metadataIsSeed: metadataIsSeed,
         systemRoot: "/"
     )
 }

--- a/Sources/PrivateHeaderKitCLI/PrivateHeaderKitCommand.swift
+++ b/Sources/PrivateHeaderKitCLI/PrivateHeaderKitCommand.swift
@@ -88,6 +88,7 @@ struct PrivateHeaderKitSimulatorResolution: Equatable, Sendable {
     let runtimeBuild: String
     let runtimeIdentifier: String
     let resolvedRuntimeRoot: String
+    let metadataIsSeed: Bool
     let deviceName: String
     let deviceUDID: String
 
@@ -96,6 +97,7 @@ struct PrivateHeaderKitSimulatorResolution: Equatable, Sendable {
         runtimeBuild: String,
         runtimeIdentifier: String,
         resolvedRuntimeRoot: String,
+        metadataIsSeed: Bool,
         deviceName: String,
         deviceUDID: String
     ) {
@@ -103,16 +105,18 @@ struct PrivateHeaderKitSimulatorResolution: Equatable, Sendable {
         self.runtimeBuild = runtimeBuild
         self.runtimeIdentifier = runtimeIdentifier
         self.resolvedRuntimeRoot = resolvedRuntimeRoot
+        self.metadataIsSeed = metadataIsSeed
         self.deviceName = deviceName
         self.deviceUDID = deviceUDID
     }
 
-    init(runtime: RuntimeInfo, device: DeviceInfo) {
+    init(runtime: RuntimeInfo, metadataIsSeed: Bool, device: DeviceInfo) {
         self.init(
             runtimeVersion: runtime.version,
             runtimeBuild: runtime.build,
             runtimeIdentifier: runtime.identifier,
             resolvedRuntimeRoot: runtime.runtimeRoot,
+            metadataIsSeed: metadataIsSeed,
             deviceName: device.name,
             deviceUDID: device.udid
         )
@@ -127,7 +131,18 @@ typealias PrivateHeaderKitHelperResolver = @Sendable (
     String?,
     SimulatorPlatform?
 ) async throws -> PrivateHeaderKitHelperPlan
+typealias PrivateHeaderKitReleaseMetadataResolver = @Sendable (
+    URL,
+    RuntimeRootLayout
+) throws -> Bool
 typealias PrivateHeaderKitOutputLogger = @Sendable (String) -> Void
+
+func resolvePrivateHeaderKitReleaseMetadata(
+    systemRoot: URL,
+    layout: RuntimeRootLayout
+) throws -> Bool {
+    try RuntimeReleaseMetadata.isSeed(in: systemRoot, layout: layout)
+}
 
 struct PrivateHeaderKitHelperPlan: Sendable {
     let helperURLs: PrivateHeaderGeneration.RawDumping.HelperURLs
@@ -184,6 +199,8 @@ func runPrivateHeaderKitCommand(
     generationClient: PrivateHeaderKitGenerationClient = .live,
     simulatorResolver: @escaping PrivateHeaderKitSimulatorResolver = resolvePrivateHeaderKitSimulator,
     helperResolver: @escaping PrivateHeaderKitHelperResolver = resolvePrivateHeaderKitHelperURLs,
+    releaseMetadataResolver: @escaping PrivateHeaderKitReleaseMetadataResolver =
+        resolvePrivateHeaderKitReleaseMetadata,
     interactiveSourceProvider: @escaping PrivateHeaderKitInteractiveSourceProvider =
         discoverPrivateHeaderKitInteractiveSources,
     interactiveOutputBaseDirectoryProvider: @escaping () -> String =
@@ -231,6 +248,7 @@ func runPrivateHeaderKitCommand(
                 generationClient: generationClient,
                 simulatorResolver: simulatorResolver,
                 helperResolver: helperResolver,
+                releaseMetadataResolver: releaseMetadataResolver,
                 sourceProvider: interactiveSourceProvider,
                 outputBaseDirectoryProvider: interactiveOutputBaseDirectoryProvider,
                 screenClearer: interactiveScreenClearer,
@@ -247,6 +265,7 @@ func runPrivateHeaderKitCommand(
                 generationClient: generationClient,
                 simulatorResolver: simulatorResolver,
                 helperResolver: helperResolver,
+                releaseMetadataResolver: releaseMetadataResolver,
                 outputLogger: outputLogger,
                 errorLogger: errorLogger
             )
@@ -273,6 +292,8 @@ func runPrivateHeaderKitGenerateCommand(
     generationClient: PrivateHeaderKitGenerationClient,
     simulatorResolver: PrivateHeaderKitSimulatorResolver,
     helperResolver: PrivateHeaderKitHelperResolver = resolvePrivateHeaderKitHelperURLs,
+    releaseMetadataResolver: PrivateHeaderKitReleaseMetadataResolver =
+        resolvePrivateHeaderKitReleaseMetadata,
     resultScreenClearer: PrivateHeaderKitInteractiveScreenClearer? = nil,
     outputLogger: @escaping PrivateHeaderKitOutputLogger,
     errorLogger: @escaping PrivateHeaderKitOutputLogger
@@ -284,6 +305,7 @@ func runPrivateHeaderKitGenerateCommand(
             currentExecutableURL: currentExecutableURL,
             simulatorResolver: simulatorResolver,
             helperResolver: helperResolver,
+            releaseMetadataResolver: releaseMetadataResolver,
             outputLogger: outputLogger
         )
         do {
@@ -324,18 +346,10 @@ func preparePrivateHeaderKitGenerationRequest(
     currentExecutableURL: URL?,
     simulatorResolver: PrivateHeaderKitSimulatorResolver,
     helperResolver: PrivateHeaderKitHelperResolver,
+    releaseMetadataResolver: PrivateHeaderKitReleaseMetadataResolver =
+        resolvePrivateHeaderKitReleaseMetadata,
     outputLogger: @escaping PrivateHeaderKitOutputLogger
 ) async throws -> PrivateHeaderKitGenerationRequest {
-    let publicExecutableURL = privateHeaderKitExecutableURL(
-        currentExecutableURL: currentExecutableURL,
-        fallbackProgramName: invokedProgramName
-    )
-    let helperPlan = try await helperResolver(
-        publicExecutableURL,
-        command.simulatorHelperPath,
-        command.platform.simulatorPlatform
-    )
-    try await preparePrivateHeaderKitHelpers(helperPlan)
     let simulatorResolution: PrivateHeaderKitSimulatorResolution?
     if command.platform.simulatorPlatform != nil {
         let resolution = try await simulatorResolver(command)
@@ -346,8 +360,24 @@ func preparePrivateHeaderKitGenerationRequest(
     } else {
         simulatorResolution = nil
     }
+    let effectiveSource = try effectiveSourceConfiguration(
+        from: command,
+        simulatorResolution: simulatorResolution,
+        releaseMetadataResolver: releaseMetadataResolver
+    )
+    let publicExecutableURL = privateHeaderKitExecutableURL(
+        currentExecutableURL: currentExecutableURL,
+        fallbackProgramName: invokedProgramName
+    )
+    let helperPlan = try await helperResolver(
+        publicExecutableURL,
+        command.simulatorHelperPath,
+        command.platform.simulatorPlatform
+    )
+    try await preparePrivateHeaderKitHelpers(helperPlan)
     return try makePrivateHeaderGenerationRequest(
         from: command,
+        effectiveSource: effectiveSource,
         helperURLs: helperPlan.helperURLs,
         toolCompatibilityIdentity: helperPlan.toolCompatibilityIdentity,
         simulatorResolution: simulatorResolution
@@ -367,10 +397,7 @@ func runPrivateHeaderKitPreparedGeneration(
         let result = try await preparedGeneration.run(
             resumeBehavior,
             privateHeaderKitProgressReporter(
-                artifactDirectory: request.output.artifactBaseDirectory.appendingPathComponent(
-                    request.source.storageIdentifier,
-                    isDirectory: true
-                ),
+                artifactDirectory: request.output.artifactDirectory(for: request.source),
                 outputLogger: outputLogger,
                 failureLogger: errorLogger
             )
@@ -408,17 +435,32 @@ func makePrivateHeaderGenerationRequest(
     from command: PrivateHeaderKitGenerateCommand,
     helperURLs: PrivateHeaderGeneration.RawDumping.HelperURLs,
     toolCompatibilityIdentity: String,
-    simulatorResolution: PrivateHeaderKitSimulatorResolution?
+    simulatorResolution: PrivateHeaderKitSimulatorResolution?,
+    releaseMetadataResolver: PrivateHeaderKitReleaseMetadataResolver =
+        resolvePrivateHeaderKitReleaseMetadata
 ) throws -> PrivateHeaderKitGenerationRequest {
     let effectiveSource = try effectiveSourceConfiguration(
         from: command,
+        simulatorResolution: simulatorResolution,
+        releaseMetadataResolver: releaseMetadataResolver
+    )
+    return try makePrivateHeaderGenerationRequest(
+        from: command,
+        effectiveSource: effectiveSource,
+        helperURLs: helperURLs,
+        toolCompatibilityIdentity: toolCompatibilityIdentity,
         simulatorResolution: simulatorResolution
     )
-    let source = try PrivateHeaderGeneration.Source(
-        platform: command.platform.corePlatform,
-        version: command.version,
-        build: effectiveSource.build
-    )
+}
+
+private func makePrivateHeaderGenerationRequest(
+    from command: PrivateHeaderKitGenerateCommand,
+    effectiveSource: EffectiveSourceConfiguration,
+    helperURLs: PrivateHeaderGeneration.RawDumping.HelperURLs,
+    toolCompatibilityIdentity: String,
+    simulatorResolution: PrivateHeaderKitSimulatorResolution?
+) throws -> PrivateHeaderKitGenerationRequest {
+    let source = effectiveSource.source
     let output = PrivateHeaderGeneration.Output(
         baseDirectory: URL(fileURLWithPath: command.outputBaseDirectory, isDirectory: true)
     )
@@ -453,21 +495,24 @@ func makePrivateHeaderGenerationRequest(
 }
 
 private struct EffectiveSourceConfiguration {
-    let build: String?
+    let source: PrivateHeaderGeneration.Source
     let systemRoot: URL
     let useSharedCache: Bool
 }
 
 private func effectiveSourceConfiguration(
     from command: PrivateHeaderKitGenerateCommand,
-    simulatorResolution: PrivateHeaderKitSimulatorResolution?
+    simulatorResolution: PrivateHeaderKitSimulatorResolution?,
+    releaseMetadataResolver: PrivateHeaderKitReleaseMetadataResolver
 ) throws -> EffectiveSourceConfiguration {
     if let systemRoot = command.systemRoot {
         let systemRootURL = canonicalDirectoryURL(path: systemRoot)
         let build: String?
+        let metadataIsSeed: Bool
         let useSharedCache: Bool
         if command.platform.simulatorPlatform == nil {
             build = command.build
+            metadataIsSeed = try releaseMetadataResolver(systemRootURL, .macOS)
             useSharedCache = systemRootURL.path == "/"
         } else {
             guard let simulatorResolution else {
@@ -478,21 +523,49 @@ private func effectiveSourceConfiguration(
             )
             build = command.build
                 ?? (identifiesSelectedRuntime ? simulatorResolution.runtimeBuild : nil)
+            if identifiesSelectedRuntime {
+                metadataIsSeed = simulatorResolution.metadataIsSeed
+            } else {
+                metadataIsSeed = try releaseMetadataResolver(systemRootURL, .simulator)
+            }
             useSharedCache = identifiesSelectedRuntime
         }
-        return EffectiveSourceConfiguration(
+        return try validatedEffectiveSourceConfiguration(
+            command: command,
             build: build,
             systemRoot: systemRootURL,
+            metadataIsSeed: metadataIsSeed,
             useSharedCache: useSharedCache
         )
     }
     guard command.platform.simulatorPlatform != nil, let simulatorResolution else {
         throw PrivateHeaderKitCLIError.missingSimulatorResolution
     }
-    return EffectiveSourceConfiguration(
+    return try validatedEffectiveSourceConfiguration(
+        command: command,
         build: command.build ?? simulatorResolution.runtimeBuild,
         systemRoot: canonicalDirectoryURL(path: simulatorResolution.resolvedRuntimeRoot),
+        metadataIsSeed: simulatorResolution.metadataIsSeed,
         useSharedCache: true
+    )
+}
+
+private func validatedEffectiveSourceConfiguration(
+    command: PrivateHeaderKitGenerateCommand,
+    build: String?,
+    systemRoot: URL,
+    metadataIsSeed: Bool,
+    useSharedCache: Bool
+) throws -> EffectiveSourceConfiguration {
+    EffectiveSourceConfiguration(
+        source: try PrivateHeaderGeneration.Source(
+            platform: command.platform.corePlatform,
+            version: command.version,
+            build: build,
+            metadataIsSeed: metadataIsSeed
+        ),
+        systemRoot: systemRoot,
+        useSharedCache: useSharedCache
     )
 }
 
@@ -1002,22 +1075,40 @@ private func currentHostSupportsNativeArm64Simulator() -> Bool {
 func resolvePrivateHeaderKitSimulator(
     for command: PrivateHeaderKitGenerateCommand
 ) async throws -> PrivateHeaderKitSimulatorResolution {
+    try await resolvePrivateHeaderKitSimulator(for: command, runner: ProcessRunner())
+}
+
+func resolvePrivateHeaderKitSimulator(
+    for command: PrivateHeaderKitGenerateCommand,
+    runner: CommandRunning
+) async throws -> PrivateHeaderKitSimulatorResolution {
     guard let simulatorPlatform = command.platform.simulatorPlatform else {
         throw PrivateHeaderKitCLIError.missingSimulatorResolution
     }
-    let runner = ProcessRunner()
     let runtime = try await Simctl.findRuntime(
         platform: simulatorPlatform,
         version: command.version,
         build: command.build,
         runner: runner
     )
+    let metadataIsSeed = try RuntimeReleaseMetadata.isSeed(
+        in: canonicalDirectoryURL(path: runtime.runtimeRoot),
+        layout: .simulator
+    )
+    try PrivateHeaderGeneration.Source.validateReleaseMetadata(
+        build: runtime.build,
+        metadataIsSeed: metadataIsSeed
+    )
     let device = try await Simctl.resolveDevice(
         runtime: runtime,
         query: command.device,
         runner: runner
     )
-    return PrivateHeaderKitSimulatorResolution(runtime: runtime, device: device)
+    return PrivateHeaderKitSimulatorResolution(
+        runtime: runtime,
+        metadataIsSeed: metadataIsSeed,
+        device: device
+    )
 }
 
 func discoverPrivateHeaderKitInteractiveSources() async throws

--- a/Sources/PrivateHeaderKitCLI/PrivateHeaderKitInteractive.swift
+++ b/Sources/PrivateHeaderKitCLI/PrivateHeaderKitInteractive.swift
@@ -19,7 +19,10 @@ struct PrivateHeaderKitInteractiveSource: Equatable, Sendable {
     let systemRoot: String?
 
     var versionAndBuildDisplayName: String {
-        build.map { "\(version) (\($0))" } ?? version
+        PrivateHeaderGeneration.Source.versionAndBuildDisplayName(
+            version: version,
+            build: build
+        )
     }
 
     var displayName: String {
@@ -57,6 +60,7 @@ func runPrivateHeaderKitInteractiveGenerate(
     generationClient: PrivateHeaderKitGenerationClient,
     simulatorResolver: PrivateHeaderKitSimulatorResolver,
     helperResolver: PrivateHeaderKitHelperResolver,
+    releaseMetadataResolver: PrivateHeaderKitReleaseMetadataResolver,
     sourceProvider: PrivateHeaderKitInteractiveSourceProvider,
     outputBaseDirectoryProvider: () -> String,
     screenClearer: @escaping PrivateHeaderKitInteractiveScreenClearer,
@@ -148,6 +152,7 @@ func runPrivateHeaderKitInteractiveGenerate(
                         currentExecutableURL: currentExecutableURL,
                         simulatorResolver: simulatorResolver,
                         helperResolver: helperResolver,
+                        releaseMetadataResolver: releaseMetadataResolver,
                         outputLogger: outputLogger
                     )
                     let preparedGeneration = try await generationClient.prepare(request)

--- a/Sources/PrivateHeaderKitCLI/PrivateHeaderKitInteractive.swift
+++ b/Sources/PrivateHeaderKitCLI/PrivateHeaderKitInteractive.swift
@@ -16,12 +16,28 @@ struct PrivateHeaderKitInteractiveSource: Equatable, Sendable {
     let platform: PrivateHeaderKitGenerateCommand.Platform
     let version: String
     let build: String?
+    let metadataIsSeed: Bool
     let systemRoot: String?
+
+    init(
+        platform: PrivateHeaderKitGenerateCommand.Platform,
+        version: String,
+        build: String?,
+        metadataIsSeed: Bool = false,
+        systemRoot: String?
+    ) {
+        self.platform = platform
+        self.version = version
+        self.build = build
+        self.metadataIsSeed = metadataIsSeed
+        self.systemRoot = systemRoot
+    }
 
     var versionAndBuildDisplayName: String {
         PrivateHeaderGeneration.Source.versionAndBuildDisplayName(
             version: version,
-            build: build
+            build: build,
+            releaseChannel: metadataIsSeed ? .beta : .release
         )
     }
 

--- a/Sources/PrivateHeaderKitCore/PrivateHeaderGeneration.swift
+++ b/Sources/PrivateHeaderKitCore/PrivateHeaderGeneration.swift
@@ -59,14 +59,6 @@ extension PrivateHeaderGeneration {
       )
     }
 
-    package static func buildIndicatesBeta(_ build: String?) -> Bool {
-      let normalizedBuild =
-        build
-        .map(\.precomposedStringWithCanonicalMapping)
-        .flatMap { $0.isEmpty ? nil : $0 }
-      return releaseChannel(for: normalizedBuild) == .beta
-    }
-
     package static func validateReleaseMetadata(
       build: String?,
       metadataIsSeed: Bool

--- a/Sources/PrivateHeaderKitCore/PrivateHeaderGeneration.swift
+++ b/Sources/PrivateHeaderKitCore/PrivateHeaderGeneration.swift
@@ -22,7 +22,115 @@ extension PrivateHeaderGeneration {
     package let version: String
     package let build: String?
 
-    package init(platform: Platform, version: String, build: String? = nil) throws {
+    private struct NormalizedIdentity {
+      let version: String
+      let build: String?
+    }
+
+    package init(
+      platform: Platform,
+      version: String,
+      build: String? = nil,
+      metadataIsSeed: Bool
+    ) throws {
+      let identity = try Self.normalizedIdentity(
+        platform: platform,
+        version: version,
+        build: build
+      )
+      try Self.validateReleaseMetadata(
+        build: identity.build,
+        metadataIsSeed: metadataIsSeed
+      )
+      self.platform = platform
+      self.version = identity.version
+      self.build = identity.build
+    }
+
+    package static func validateIdentity(
+      platform: Platform,
+      version: String,
+      build: String?
+    ) throws {
+      _ = try normalizedIdentity(
+        platform: platform,
+        version: version,
+        build: build
+      )
+    }
+
+    package static func buildIndicatesBeta(_ build: String?) -> Bool {
+      let normalizedBuild =
+        build
+        .map(\.precomposedStringWithCanonicalMapping)
+        .flatMap { $0.isEmpty ? nil : $0 }
+      return releaseChannel(for: normalizedBuild) == .beta
+    }
+
+    package static func validateReleaseMetadata(
+      build: String?,
+      metadataIsSeed: Bool
+    ) throws {
+      let normalizedBuild =
+        build
+        .map(\.precomposedStringWithCanonicalMapping)
+        .flatMap { $0.isEmpty ? nil : $0 }
+      guard metadataIsSeed == (releaseChannel(for: normalizedBuild) == .beta) else {
+        throw ValidationError.releaseMetadataMismatch(
+          build: normalizedBuild,
+          metadataIsSeed: metadataIsSeed
+        )
+      }
+    }
+
+    package static func versionAndBuildDisplayName(
+      version: String,
+      build: String?
+    ) -> String {
+      let normalizedVersion = version.precomposedStringWithCanonicalMapping
+      let normalizedBuild =
+        build
+        .map(\.precomposedStringWithCanonicalMapping)
+        .flatMap { $0.isEmpty ? nil : $0 }
+      var name = normalizedVersion
+      if releaseChannel(for: normalizedBuild) == .beta {
+        name += " beta"
+      }
+      if let normalizedBuild {
+        name += " (\(normalizedBuild))"
+      }
+      return name
+    }
+
+    package var label: Label {
+      Label(
+        platform: platform,
+        version: version,
+        build: build
+      )
+    }
+
+    package var storageIdentifier: String {
+      Self.makeStorageIdentifier(platform: platform, version: version, build: build)
+    }
+
+    package var releaseChannel: ReleaseChannel {
+      Self.releaseChannel(for: build)
+    }
+
+    package var artifactDirectoryName: String {
+      Self.makeArtifactDirectoryName(
+        version: version,
+        build: build,
+        releaseChannel: releaseChannel
+      )
+    }
+
+    private static func normalizedIdentity(
+      platform: Platform,
+      version: String,
+      build: String?
+    ) throws -> NormalizedIdentity {
       let version = version.precomposedStringWithCanonicalMapping
       guard !version.isEmpty else {
         throw ValidationError.emptyComponent(field: "version")
@@ -31,7 +139,7 @@ extension PrivateHeaderGeneration {
         build
         .map(\.precomposedStringWithCanonicalMapping)
         .flatMap { $0.isEmpty ? nil : $0 }
-      let storageIdentifier = Self.makeStorageIdentifier(
+      let storageIdentifier = makeStorageIdentifier(
         platform: platform,
         version: version,
         build: build
@@ -42,17 +150,31 @@ extension PrivateHeaderGeneration {
           maximumUTF8Count: Int(NAME_MAX)
         )
       }
-      self.platform = platform
-      self.version = version
-      self.build = build
+      let artifactDirectoryName = makeArtifactDirectoryName(
+        version: version,
+        build: build,
+        releaseChannel: releaseChannel(for: build)
+      )
+      guard artifactDirectoryName.utf8.count <= Int(NAME_MAX) else {
+        throw ValidationError.artifactDirectoryNameTooLong(
+          actualUTF8Count: artifactDirectoryName.utf8.count,
+          maximumUTF8Count: Int(NAME_MAX)
+        )
+      }
+      return NormalizedIdentity(version: version, build: build)
     }
 
-    package var label: Label {
-      Label(platform: platform, version: version, build: build)
-    }
-
-    package var storageIdentifier: String {
-      Self.makeStorageIdentifier(platform: platform, version: version, build: build)
+    private static func releaseChannel(for build: String?) -> ReleaseChannel {
+      // Keep the public path a pure function of the build identity. Installed runtime metadata
+      // validates the suffix convention, but is not stored as a second source of path identity.
+      guard let build,
+        isHumanReadableBuild(build),
+        let suffix = build.utf8.last,
+        (0x61...0x7a).contains(suffix)
+      else {
+        return .release
+      }
+      return .beta
     }
 
     private static func makeStorageIdentifier(
@@ -77,6 +199,67 @@ extension PrivateHeaderGeneration {
       return "\(platformName)-v1-\(version)-b1-\(encodeStorageField(build))"
     }
 
+    private static func makeArtifactDirectoryName(
+      version: String,
+      build: String?,
+      releaseChannel: ReleaseChannel
+    ) -> String {
+      var name = isHumanReadableVersion(version) ? version : encodeArtifactField(version)
+      if releaseChannel == .beta {
+        name += " beta"
+      }
+      if let build {
+        let displayedBuild =
+          isHumanReadableBuild(build) ? build : encodeArtifactField(build)
+        name += " (\(displayedBuild))"
+      }
+      return name
+    }
+
+    private static func isHumanReadableVersion(_ value: String) -> Bool {
+      guard value != ".", value != ".." else { return false }
+      return value.utf8.allSatisfy { byte in
+        byte == 0x2e || (0x30...0x39).contains(byte)
+      }
+    }
+
+    private static func isHumanReadableBuild(_ value: String) -> Bool {
+      let bytes = Array(value.utf8)
+      var index = bytes.startIndex
+      while index < bytes.endIndex, (0x30...0x39).contains(bytes[index]) {
+        index += 1
+      }
+      guard index > bytes.startIndex,
+        index < bytes.endIndex,
+        (0x41...0x5a).contains(bytes[index])
+      else {
+        return false
+      }
+      index += 1
+      let digitStart = index
+      while index < bytes.endIndex, (0x30...0x39).contains(bytes[index]) {
+        index += 1
+      }
+      guard index > digitStart else { return false }
+      return bytes[index...].allSatisfy { (0x61...0x7a).contains($0) }
+    }
+
+    private static func encodeArtifactField(_ value: String) -> String {
+      let hexDigits = Array("0123456789abcdef")
+      var result = ""
+      result.reserveCapacity(value.utf8.count * 3)
+      for byte in value.utf8 {
+        if (0x30...0x39).contains(byte) {
+          result.append(hexDigits[Int(byte) - 0x30])
+        } else {
+          result.append("~")
+          result.append(hexDigits[Int(byte >> 4)])
+          result.append(hexDigits[Int(byte & 0x0f)])
+        }
+      }
+      return result
+    }
+
     private static func encodeStorageField(_ value: String) -> String {
       let hexDigits = Array("0123456789abcdef")
       var result = ""
@@ -99,6 +282,8 @@ extension PrivateHeaderGeneration {
     package enum ValidationError: Error, Equatable, CustomStringConvertible, Sendable {
       case emptyComponent(field: String)
       case storageIdentifierTooLong(actualUTF8Count: Int, maximumUTF8Count: Int)
+      case artifactDirectoryNameTooLong(actualUTF8Count: Int, maximumUTF8Count: Int)
+      case releaseMetadataMismatch(build: String?, metadataIsSeed: Bool)
 
       package var description: String {
         switch self {
@@ -107,8 +292,19 @@ extension PrivateHeaderGeneration {
         case .storageIdentifierTooLong(let actualUTF8Count, let maximumUTF8Count):
           "source storage identifier is \(actualUTF8Count) UTF-8 bytes; "
             + "the maximum is \(maximumUTF8Count)"
+        case .artifactDirectoryNameTooLong(let actualUTF8Count, let maximumUTF8Count):
+          "source artifact directory name is \(actualUTF8Count) UTF-8 bytes; "
+            + "the maximum is \(maximumUTF8Count)"
+        case .releaseMetadataMismatch(let build, let metadataIsSeed):
+          "source build \(build ?? "<missing>") and runtime seed metadata disagree "
+            + "(IsSeed=\(metadataIsSeed))"
         }
       }
+    }
+
+    package enum ReleaseChannel: String, Hashable, Sendable {
+      case release
+      case beta
     }
 
     package enum Platform: String, Codable, CaseIterable, Hashable, Sendable {
@@ -117,18 +313,20 @@ extension PrivateHeaderGeneration {
       case watchOS = "watchOS"
 
       package var displayName: String { rawValue }
+
+      package var directoryName: String { rawValue }
     }
 
     package struct Label: CustomStringConvertible, Hashable, Sendable {
       package let displayName: String
 
-      fileprivate init(platform: Platform, version: String, build: String?) {
-        let baseName = "\(platform.displayName) \(version)"
-        if let build {
-          displayName = "\(baseName) (\(build))"
-        } else {
-          displayName = baseName
-        }
+      fileprivate init(
+        platform: Platform,
+        version: String,
+        build: String?
+      ) {
+        displayName = "\(platform.displayName) "
+          + Source.versionAndBuildDisplayName(version: version, build: build)
       }
 
       package var description: String { displayName }
@@ -312,6 +510,23 @@ extension PrivateHeaderGeneration {
     package var stateBaseDirectory: URL {
       baseDirectory.appendingPathComponent(".state", isDirectory: true)
     }
+
+    package func artifactDirectory(for source: Source) -> URL {
+      artifactBaseDirectory
+        .appendingPathComponent(source.platform.directoryName, isDirectory: true)
+        .appendingPathComponent(source.artifactDirectoryName, isDirectory: true)
+    }
+
+    package func legacyStorageArtifactDirectory(for source: Source) -> URL {
+      artifactBaseDirectory.appendingPathComponent(
+        source.storageIdentifier,
+        isDirectory: true
+      )
+    }
+
+    package func stateDirectory(for source: Source) -> URL {
+      stateBaseDirectory.appendingPathComponent(source.storageIdentifier, isDirectory: true)
+    }
   }
 
   package struct Plan: Hashable, Sendable {
@@ -325,14 +540,8 @@ extension PrivateHeaderGeneration {
     package init(source: Source, output: Output, options: Options) {
       self.source = source
       self.output = output
-      artifactDirectory = output.artifactBaseDirectory.appendingPathComponent(
-        source.storageIdentifier,
-        isDirectory: true
-      )
-      stateDirectory = output.stateBaseDirectory.appendingPathComponent(
-        source.storageIdentifier,
-        isDirectory: true
-      )
+      artifactDirectory = output.artifactDirectory(for: source)
+      stateDirectory = output.stateDirectory(for: source)
       target = .allAvailable
       self.options = options
     }
@@ -396,6 +605,7 @@ extension PrivateHeaderGeneration {
     case incompatibleResume(String)
     case resumeRequired(ResumeSummary)
     case legacyMigrationRequiresFresh(LegacyMigrationRequirement)
+    case conflictingArtifactDirectories(legacyPath: String, currentPath: String)
     case runFailed(RunFailure)
     case runInterrupted(RunInterruption)
     case infrastructureFailed(RunInfrastructureFailure)
@@ -435,6 +645,10 @@ extension PrivateHeaderGeneration {
           "legacy JSON state at \(statePath) and artifact directory at \(artifactsPath) "
             + "require an explicit fresh migration"
         }
+      case .conflictingArtifactDirectories(let legacyPath, let currentPath):
+        "both the legacy and current generated-header directories exist "
+          + "(legacy: \(legacyPath), current: \(currentPath)); "
+          + "move one directory aside before retrying"
       case .runFailed(let failure):
         "private header generation run \(failure.summary.runID.rawValue) failed for \(failure.failedTargetIDs.count) targets"
       case .runInterrupted(let interruption):

--- a/Sources/PrivateHeaderKitCore/PrivateHeaderGeneration.swift
+++ b/Sources/PrivateHeaderKitCore/PrivateHeaderGeneration.swift
@@ -21,6 +21,7 @@ extension PrivateHeaderGeneration {
     package let platform: Platform
     package let version: String
     package let build: String?
+    package let releaseChannel: ReleaseChannel
 
     private struct NormalizedIdentity {
       let version: String
@@ -38,13 +39,25 @@ extension PrivateHeaderGeneration {
         version: version,
         build: build
       )
-      try Self.validateReleaseMetadata(
+      let releaseChannel: ReleaseChannel = metadataIsSeed ? .beta : .release
+      guard releaseChannel != .beta || identity.build != nil else {
+        throw ValidationError.seedBuildMissing
+      }
+      let artifactDirectoryName = Self.makeArtifactDirectoryName(
+        version: identity.version,
         build: identity.build,
-        metadataIsSeed: metadataIsSeed
+        releaseChannel: releaseChannel
       )
+      guard artifactDirectoryName.utf8.count <= Int(NAME_MAX) else {
+        throw ValidationError.artifactDirectoryNameTooLong(
+          actualUTF8Count: artifactDirectoryName.utf8.count,
+          maximumUTF8Count: Int(NAME_MAX)
+        )
+      }
       self.platform = platform
       self.version = identity.version
       self.build = identity.build
+      self.releaseChannel = releaseChannel
     }
 
     package static func validateIdentity(
@@ -59,25 +72,10 @@ extension PrivateHeaderGeneration {
       )
     }
 
-    package static func validateReleaseMetadata(
-      build: String?,
-      metadataIsSeed: Bool
-    ) throws {
-      let normalizedBuild =
-        build
-        .map(\.precomposedStringWithCanonicalMapping)
-        .flatMap { $0.isEmpty ? nil : $0 }
-      guard metadataIsSeed == (releaseChannel(for: normalizedBuild) == .beta) else {
-        throw ValidationError.releaseMetadataMismatch(
-          build: normalizedBuild,
-          metadataIsSeed: metadataIsSeed
-        )
-      }
-    }
-
     package static func versionAndBuildDisplayName(
       version: String,
-      build: String?
+      build: String?,
+      releaseChannel: ReleaseChannel
     ) -> String {
       let normalizedVersion = version.precomposedStringWithCanonicalMapping
       let normalizedBuild =
@@ -85,7 +83,7 @@ extension PrivateHeaderGeneration {
         .map(\.precomposedStringWithCanonicalMapping)
         .flatMap { $0.isEmpty ? nil : $0 }
       var name = normalizedVersion
-      if releaseChannel(for: normalizedBuild) == .beta {
+      if releaseChannel == .beta {
         name += " beta"
       }
       if let normalizedBuild {
@@ -98,16 +96,13 @@ extension PrivateHeaderGeneration {
       Label(
         platform: platform,
         version: version,
-        build: build
+        build: build,
+        releaseChannel: releaseChannel
       )
     }
 
     package var storageIdentifier: String {
       Self.makeStorageIdentifier(platform: platform, version: version, build: build)
-    }
-
-    package var releaseChannel: ReleaseChannel {
-      Self.releaseChannel(for: build)
     }
 
     package var artifactDirectoryName: String {
@@ -142,31 +137,7 @@ extension PrivateHeaderGeneration {
           maximumUTF8Count: Int(NAME_MAX)
         )
       }
-      let artifactDirectoryName = makeArtifactDirectoryName(
-        version: version,
-        build: build,
-        releaseChannel: releaseChannel(for: build)
-      )
-      guard artifactDirectoryName.utf8.count <= Int(NAME_MAX) else {
-        throw ValidationError.artifactDirectoryNameTooLong(
-          actualUTF8Count: artifactDirectoryName.utf8.count,
-          maximumUTF8Count: Int(NAME_MAX)
-        )
-      }
       return NormalizedIdentity(version: version, build: build)
-    }
-
-    private static func releaseChannel(for build: String?) -> ReleaseChannel {
-      // Keep the public path a pure function of the build identity. Installed runtime metadata
-      // validates the suffix convention, but is not stored as a second source of path identity.
-      guard let build,
-        isHumanReadableBuild(build),
-        let suffix = build.utf8.last,
-        (0x61...0x7a).contains(suffix)
-      else {
-        return .release
-      }
-      return .beta
     }
 
     private static func makeStorageIdentifier(
@@ -196,16 +167,18 @@ extension PrivateHeaderGeneration {
       build: String?,
       releaseChannel: ReleaseChannel
     ) -> String {
-      var name = isHumanReadableVersion(version) ? version : encodeArtifactField(version)
+      var components = [
+        isHumanReadableVersion(version) ? version : encodeArtifactField(version)
+      ]
       if releaseChannel == .beta {
-        name += " beta"
+        components.append("beta")
       }
       if let build {
-        let displayedBuild =
+        components.append(
           isHumanReadableBuild(build) ? build : encodeArtifactField(build)
-        name += " (\(displayedBuild))"
+        )
       }
-      return name
+      return components.joined(separator: "_")
     }
 
     private static func isHumanReadableVersion(_ value: String) -> Bool {
@@ -275,7 +248,7 @@ extension PrivateHeaderGeneration {
       case emptyComponent(field: String)
       case storageIdentifierTooLong(actualUTF8Count: Int, maximumUTF8Count: Int)
       case artifactDirectoryNameTooLong(actualUTF8Count: Int, maximumUTF8Count: Int)
-      case releaseMetadataMismatch(build: String?, metadataIsSeed: Bool)
+      case seedBuildMissing
 
       package var description: String {
         switch self {
@@ -287,9 +260,8 @@ extension PrivateHeaderGeneration {
         case .artifactDirectoryNameTooLong(let actualUTF8Count, let maximumUTF8Count):
           "source artifact directory name is \(actualUTF8Count) UTF-8 bytes; "
             + "the maximum is \(maximumUTF8Count)"
-        case .releaseMetadataMismatch(let build, let metadataIsSeed):
-          "source build \(build ?? "<missing>") and runtime seed metadata disagree "
-            + "(IsSeed=\(metadataIsSeed))"
+        case .seedBuildMissing:
+          "source build is required for a seed runtime"
         }
       }
     }
@@ -315,10 +287,15 @@ extension PrivateHeaderGeneration {
       fileprivate init(
         platform: Platform,
         version: String,
-        build: String?
+        build: String?,
+        releaseChannel: ReleaseChannel
       ) {
         displayName = "\(platform.displayName) "
-          + Source.versionAndBuildDisplayName(version: version, build: build)
+          + Source.versionAndBuildDisplayName(
+            version: version,
+            build: build,
+            releaseChannel: releaseChannel
+          )
       }
 
       package var description: String { displayName }

--- a/Sources/PrivateHeaderKitCore/PrivateHeaderGenerationExecutor.swift
+++ b/Sources/PrivateHeaderKitCore/PrivateHeaderGenerationExecutor.swift
@@ -133,14 +133,12 @@ extension PrivateHeaderGeneration {
       )
       try publisher.prepareForLease()
       return try await GenerationLease.withExclusiveLease(at: publisher.lockURL) {
-        let artifactDirectory = Self.canonicalArtifactDirectory(
+        let directories = try Self.prepareSourceDirectories(
           outputBase: publisher.artifactBaseDirectory,
-          sourceLabel: plan.source.storageIdentifier
+          source: plan.source
         )
-        let stateDirectory = Self.canonicalStateDirectory(
-          outputBase: publisher.artifactBaseDirectory,
-          sourceLabel: plan.source.storageIdentifier
-        )
+        let artifactDirectory = directories.artifactDirectory
+        let stateDirectory = directories.stateDirectory
         let databaseURL = stateDirectory.appendingPathComponent(
           "generation.sqlite",
           isDirectory: false
@@ -1556,14 +1554,12 @@ extension PrivateHeaderGeneration.GenerationExecutor {
     )
     try publisher.prepareForLease()
     return try await GenerationLease.withExclusiveLease(at: publisher.lockURL) {
-      let artifactDirectory = canonicalArtifactDirectory(
+      let directories = try prepareSourceDirectories(
         outputBase: publisher.artifactBaseDirectory,
-        sourceLabel: plan.source.storageIdentifier
+        source: plan.source
       )
-      let stateDirectory = canonicalStateDirectory(
-        outputBase: publisher.artifactBaseDirectory,
-        sourceLabel: plan.source.storageIdentifier
-      )
+      let artifactDirectory = directories.artifactDirectory
+      let stateDirectory = directories.stateDirectory
       let databaseURL = stateDirectory.appendingPathComponent(
         "generation.sqlite",
         isDirectory: false
@@ -2139,16 +2135,73 @@ extension PrivateHeaderGeneration.GenerationExecutor {
     }
   }
 
-  fileprivate static func canonicalArtifactDirectory(outputBase: URL, sourceLabel: String) -> URL {
-    outputBase
-      .appendingPathComponent("generated-headers", isDirectory: true)
-      .appendingPathComponent(sourceLabel, isDirectory: true)
+  fileprivate struct SourceDirectories {
+    let artifactDirectory: URL
+    let stateDirectory: URL
   }
 
-  fileprivate static func canonicalStateDirectory(outputBase: URL, sourceLabel: String) -> URL {
-    outputBase
-      .appendingPathComponent(".state", isDirectory: true)
-      .appendingPathComponent(sourceLabel, isDirectory: true)
+  fileprivate static func prepareSourceDirectories(
+    outputBase: URL,
+    source: PrivateHeaderGeneration.Source
+  ) throws -> SourceDirectories {
+    let output = PrivateHeaderGeneration.Output(baseDirectory: outputBase)
+    let artifactDirectory = output.artifactDirectory(for: source)
+    do {
+      try ManagedFileSystem.ensureRealDirectory(output.artifactBaseDirectory)
+      try ManagedFileSystem.ensureRealDirectory(artifactDirectory.deletingLastPathComponent())
+    } catch let error as ManagedFileSystem.Failure {
+      throw stateFileSystemError(error)
+    }
+    try migrateLegacyStorageArtifactDirectory(
+      output.legacyStorageArtifactDirectory(for: source),
+      to: artifactDirectory
+    )
+    return SourceDirectories(
+      artifactDirectory: artifactDirectory,
+      stateDirectory: output.stateDirectory(for: source)
+    )
+  }
+
+  fileprivate static func migrateLegacyStorageArtifactDirectory(
+    _ legacyDirectory: URL,
+    to currentDirectory: URL
+  ) throws {
+    let legacyKind = try publisherItemKind(at: legacyDirectory)
+    let currentKind = try publisherItemKind(at: currentDirectory)
+    if let legacyKind, legacyKind != .directory {
+      throw PrivateHeaderGeneration.StateError.corruptPublication(
+        "legacy generated-header path is \(legacyKind.rawValue), expected directory or missing: "
+          + legacyDirectory.path
+      )
+    }
+    if let currentKind, currentKind != .directory {
+      throw PrivateHeaderGeneration.StateError.corruptPublication(
+        "generated-header path is \(currentKind.rawValue), expected directory or missing: "
+          + currentDirectory.path
+      )
+    }
+    switch (legacyKind != nil, currentKind != nil) {
+    case (false, _):
+      return
+    case (true, false):
+      do {
+        let destinationParent = currentDirectory.deletingLastPathComponent()
+        try ManagedFileSystem.atomicRenameExclusively(
+          from: legacyDirectory,
+          to: currentDirectory
+        )
+        try ManagedFileSystem.syncDirectory(legacyDirectory.deletingLastPathComponent())
+        try ManagedFileSystem.syncDirectory(destinationParent)
+        try ManagedFileSystem.syncDirectory(currentDirectory)
+      } catch let error as ManagedFileSystem.Failure {
+        throw stateFileSystemError(error)
+      }
+    case (true, true):
+      throw PrivateHeaderGeneration.GenerationError.conflictingArtifactDirectories(
+        legacyPath: legacyDirectory.path,
+        currentPath: currentDirectory.path
+      )
+    }
   }
 
   fileprivate static func legacyStateExists(in stateDirectory: URL) throws -> Bool {

--- a/Sources/PrivateHeaderKitTooling/RuntimeReleaseMetadata.swift
+++ b/Sources/PrivateHeaderKitTooling/RuntimeReleaseMetadata.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+package enum RuntimeRootLayout: Sendable {
+    case simulator
+    case macOS
+}
+
+package enum RuntimeReleaseMetadata {
+    private struct RestoreVersion: Decodable {
+        let isSeed: Bool?
+
+        private enum CodingKeys: String, CodingKey {
+            case isSeed = "IsSeed"
+        }
+    }
+
+    package static func isSeed(
+        in systemRoot: URL,
+        layout: RuntimeRootLayout
+    ) throws -> Bool {
+        guard systemRoot.isFileURL else {
+            throw ToolingError.message(
+                "runtime system root is not a file URL: \(systemRoot.absoluteString)"
+            )
+        }
+        let metadataURL: URL
+        switch layout {
+        case .simulator:
+            metadataURL = systemRoot.appendingPathComponent(
+                "RestoreVersion.plist",
+                isDirectory: false
+            )
+        case .macOS:
+            metadataURL = systemRoot.appendingPathComponent(
+                "System/Library/CoreServices/RestoreVersion.plist",
+                isDirectory: false
+            )
+        }
+
+        let data: Data
+        do {
+            data = try Data(contentsOf: metadataURL)
+        } catch {
+            throw ToolingError.message(
+                "failed to read runtime release metadata at \(metadataURL.path): \(error)"
+            )
+        }
+        do {
+            return try PropertyListDecoder().decode(RestoreVersion.self, from: data).isSeed ?? false
+        } catch {
+            throw ToolingError.message(
+                "failed to decode runtime release metadata at \(metadataURL.path): \(error)"
+            )
+        }
+    }
+}

--- a/Tests/PrivateHeaderKitCLITests/PrivateHeaderKitCLITests.swift
+++ b/Tests/PrivateHeaderKitCLITests/PrivateHeaderKitCLITests.swift
@@ -276,7 +276,7 @@ struct PrivateHeaderKitCLIExecutionTests {
         #expect(request.source.label.displayName == "iOS 27.0 beta (24A5390f)")
         #expect(
             request.output.artifactDirectory(for: request.source).path
-                == "/tmp/PrivateHeaderKit/generated-headers/iOS/27.0 beta (24A5390f)"
+                == "/tmp/PrivateHeaderKit/generated-headers/iOS/27.0_beta_24A5390f"
         )
         #expect(request.source.storageIdentifier == "ios-v1-27.0-b1-24~415390~66")
     }
@@ -322,21 +322,56 @@ struct PrivateHeaderKitCLIExecutionTests {
         )
     }
 
-    @Test func explicitIOSSeedRootRequiresABetaBuildIdentity() {
-        for build in [String?.none, "24A123"] {
-            #expect(throws: PrivateHeaderGeneration.Source.ValidationError.self) {
-                _ = try makePrivateHeaderGenerationRequest(
-                    from: iosGenerateCommand(build: build, systemRoot: "/OverrideSeedRuntime"),
-                    helperURLs: testPrivateHeaderKitHelperURLs,
-                    toolCompatibilityIdentity: "test-tool-identity",
-                    simulatorResolution: testPrivateHeaderKitSimulatorResolution,
-                    releaseMetadataResolver: { _, layout in
-                        #expect(layout == .simulator)
-                        return true
-                    }
-                )
+    @Test func explicitIOSSeedRootRequiresBuildButNotALowercaseSuffix() throws {
+        let metadataResolver: PrivateHeaderKitReleaseMetadataResolver = { _, layout in
+            if case .macOS = layout {
+                Issue.record("expected simulator metadata layout")
             }
+            return true
         }
+        #expect(throws: PrivateHeaderGeneration.Source.ValidationError.self) {
+            _ = try makePrivateHeaderGenerationRequest(
+                from: iosGenerateCommand(build: nil, systemRoot: "/OverrideSeedRuntime"),
+                helperURLs: testPrivateHeaderKitHelperURLs,
+                toolCompatibilityIdentity: "test-tool-identity",
+                simulatorResolution: testPrivateHeaderKitSimulatorResolution,
+                releaseMetadataResolver: metadataResolver
+            )
+        }
+
+        let request = try makePrivateHeaderGenerationRequest(
+            from: iosGenerateCommand(build: "24A123", systemRoot: "/OverrideSeedRuntime"),
+            helperURLs: testPrivateHeaderKitHelperURLs,
+            toolCompatibilityIdentity: "test-tool-identity",
+            simulatorResolution: testPrivateHeaderKitSimulatorResolution,
+            releaseMetadataResolver: metadataResolver
+        )
+        #expect(request.source.releaseChannel == .beta)
+        #expect(request.source.artifactDirectoryName == "27.0_beta_24A123")
+    }
+
+    @Test func explicitPublicRootKeepsLowercaseBuildSuffixOutOfBetaNamespace() throws {
+        let command = PrivateHeaderKitGenerateCommand(
+            platform: .iOS,
+            version: "16.4.1",
+            build: "20E772520a",
+            systemRoot: "/OverridePublicRuntime",
+            outputBaseDirectory: "/tmp/PrivateHeaderKit",
+            targetQuery: "all",
+            continuationMode: .fresh,
+            device: nil,
+            simulatorHelperPath: nil
+        )
+        let request = try makePrivateHeaderGenerationRequest(
+            from: command,
+            helperURLs: testPrivateHeaderKitHelperURLs,
+            toolCompatibilityIdentity: "test-tool-identity",
+            simulatorResolution: testPrivateHeaderKitSimulatorResolution,
+            releaseMetadataResolver: { _, _ in false }
+        )
+
+        #expect(request.source.releaseChannel == .release)
+        #expect(request.source.artifactDirectoryName == "16.4.1_20E772520a")
     }
 
     @Test func explicitIOSBuildOverridesResolvedRuntimeBuild() throws {
@@ -739,7 +774,15 @@ struct PrivateHeaderKitCLIExecutionTests {
             }
         }
         let sources = try await discoverPrivateHeaderKitInteractiveSources(
-            runner: availableRunner
+            runner: availableRunner,
+            releaseMetadataResolver: { root, layout in
+                switch layout {
+                case .simulator:
+                    return root.path == "/runtimes/watch"
+                case .macOS:
+                    return false
+                }
+            }
         )
         #expect(sources == [
             PrivateHeaderKitInteractiveSource(
@@ -752,6 +795,7 @@ struct PrivateHeaderKitCLIExecutionTests {
                 platform: .watchOS,
                 version: "27.0",
                 build: "24R5325f",
+                metadataIsSeed: true,
                 systemRoot: nil
             ),
             PrivateHeaderKitInteractiveSource(
@@ -774,14 +818,19 @@ struct PrivateHeaderKitCLIExecutionTests {
                 throw ToolingError.message("unexpected command: \(command)")
             }
         }
-        #expect(try await discoverPrivateHeaderKitInteractiveSources(runner: unavailableRunner) == [
-            PrivateHeaderKitInteractiveSource(
-                platform: .macOS,
-                version: "16.0",
-                build: "24A1",
-                systemRoot: "/"
-            ),
-        ])
+        #expect(
+            try await discoverPrivateHeaderKitInteractiveSources(
+                runner: unavailableRunner,
+                releaseMetadataResolver: { _, _ in false }
+            ) == [
+                PrivateHeaderKitInteractiveSource(
+                    platform: .macOS,
+                    version: "16.0",
+                    build: "24A1",
+                    systemRoot: "/"
+                )
+            ]
+        )
 
         let failingRunner = CaptureOnlyCommandRunner { command, _, _ in
             if command == ["xcrun", "--find", "simctl"] {
@@ -1078,20 +1127,22 @@ struct PrivateHeaderKitCLIExecutionTests {
                 [
                     PrivateHeaderKitInteractiveSource(
                         platform: .iOS,
-                        version: "18.0",
-                        build: "22A3351",
+                        version: "16.4.1",
+                        build: "20E772520a",
                         systemRoot: nil
                     ),
                     PrivateHeaderKitInteractiveSource(
                         platform: .iOS,
                         version: "27.0",
                         build: "24A5390f",
+                        metadataIsSeed: true,
                         systemRoot: nil
                     ),
                     PrivateHeaderKitInteractiveSource(
                         platform: .watchOS,
                         version: "27.0",
                         build: "24R5325f",
+                        metadataIsSeed: true,
                         systemRoot: nil
                     ),
                     PrivateHeaderKitInteractiveSource(
@@ -1116,7 +1167,7 @@ struct PrivateHeaderKitCLIExecutionTests {
             Step 1 of 3: Source
 
             iOS
-              [1] 18.0 (22A3351)
+              [1] 16.4.1 (20E772520a)
               [2] 27.0 beta (24A5390f)
 
             watchOS

--- a/Tests/PrivateHeaderKitCLITests/PrivateHeaderKitCLITests.swift
+++ b/Tests/PrivateHeaderKitCLITests/PrivateHeaderKitCLITests.swift
@@ -242,7 +242,8 @@ struct PrivateHeaderKitCLIExecutionTests {
             from: iosGenerateCommand(build: nil, systemRoot: nil),
             helperURLs: testPrivateHeaderKitHelperURLs,
             toolCompatibilityIdentity: "test-tool-identity",
-            simulatorResolution: testPrivateHeaderKitSimulatorResolution
+            simulatorResolution: testPrivateHeaderKitSimulatorResolution,
+            releaseMetadataResolver: testPrivateHeaderKitReleaseMetadataResolver
         )
 
         #expect(request.source.build == "24A123")
@@ -255,12 +256,60 @@ struct PrivateHeaderKitCLIExecutionTests {
         )
     }
 
+    @Test func betaRuntimeProducesHumanReadableArtifactPath() throws {
+        let resolution = PrivateHeaderKitSimulatorResolution(
+            runtimeVersion: "27.0",
+            runtimeBuild: "24A5390f",
+            runtimeIdentifier: "com.apple.CoreSimulator.SimRuntime.iOS-27-0",
+            resolvedRuntimeRoot: "/ResolvedBetaRuntime",
+            metadataIsSeed: true,
+            deviceName: "iPhone 17 Pro",
+            deviceUDID: "SIM-BETA"
+        )
+        let request = try makePrivateHeaderGenerationRequest(
+            from: iosGenerateCommand(build: nil, systemRoot: nil),
+            helperURLs: testPrivateHeaderKitHelperURLs,
+            toolCompatibilityIdentity: "test-tool-identity",
+            simulatorResolution: resolution
+        )
+
+        #expect(request.source.label.displayName == "iOS 27.0 beta (24A5390f)")
+        #expect(
+            request.output.artifactDirectory(for: request.source).path
+                == "/tmp/PrivateHeaderKit/generated-headers/iOS/27.0 beta (24A5390f)"
+        )
+        #expect(request.source.storageIdentifier == "ios-v1-27.0-b1-24~415390~66")
+    }
+
+    @Test func simulatorReleaseMetadataIsValidatedBeforeResolvingADevice() async throws {
+        let root = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let runtimeRoot = root.appendingPathComponent("RuntimeRoot", isDirectory: true)
+        try FileManager.default.createDirectory(at: runtimeRoot, withIntermediateDirectories: true)
+        let runner = RecordingCommandRunner()
+        await runner.setCaptureOutput(
+            """
+            {"runtimes":[{"name":"iOS 27.0","platform":"iOS","version":"27.0","buildversion":"24A5390f","identifier":"ios-27","runtimeRoot":"\(runtimeRoot.path)","isAvailable":true}]}
+            """,
+            for: ["xcrun", "simctl", "list", "runtimes", "-j"]
+        )
+
+        await #expect(throws: ToolingError.self) {
+            _ = try await resolvePrivateHeaderKitSimulator(
+                for: iosGenerateCommand(build: nil, systemRoot: nil),
+                runner: runner
+            )
+        }
+        #expect(await runner.simpleCommandSnapshot().isEmpty)
+    }
+
     @Test func explicitIOSSystemRootDoesNotBorrowResolvedRuntimeBuild() throws {
         let request = try makePrivateHeaderGenerationRequest(
             from: iosGenerateCommand(build: nil, systemRoot: "/OverrideRuntime"),
             helperURLs: testPrivateHeaderKitHelperURLs,
             toolCompatibilityIdentity: "test-tool-identity",
-            simulatorResolution: testPrivateHeaderKitSimulatorResolution
+            simulatorResolution: testPrivateHeaderKitSimulatorResolution,
+            releaseMetadataResolver: testPrivateHeaderKitReleaseMetadataResolver
         )
 
         #expect(request.source.build == nil)
@@ -271,6 +320,23 @@ struct PrivateHeaderKitCLIExecutionTests {
             request.options.executionMode
                 == .simulator(deviceUDID: "SIM-001", runtimeRoot: "/OverrideRuntime")
         )
+    }
+
+    @Test func explicitIOSSeedRootRequiresABetaBuildIdentity() {
+        for build in [String?.none, "24A123"] {
+            #expect(throws: PrivateHeaderGeneration.Source.ValidationError.self) {
+                _ = try makePrivateHeaderGenerationRequest(
+                    from: iosGenerateCommand(build: build, systemRoot: "/OverrideSeedRuntime"),
+                    helperURLs: testPrivateHeaderKitHelperURLs,
+                    toolCompatibilityIdentity: "test-tool-identity",
+                    simulatorResolution: testPrivateHeaderKitSimulatorResolution,
+                    releaseMetadataResolver: { _, layout in
+                        #expect(layout == .simulator)
+                        return true
+                    }
+                )
+            }
+        }
     }
 
     @Test func explicitIOSBuildOverridesResolvedRuntimeBuild() throws {
@@ -301,6 +367,7 @@ struct PrivateHeaderKitCLIExecutionTests {
             runtimeBuild: "24A123",
             runtimeIdentifier: "com.apple.CoreSimulator.SimRuntime.iOS-27-0",
             resolvedRuntimeRoot: runtimeRoot.path,
+            metadataIsSeed: false,
             deviceName: "iPhone 17 Pro",
             deviceUDID: "SIM-001"
         )
@@ -346,7 +413,8 @@ struct PrivateHeaderKitCLIExecutionTests {
             from: macOSGenerateCommand(systemRoot: "/"),
             helperURLs: testPrivateHeaderKitHelperURLs,
             toolCompatibilityIdentity: "test-tool-identity",
-            simulatorResolution: nil
+            simulatorResolution: nil,
+            releaseMetadataResolver: testPrivateHeaderKitReleaseMetadataResolver
         )
         #expect(currentRootRequest.options.systemRoot?.path == "/")
         #expect(currentRootRequest.options.rawDumpingOptions.useSharedCache)
@@ -359,13 +427,44 @@ struct PrivateHeaderKitCLIExecutionTests {
             from: macOSGenerateCommand(systemRoot: customRoot.path),
             helperURLs: testPrivateHeaderKitHelperURLs,
             toolCompatibilityIdentity: "test-tool-identity",
-            simulatorResolution: nil
+            simulatorResolution: nil,
+            releaseMetadataResolver: testPrivateHeaderKitReleaseMetadataResolver
         )
         #expect(
             customRootRequest.options.systemRoot
                 == customRoot.resolvingSymlinksInPath().standardizedFileURL
         )
         #expect(!customRootRequest.options.rawDumpingOptions.useSharedCache)
+    }
+
+    @Test func invalidSourceMetadataFailsBeforeHelperResolution() async {
+        let helperResolutionCount = ThreadSafeCounter()
+
+        await #expect(throws: PrivateHeaderGeneration.Source.ValidationError.self) {
+            _ = try await preparePrivateHeaderKitGenerationRequest(
+                macOSGenerateCommand(systemRoot: "/SeedSystemRoot"),
+                invokedProgramName: "privateheaderkit",
+                currentExecutableURL: URL(fileURLWithPath: "/cohort/privateheaderkit"),
+                simulatorResolver: { _ in
+                    Issue.record("macOS generation must not resolve a simulator")
+                    return testPrivateHeaderKitSimulatorResolution
+                },
+                helperResolver: { _, _, _ in
+                    helperResolutionCount.increment()
+                    return PrivateHeaderKitHelperPlan(
+                        helperURLs: testPrivateHeaderKitHelperURLs,
+                        toolCompatibilityIdentity: "test-tool-identity"
+                    )
+                },
+                releaseMetadataResolver: { _, layout in
+                    #expect(layout == .macOS)
+                    return true
+                },
+                outputLogger: { _ in }
+            )
+        }
+
+        #expect(helperResolutionCount.value == 0)
     }
 
     @Test func directRunMapsFreshModeAndRendersTypedResultAndWarnings() async throws {
@@ -414,6 +513,7 @@ struct PrivateHeaderKitCLIExecutionTests {
                 }
             ),
             helperResolver: testPrivateHeaderKitHelperResolver,
+            releaseMetadataResolver: testPrivateHeaderKitReleaseMetadataResolver,
             outputLogger: output.append,
             errorLogger: output.append
         )
@@ -434,6 +534,8 @@ struct PrivateHeaderKitCLIExecutionTests {
         #expect(output.text.contains("Skipped    1"))
         #expect(output.text.contains("opaque-path"))
         #expect(output.text.contains("generation.sqlite"))
+        let headersPath = "/tmp/PrivateHeaderKit/generated-headers/macOS/16.0"
+        #expect(output.text.components(separatedBy: headersPath).count == 3)
         #expect(!output.text.contains("manifest.json"))
         #expect(!output.text.contains("run.json"))
     }
@@ -466,6 +568,7 @@ struct PrivateHeaderKitCLIExecutionTests {
                 return testPrivateHeaderKitSimulatorResolution
             },
             helperResolver: testPrivateHeaderKitHelperResolver,
+            releaseMetadataResolver: testPrivateHeaderKitReleaseMetadataResolver,
             outputLogger: { _ in },
             errorLogger: { _ in }
         )
@@ -509,6 +612,7 @@ struct PrivateHeaderKitCLIExecutionTests {
                 }
             ),
             helperResolver: testPrivateHeaderKitHelperResolver,
+            releaseMetadataResolver: testPrivateHeaderKitReleaseMetadataResolver,
             outputLogger: output.append,
             errorLogger: output.append
         )
@@ -560,6 +664,7 @@ struct PrivateHeaderKitCLIExecutionTests {
                     }
                 ),
                 helperResolver: testPrivateHeaderKitHelperResolver,
+                releaseMetadataResolver: testPrivateHeaderKitReleaseMetadataResolver,
                 outputLogger: output.append,
                 errorLogger: output.append
             )
@@ -605,6 +710,7 @@ struct PrivateHeaderKitCLIExecutionTests {
                     )
                 },
                 helperResolver: testPrivateHeaderKitHelperResolver,
+                releaseMetadataResolver: testPrivateHeaderKitReleaseMetadataResolver,
                 outputLogger: output.append,
                 errorLogger: output.append
             )
@@ -751,7 +857,11 @@ struct PrivateHeaderKitCLIExecutionTests {
             simulator: root.appendingPathComponent("privateheaderkit-sim-helper")
         )
         let request = PrivateHeaderKitGenerationRequest(
-            source: try PrivateHeaderGeneration.Source(platform: .macOS, version: "16.0"),
+            source: try PrivateHeaderGeneration.Source(
+                platform: .macOS,
+                version: "16.0",
+                metadataIsSeed: false
+            ),
             output: PrivateHeaderGeneration.Output(
                 baseDirectory: root.appendingPathComponent("Output", isDirectory: true)
             ),
@@ -1007,10 +1117,10 @@ struct PrivateHeaderKitCLIExecutionTests {
 
             iOS
               [1] 18.0 (22A3351)
-              [2] 27.0 (24A5390f)
+              [2] 27.0 beta (24A5390f)
 
             watchOS
-              [3] 27.0 (24R5325f)
+              [3] 27.0 beta (24R5325f)
 
             macOS
               [4] 26.6.1 (25G76)
@@ -1062,6 +1172,7 @@ struct PrivateHeaderKitCLIExecutionTests {
                     toolCompatibilityIdentity: "test-tool-identity"
                 )
             },
+            releaseMetadataResolver: testPrivateHeaderKitReleaseMetadataResolver,
             interactiveSourceProvider: {
                 [
                     PrivateHeaderKitInteractiveSource(
@@ -1156,6 +1267,7 @@ struct PrivateHeaderKitCLIExecutionTests {
                     runtimeBuild: "24A123",
                     runtimeIdentifier: "com.apple.CoreSimulator.SimRuntime.iOS-27-0",
                     resolvedRuntimeRoot: runtimeRoot.path,
+                    metadataIsSeed: false,
                     deviceName: "iPhone 17 Pro",
                     deviceUDID: "SIM-001"
                 )
@@ -1249,6 +1361,7 @@ struct PrivateHeaderKitCLIExecutionTests {
                     runtimeBuild: "24A123",
                     runtimeIdentifier: "com.apple.CoreSimulator.SimRuntime.iOS-27-0",
                     resolvedRuntimeRoot: runtimeRoot.path,
+                    metadataIsSeed: false,
                     deviceName: "iPhone 17 Pro",
                     deviceUDID: "SIM-001"
                 )
@@ -1326,6 +1439,7 @@ struct PrivateHeaderKitCLIExecutionTests {
                     runtimeBuild: "24A123",
                     runtimeIdentifier: "com.apple.CoreSimulator.SimRuntime.iOS-27-0",
                     resolvedRuntimeRoot: root.appendingPathComponent("RuntimeRoot").path,
+                    metadataIsSeed: false,
                     deviceName: "iPhone 17 Pro",
                     deviceUDID: "SIM-001"
                 )
@@ -1400,6 +1514,7 @@ struct PrivateHeaderKitCLIExecutionTests {
                     runtimeBuild: "24A123",
                     runtimeIdentifier: "com.apple.CoreSimulator.SimRuntime.iOS-27-0",
                     resolvedRuntimeRoot: root.appendingPathComponent("RuntimeRoot").path,
+                    metadataIsSeed: false,
                     deviceName: "iPhone 17 Pro",
                     deviceUDID: "SIM-001"
                 )
@@ -1463,6 +1578,7 @@ struct PrivateHeaderKitCLIExecutionTests {
                 }
             ),
             helperResolver: testPrivateHeaderKitHelperResolver,
+            releaseMetadataResolver: testPrivateHeaderKitReleaseMetadataResolver,
             interactiveSourceProvider: {
                 [
                     PrivateHeaderKitInteractiveSource(
@@ -1487,6 +1603,9 @@ struct PrivateHeaderKitCLIExecutionTests {
 
 }
 
+private let testPrivateHeaderKitReleaseMetadataResolver:
+    PrivateHeaderKitReleaseMetadataResolver = { _, _ in false }
+
 private let testPrivateHeaderKitHelperURLs = PrivateHeaderGeneration.RawDumping.HelperURLs(
     host: URL(fileURLWithPath: "/cohort/privateheaderkit-raw-helper"),
     simulator: URL(fileURLWithPath: "/cohort/privateheaderkit-sim-helper")
@@ -1497,6 +1616,7 @@ private let testPrivateHeaderKitSimulatorResolution = PrivateHeaderKitSimulatorR
     runtimeBuild: "24A123",
     runtimeIdentifier: "com.apple.CoreSimulator.SimRuntime.iOS-27-0",
     resolvedRuntimeRoot: "/ResolvedRuntime",
+    metadataIsSeed: false,
     deviceName: "iPhone 17 Pro",
     deviceUDID: "SIM-001"
 )
@@ -1506,6 +1626,7 @@ private let testPrivateHeaderKitWatchSimulatorResolution = PrivateHeaderKitSimul
     runtimeBuild: "24R5325f",
     runtimeIdentifier: "com.apple.CoreSimulator.SimRuntime.watchOS-27-0",
     resolvedRuntimeRoot: "/ResolvedWatchRuntime",
+    metadataIsSeed: true,
     deviceName: "Apple Watch Series 11 (46mm)",
     deviceUDID: "WATCH-001"
 )
@@ -2908,6 +3029,7 @@ private func assertInteractiveLegacyMigration(kind: LegacyInputKind) async throw
             }
         ),
         helperResolver: testPrivateHeaderKitHelperResolver,
+        releaseMetadataResolver: testPrivateHeaderKitReleaseMetadataResolver,
         interactiveSourceProvider: {
             [
                 PrivateHeaderKitInteractiveSource(
@@ -2993,7 +3115,8 @@ private func unfinishedResumeSummaryFixture() async throws
     try Data().write(to: frameworkURL.appendingPathComponent("Foo", isDirectory: false))
     let source = try PrivateHeaderGeneration.Source(
         platform: .macOS,
-        version: "16.0"
+        version: "16.0",
+        metadataIsSeed: false
     )
     let plan = PrivateHeaderGeneration.makePlan(
         source: source,

--- a/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationExecutorTests.swift
+++ b/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationExecutorTests.swift
@@ -1993,6 +1993,118 @@ struct PrivateHeaderGenerationExecutorTests {
     #expect(try String(contentsOf: additionalHeader, encoding: .utf8) == "stable")
   }
 
+  @Test func storageIdentifierLiveDirectoryMovesToHumanPathBeforeResume() async throws {
+    let fixture = try ExecutorFixture()
+    defer { fixture.cleanup() }
+    try fixture.createFramework("Foo.framework")
+    await #expect(throws: InjectedFault.self) {
+      _ = try await fixture.executor(
+        runner: RecordingRunner(contents: "incremental"),
+        runID: "run-before-layout-migration",
+        generationID: "generation-before-layout-migration",
+        publicationFaultInjector: { point in
+          if point == .afterPrepared { throw InjectedFault.stop }
+        }
+      ).run(plan: try fixture.plan(.query("Foo"), resumeBehavior: .fresh))
+    }
+
+    try FileManager.default.moveItem(at: fixture.liveURL, to: fixture.legacyStorageLiveURL)
+    let unrelatedFile = fixture.outputBase.appendingPathComponent(
+      "generated-headers/scripts/keep.txt",
+      isDirectory: false
+    )
+    try FileManager.default.createDirectory(
+      at: unrelatedFile.deletingLastPathComponent(),
+      withIntermediateDirectories: true
+    )
+    try Data("unrelated".utf8).write(to: unrelatedFile)
+
+    let summaryExecutor = fixture.executor(
+      runner: RecordingRunner(contents: "must-not-run"),
+      runID: "run-layout-summary",
+      generationID: "generation-layout-summary"
+    )
+    let preparedPlan = try await summaryExecutor.prepare(
+      fixture.plan(.query("Foo"), resumeBehavior: .resume)
+    )
+    #expect(try await summaryExecutor.availableResumeSummary(for: preparedPlan) == nil)
+    #expect(!FileManager.default.fileExists(atPath: fixture.legacyStorageLiveURL.path))
+    #expect(try fixture.readLiveHeader() == "incremental")
+
+    let runner = RecordingRunner(contents: "must-not-run")
+    let result = try await fixture.executor(
+      runner: runner,
+      runID: "run-after-layout-migration",
+      generationID: "generation-after-layout-migration"
+    ).run(plan: try fixture.plan(.query("Foo"), resumeBehavior: .resume))
+
+    #expect(await runner.invocationCount == 0)
+    #expect(result.artifactDirectory == fixture.liveURL)
+    #expect(try fixture.readLiveHeader() == "incremental")
+    #expect(try String(contentsOf: unrelatedFile, encoding: .utf8) == "unrelated")
+  }
+
+  @Test func layoutMigrationRefusesToMergeLegacyAndHumanDirectories() async throws {
+    let fixture = try ExecutorFixture()
+    defer { fixture.cleanup() }
+    try fixture.createFramework("Foo.framework")
+    let legacyFile = fixture.legacyStorageLiveURL.appendingPathComponent("legacy.txt")
+    let currentFile = fixture.liveURL.appendingPathComponent("current.txt")
+    for (url, contents) in [(legacyFile, "legacy"), (currentFile, "current")] {
+      try FileManager.default.createDirectory(
+        at: url.deletingLastPathComponent(),
+        withIntermediateDirectories: true
+      )
+      try Data(contents.utf8).write(to: url)
+    }
+    let runner = RecordingRunner(contents: "must-not-run")
+
+    await #expect(throws: PrivateHeaderGeneration.GenerationError.self) {
+      _ = try await fixture.executor(
+        runner: runner,
+        runID: "run-conflicting-layouts",
+        generationID: "generation-conflicting-layouts"
+      ).run(plan: try fixture.plan(.query("Foo"), resumeBehavior: .fresh))
+    }
+
+    #expect(await runner.invocationCount == 0)
+    #expect(try String(contentsOf: legacyFile, encoding: .utf8) == "legacy")
+    #expect(try String(contentsOf: currentFile, encoding: .utf8) == "current")
+    #expect(!FileManager.default.fileExists(atPath: fixture.databaseURL.path))
+  }
+
+  @Test func humanArtifactPlatformDirectoryCannotBeASymlink() async throws {
+    let fixture = try ExecutorFixture()
+    defer { fixture.cleanup() }
+    try fixture.createFramework("Foo.framework")
+    let external = fixture.root.appendingPathComponent("External", isDirectory: true)
+    try FileManager.default.createDirectory(at: external, withIntermediateDirectories: true)
+    let platformDirectory = fixture.outputBase.appendingPathComponent(
+      "generated-headers/macOS",
+      isDirectory: true
+    )
+    try FileManager.default.createDirectory(
+      at: platformDirectory.deletingLastPathComponent(),
+      withIntermediateDirectories: true
+    )
+    try FileManager.default.createSymbolicLink(
+      at: platformDirectory,
+      withDestinationURL: external
+    )
+    let runner = RecordingRunner(contents: "must-not-run")
+
+    await #expect(throws: PrivateHeaderGeneration.StateError.self) {
+      _ = try await fixture.executor(
+        runner: runner,
+        runID: "run-symlink-platform",
+        generationID: "generation-symlink-platform"
+      ).run(plan: try fixture.plan(.query("Foo"), resumeBehavior: .fresh))
+    }
+
+    #expect(await runner.invocationCount == 0)
+    #expect((try FileManager.default.contentsOfDirectory(atPath: external.path)).isEmpty)
+  }
+
   @Test func legacyJSONGateRunsBeforeDatabaseCreationOnEveryRetry() async throws {
     let fixture = try ExecutorFixture()
     defer { fixture.cleanup() }
@@ -2636,7 +2748,8 @@ private struct ExecutorFixture {
     source = try PrivateHeaderGeneration.Source(
       platform: .macOS,
       version: "16.0",
-      build: "25A000"
+      build: "25A000",
+      metadataIsSeed: false
     )
     try FileManager.default.createDirectory(at: systemRoot, withIntermediateDirectories: true)
   }
@@ -2644,10 +2757,11 @@ private struct ExecutorFixture {
   var sourceLabel: String { source.storageIdentifier }
   var stableURL: URL { outputBase.appendingPathComponent(sourceLabel, isDirectory: false) }
   var liveURL: URL {
-    outputBase.appendingPathComponent(
-      "generated-headers/\(sourceLabel)",
-      isDirectory: true
-    )
+    PrivateHeaderGeneration.Output(baseDirectory: outputBase).artifactDirectory(for: source)
+  }
+  var legacyStorageLiveURL: URL {
+    PrivateHeaderGeneration.Output(baseDirectory: outputBase)
+      .legacyStorageArtifactDirectory(for: source)
   }
   var stateDirectory: URL {
     outputBase.appendingPathComponent(".state/\(sourceLabel)", isDirectory: true)

--- a/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationTests.swift
+++ b/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationTests.swift
@@ -13,7 +13,7 @@ struct PrivateHeaderGenerationTests {
       metadataIsSeed: true
     )
     #expect(source.label.displayName == "iOS 27.0 beta (24A5355q)")
-    #expect(source.artifactDirectoryName == "27.0 beta (24A5355q)")
+    #expect(source.artifactDirectoryName == "27.0_beta_24A5355q")
     #expect(source.storageIdentifier == "ios-v1-27.0-b1-24~415355~71")
   }
 
@@ -93,7 +93,7 @@ struct PrivateHeaderGenerationTests {
 
     #expect(!source.artifactDirectoryName.contains("/"))
     #expect(!source.artifactDirectoryName.contains("\0"))
-    #expect(!source.artifactDirectoryName.contains(" beta"))
+    #expect(!source.artifactDirectoryName.contains("_beta_"))
   }
 
   @Test func sourceRejectsArtifactDirectoryNameLongerThanAPathComponent() {
@@ -106,20 +106,33 @@ struct PrivateHeaderGenerationTests {
     }
   }
 
-  @Test func sourceRejectsReleaseMetadataThatDisagreesWithBuildIdentity() {
+  @Test func releaseMetadataOwnsBetaClassificationInsteadOfBuildSuffix() throws {
+    let rapidSecurityResponse = try PrivateHeaderGeneration.Source(
+      platform: .iOS,
+      version: "16.4.1",
+      build: "20E772520a",
+      metadataIsSeed: false
+    )
+    let betaWithoutSuffix = try PrivateHeaderGeneration.Source(
+      platform: .iOS,
+      version: "27.0",
+      build: "24A123",
+      metadataIsSeed: true
+    )
+
+    #expect(rapidSecurityResponse.releaseChannel == .release)
+    #expect(rapidSecurityResponse.label.displayName == "iOS 16.4.1 (20E772520a)")
+    #expect(rapidSecurityResponse.artifactDirectoryName == "16.4.1_20E772520a")
+    #expect(betaWithoutSuffix.releaseChannel == .beta)
+    #expect(betaWithoutSuffix.label.displayName == "iOS 27.0 beta (24A123)")
+    #expect(betaWithoutSuffix.artifactDirectoryName == "27.0_beta_24A123")
+  }
+
+  @Test func seedSourceRequiresAnExactBuild() {
     #expect(throws: PrivateHeaderGeneration.Source.ValidationError.self) {
       _ = try PrivateHeaderGeneration.Source(
         platform: .iOS,
         version: "27.0",
-        build: "24A5390f",
-        metadataIsSeed: false
-      )
-    }
-    #expect(throws: PrivateHeaderGeneration.Source.ValidationError.self) {
-      _ = try PrivateHeaderGeneration.Source(
-        platform: .iOS,
-        version: "27.0",
-        build: "24A123",
         metadataIsSeed: true
       )
     }
@@ -139,7 +152,7 @@ struct PrivateHeaderGenerationTests {
 
     #expect(
       plan.artifactDirectory.path
-        == "/tmp/PrivateHeaderKit/generated-headers/macOS/16.0 (25A000)")
+        == "/tmp/PrivateHeaderKit/generated-headers/macOS/16.0_25A000")
     #expect(
       plan.stateDirectory.path == "/tmp/PrivateHeaderKit/.state/macos-v1-16.0-b1-25~41000")
     #expect(

--- a/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationTests.swift
+++ b/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationTests.swift
@@ -9,9 +9,11 @@ struct PrivateHeaderGenerationTests {
     let source = try PrivateHeaderGeneration.Source(
       platform: .iOS,
       version: "27.0",
-      build: "24A5355q"
+      build: "24A5355q",
+      metadataIsSeed: true
     )
-    #expect(source.label.displayName == "iOS 27.0 (24A5355q)")
+    #expect(source.label.displayName == "iOS 27.0 beta (24A5355q)")
+    #expect(source.artifactDirectoryName == "27.0 beta (24A5355q)")
     #expect(source.storageIdentifier == "ios-v1-27.0-b1-24~415355~71")
   }
 
@@ -19,42 +21,52 @@ struct PrivateHeaderGenerationTests {
     let source = try PrivateHeaderGeneration.Source(
       platform: .watchOS,
       version: "27.0",
-      build: "24R5325f"
+      build: "24R5325f",
+      metadataIsSeed: true
     )
 
-    #expect(source.label.displayName == "watchOS 27.0 (24R5325f)")
+    #expect(source.label.displayName == "watchOS 27.0 beta (24R5325f)")
     #expect(source.storageIdentifier == "watchos-v1-27.0-b1-24~525325~66")
   }
 
   @Test func storageIdentityDistinguishesAmbiguousLabelsAndFilesystemAliases() throws {
     let versionContainsBuild = try PrivateHeaderGeneration.Source(
       platform: .iOS,
-      version: "17.0(A)"
+      version: "17.0(A)",
+      metadataIsSeed: false
     )
     let separateBuild = try PrivateHeaderGeneration.Source(
       platform: .iOS,
       version: "17.0",
-      build: "A"
+      build: "A",
+      metadataIsSeed: false
     )
     let lowercaseBuild = try PrivateHeaderGeneration.Source(
       platform: .iOS,
       version: "17.0",
-      build: "a"
+      build: "a",
+      metadataIsSeed: false
     )
     let literalEscape = try PrivateHeaderGeneration.Source(
       platform: .iOS,
       version: "17.0",
-      build: "~41"
+      build: "~41",
+      metadataIsSeed: false
     )
 
     #expect(versionContainsBuild.storageIdentifier != separateBuild.storageIdentifier)
     #expect(separateBuild.storageIdentifier != lowercaseBuild.storageIdentifier)
     #expect(separateBuild.storageIdentifier != literalEscape.storageIdentifier)
+    #expect(versionContainsBuild.artifactDirectoryName != separateBuild.artifactDirectoryName)
+    #expect(separateBuild.artifactDirectoryName != lowercaseBuild.artifactDirectoryName)
+    #expect(separateBuild.artifactDirectoryName != literalEscape.artifactDirectoryName)
   }
 
   @Test func sourceCanonicalizesUnicodeBeforeDerivingStorageIdentity() throws {
-    let precomposed = try PrivateHeaderGeneration.Source(platform: .iOS, version: "é")
-    let decomposed = try PrivateHeaderGeneration.Source(platform: .iOS, version: "e\u{301}")
+    let precomposed = try PrivateHeaderGeneration.Source(
+      platform: .iOS, version: "é", metadataIsSeed: false)
+    let decomposed = try PrivateHeaderGeneration.Source(
+      platform: .iOS, version: "e\u{301}", metadataIsSeed: false)
 
     #expect(precomposed == decomposed)
     #expect(decomposed.version == "é")
@@ -65,14 +77,57 @@ struct PrivateHeaderGenerationTests {
     #expect(throws: PrivateHeaderGeneration.Source.ValidationError.self) {
       _ = try PrivateHeaderGeneration.Source(
         platform: .iOS,
-        version: String(repeating: "A", count: 82)
+        version: String(repeating: "A", count: 82),
+        metadataIsSeed: false
+      )
+    }
+  }
+
+  @Test func sourceEscapesPathSeparatorsAndInvalidBetaShapedBuilds() throws {
+    let source = try PrivateHeaderGeneration.Source(
+      platform: .iOS,
+      version: "../27/0\0",
+      build: "not-a-build",
+      metadataIsSeed: false
+    )
+
+    #expect(!source.artifactDirectoryName.contains("/"))
+    #expect(!source.artifactDirectoryName.contains("\0"))
+    #expect(!source.artifactDirectoryName.contains(" beta"))
+  }
+
+  @Test func sourceRejectsArtifactDirectoryNameLongerThanAPathComponent() {
+    #expect(throws: PrivateHeaderGeneration.Source.ValidationError.self) {
+      _ = try PrivateHeaderGeneration.Source(
+        platform: .iOS,
+        version: String(repeating: ".", count: 85) + "A",
+        metadataIsSeed: false
+      )
+    }
+  }
+
+  @Test func sourceRejectsReleaseMetadataThatDisagreesWithBuildIdentity() {
+    #expect(throws: PrivateHeaderGeneration.Source.ValidationError.self) {
+      _ = try PrivateHeaderGeneration.Source(
+        platform: .iOS,
+        version: "27.0",
+        build: "24A5390f",
+        metadataIsSeed: false
+      )
+    }
+    #expect(throws: PrivateHeaderGeneration.Source.ValidationError.self) {
+      _ = try PrivateHeaderGeneration.Source(
+        platform: .iOS,
+        version: "27.0",
+        build: "24A123",
+        metadataIsSeed: true
       )
     }
   }
 
   @Test func oneOutputRootDerivesArtifactAndStateIdentity() throws {
     let source = try PrivateHeaderGeneration.Source(
-      platform: .macOS, version: "16.0", build: "25A000")
+      platform: .macOS, version: "16.0", build: "25A000", metadataIsSeed: false)
     let output = PrivateHeaderGeneration.Output(
       baseDirectory: URL(fileURLWithPath: "/tmp/PrivateHeaderKit", isDirectory: true)
     )
@@ -84,7 +139,7 @@ struct PrivateHeaderGenerationTests {
 
     #expect(
       plan.artifactDirectory.path
-        == "/tmp/PrivateHeaderKit/generated-headers/macos-v1-16.0-b1-25~41000")
+        == "/tmp/PrivateHeaderKit/generated-headers/macOS/16.0 (25A000)")
     #expect(
       plan.stateDirectory.path == "/tmp/PrivateHeaderKit/.state/macos-v1-16.0-b1-25~41000")
     #expect(
@@ -93,7 +148,8 @@ struct PrivateHeaderGenerationTests {
   }
 
   @Test func distinctPlansWithEmbeddedNewlinesHaveDistinctFingerprints() throws {
-    let source = try PrivateHeaderGeneration.Source(platform: .macOS, version: "16.0")
+    let source = try PrivateHeaderGeneration.Source(
+      platform: .macOS, version: "16.0", metadataIsSeed: false)
     let output = PrivateHeaderGeneration.Output(
       baseDirectory: URL(fileURLWithPath: "/tmp/PrivateHeaderKit", isDirectory: true)
     )

--- a/Tests/PrivateHeaderKitToolingTests/RuntimeReleaseMetadataTests.swift
+++ b/Tests/PrivateHeaderKitToolingTests/RuntimeReleaseMetadataTests.swift
@@ -1,0 +1,66 @@
+import Foundation
+import Testing
+
+@testable import PrivateHeaderKitTooling
+
+@Suite
+struct RuntimeReleaseMetadataTests {
+    @Test func simulatorSeedMetadataIsReadFromRuntimeRoot() throws {
+        let root = try temporaryRuntimeRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        try writeRestoreVersion(
+            ["IsSeed": true],
+            to: root.appendingPathComponent("RestoreVersion.plist")
+        )
+
+        #expect(try RuntimeReleaseMetadata.isSeed(in: root, layout: .simulator))
+    }
+
+    @Test func absentSeedKeyRepresentsARelease() throws {
+        let root = try temporaryRuntimeRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let metadataURL = root.appendingPathComponent(
+            "System/Library/CoreServices/RestoreVersion.plist"
+        )
+        try writeRestoreVersion(["RestoreVersion": "25.7.83.0.0"], to: metadataURL)
+
+        #expect(try !RuntimeReleaseMetadata.isSeed(in: root, layout: .macOS))
+    }
+
+    @Test func malformedOrMissingMetadataFailsWithItsPath() throws {
+        let root = try temporaryRuntimeRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let metadataURL = root.appendingPathComponent("RestoreVersion.plist")
+        try writeRestoreVersion(["IsSeed": "true"], to: metadataURL)
+
+        #expect(throws: ToolingError.self) {
+            _ = try RuntimeReleaseMetadata.isSeed(in: root, layout: .simulator)
+        }
+        try FileManager.default.removeItem(at: metadataURL)
+        #expect(throws: ToolingError.self) {
+            _ = try RuntimeReleaseMetadata.isSeed(in: root, layout: .simulator)
+        }
+    }
+}
+
+private func temporaryRuntimeRoot() throws -> URL {
+    let root = FileManager.default.temporaryDirectory.appendingPathComponent(
+        "RuntimeReleaseMetadataTests-\(UUID().uuidString)",
+        isDirectory: true
+    )
+    try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+    return root
+}
+
+private func writeRestoreVersion(_ values: [String: Any], to url: URL) throws {
+    try FileManager.default.createDirectory(
+        at: url.deletingLastPathComponent(),
+        withIntermediateDirectories: true
+    )
+    let data = try PropertyListSerialization.data(
+        fromPropertyList: values,
+        format: .binary,
+        options: 0
+    )
+    try data.write(to: url)
+}


### PR DESCRIPTION
## Purpose

Make generated header locations shell-friendly by grouping them under the Apple platform and exact source release while keeping opaque storage identities internal.

## Changes

- Publish headers under paths such as `generated-headers/iOS/27.0_beta_24A5390f` without spaces or shell-sensitive punctuation.
- Keep `.state`, `.privateheaderkit`, source leases, and recovery links keyed by the existing opaque storage identifier.
- Derive beta classification from installed runtime `RestoreVersion.plist` seed metadata, so lowercase-suffixed public releases such as Rapid Security Responses remain in the release namespace.
- Fail before helper preparation when a seed source does not provide an exact build.
- Atomically relocate the previous `generated-headers/<source-storage-id>` live tree under the same source lease so interrupted output remains resumable.
- Reject old/new layout conflicts without merging or overwriting either directory.
- Keep progress output, completion output, the interactive source picker, documentation, and troubleshooting guidance aligned with the same release metadata.
- Include `main` changes from #68 for deleted-publication recovery.

## Testing

- `swift test` — 532 tests in 42 suites passed.
- iOS Simulator compile checks passed for `PrivateHeaderKitCore` and `PrivateHeaderKitCoreTests`.
- watchOS Simulator compile checks passed for `PrivateHeaderKitCore`, `PrivateHeaderKitCoreTests`, and `privateheaderkit-sim-helper`.
- Branch-wide `codex-review` against pinned `main` (`110b05805f54729df2bb18e14ebc3e595a54eb83`) — 0 findings.
