### PR TITLE
Fix simulator runtimes without release metadata

### DIFF
--- a/Docs/generation.md
+++ b/Docs/generation.md
@@ -101,8 +101,10 @@ Release directory fields use underscores so paths do not require shell quoting.
 PrivateHeaderKit derives the `beta` field from the source runtime's seed
 metadata, not from the build suffix; this keeps lowercase-suffixed public
 releases out of the beta namespace. Installed metadata does not provide a beta
-number, so the build disambiguates beta sources. Missing or unreadable metadata
-stops generation instead of publishing under a guessed name.
+number, so the build disambiguates beta sources. Older Simulator runtimes that
+omit `RestoreVersion.plist` are treated as non-seed releases. An unreadable or
+malformed metadata file, or missing macOS metadata, stops generation instead of
+publishing under a guessed name.
 
 The complete output base is:
 

--- a/Sources/PrivateHeaderKitTooling/RuntimeReleaseMetadata.swift
+++ b/Sources/PrivateHeaderKitTooling/RuntimeReleaseMetadata.swift
@@ -1,5 +1,11 @@
 import Foundation
 
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#endif
+
 package enum RuntimeRootLayout: Sendable {
     case simulator
     case macOS
@@ -40,7 +46,12 @@ package enum RuntimeReleaseMetadata {
         let data: Data
         do {
             data = try Data(contentsOf: metadataURL)
-        } catch where missingSimulatorMetadataRepresentsRelease(error, layout: layout) {
+        } catch where missingSimulatorMetadataRepresentsRelease(
+            error,
+            systemRoot: systemRoot,
+            metadataURL: metadataURL,
+            layout: layout
+        ) {
             return false
         } catch {
             throw ToolingError.message(
@@ -58,12 +69,32 @@ package enum RuntimeReleaseMetadata {
 
     private static func missingSimulatorMetadataRepresentsRelease(
         _ error: any Error,
+        systemRoot: URL,
+        metadataURL: URL,
         layout: RuntimeRootLayout
     ) -> Bool {
-        guard case .simulator = layout else { return false }
+        guard case .simulator = layout,
+              isMissingFileError(error),
+              isExistingDirectory(at: systemRoot),
+              hasNoDirectoryEntry(at: metadataURL)
+        else {
+            return false
+        }
 
         // Older Simulator runtime bundles legitimately omit RestoreVersion.plist.
-        return isMissingFileError(error)
+        return true
+    }
+
+    private static func isExistingDirectory(at url: URL) -> Bool {
+        var info = stat()
+        guard stat(url.path, &info) == 0 else { return false }
+        return info.st_mode & mode_t(S_IFMT) == mode_t(S_IFDIR)
+    }
+
+    private static func hasNoDirectoryEntry(at url: URL) -> Bool {
+        var info = stat()
+        guard lstat(url.path, &info) != 0 else { return false }
+        return errno == ENOENT
     }
 
     private static func isMissingFileError(_ error: any Error) -> Bool {

--- a/Sources/PrivateHeaderKitTooling/RuntimeReleaseMetadata.swift
+++ b/Sources/PrivateHeaderKitTooling/RuntimeReleaseMetadata.swift
@@ -40,6 +40,8 @@ package enum RuntimeReleaseMetadata {
         let data: Data
         do {
             data = try Data(contentsOf: metadataURL)
+        } catch where missingSimulatorMetadataRepresentsRelease(error, layout: layout) {
+            return false
         } catch {
             throw ToolingError.message(
                 "failed to read runtime release metadata at \(metadataURL.path): \(error)"
@@ -52,5 +54,34 @@ package enum RuntimeReleaseMetadata {
                 "failed to decode runtime release metadata at \(metadataURL.path): \(error)"
             )
         }
+    }
+
+    private static func missingSimulatorMetadataRepresentsRelease(
+        _ error: any Error,
+        layout: RuntimeRootLayout
+    ) -> Bool {
+        guard case .simulator = layout else { return false }
+
+        // Older Simulator runtime bundles legitimately omit RestoreVersion.plist.
+        return isMissingFileError(error)
+    }
+
+    private static func isMissingFileError(_ error: any Error) -> Bool {
+        let error = error as NSError
+        if error.domain == NSCocoaErrorDomain,
+           (error.code == CocoaError.Code.fileNoSuchFile.rawValue
+            || error.code == CocoaError.Code.fileReadNoSuchFile.rawValue)
+        {
+            return true
+        }
+        if error.domain == NSPOSIXErrorDomain,
+           error.code == Int(POSIXError.Code.ENOENT.rawValue)
+        {
+            return true
+        }
+        if let underlying = error.userInfo[NSUnderlyingErrorKey] as? NSError {
+            return isMissingFileError(underlying)
+        }
+        return false
     }
 }

--- a/Tests/PrivateHeaderKitCLITests/PrivateHeaderKitCLITests.swift
+++ b/Tests/PrivateHeaderKitCLITests/PrivateHeaderKitCLITests.swift
@@ -281,11 +281,48 @@ struct PrivateHeaderKitCLIExecutionTests {
         #expect(request.source.storageIdentifier == "ios-v1-27.0-b1-24~415390~66")
     }
 
-    @Test func simulatorReleaseMetadataIsValidatedBeforeResolvingADevice() async throws {
+    @Test func simulatorWithoutReleaseMetadataResolvesAsARelease() async throws {
         let root = try temporaryDirectory()
         defer { try? FileManager.default.removeItem(at: root) }
         let runtimeRoot = root.appendingPathComponent("RuntimeRoot", isDirectory: true)
         try FileManager.default.createDirectory(at: runtimeRoot, withIntermediateDirectories: true)
+        let runner = RecordingCommandRunner()
+        await runner.setCaptureOutput(
+            """
+            {"runtimes":[{"name":"iOS 27.0","platform":"iOS","version":"27.0","buildversion":"24A5390f","identifier":"ios-27","runtimeRoot":"\(runtimeRoot.path)","isAvailable":true}]}
+            """,
+            for: ["xcrun", "simctl", "list", "runtimes", "-j"]
+        )
+        await runner.setCaptureOutput(
+            """
+            {"devices":{"ios-27":[{"name":"Dumping Device (iOS 27.0)","udid":"SIM-001","state":"Booted"}]}}
+            """,
+            for: ["xcrun", "simctl", "list", "devices", "-j"]
+        )
+
+        let resolution = try await resolvePrivateHeaderKitSimulator(
+            for: iosGenerateCommand(build: nil, systemRoot: nil),
+            runner: runner
+        )
+
+        #expect(!resolution.metadataIsSeed)
+        #expect(resolution.resolvedRuntimeRoot == runtimeRoot.path)
+        #expect(resolution.deviceUDID == "SIM-001")
+        #expect(await runner.captureCommandSnapshot().map(\.command) == [
+            ["xcrun", "simctl", "list", "runtimes", "-j"],
+            ["xcrun", "simctl", "list", "devices", "-j"],
+        ])
+        #expect(await runner.simpleCommandSnapshot().isEmpty)
+    }
+
+    @Test func malformedSimulatorReleaseMetadataFailsBeforeResolvingADevice() async throws {
+        let root = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let runtimeRoot = root.appendingPathComponent("RuntimeRoot", isDirectory: true)
+        try FileManager.default.createDirectory(at: runtimeRoot, withIntermediateDirectories: true)
+        try Data("not a property list".utf8).write(
+            to: runtimeRoot.appendingPathComponent("RestoreVersion.plist")
+        )
         let runner = RecordingCommandRunner()
         await runner.setCaptureOutput(
             """
@@ -300,6 +337,9 @@ struct PrivateHeaderKitCLIExecutionTests {
                 runner: runner
             )
         }
+        #expect(await runner.captureCommandSnapshot().map(\.command) == [
+            ["xcrun", "simctl", "list", "runtimes", "-j"],
+        ])
         #expect(await runner.simpleCommandSnapshot().isEmpty)
     }
 
@@ -756,6 +796,82 @@ struct PrivateHeaderKitCLIExecutionTests {
         #expect(await task.value == 130)
         #expect(!output.text.contains("Generation interrupted"))
         #expect(!output.text.contains("error:"))
+    }
+
+    @Test func sourceDiscoveryIncludesSimulatorRuntimeWithoutReleaseMetadata() async throws {
+        let root = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let releaseRuntimeRoot = root.appendingPathComponent("iOS 17.5", isDirectory: true)
+        let seedRuntimeRoot = root.appendingPathComponent("watchOS 27.0", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: releaseRuntimeRoot,
+            withIntermediateDirectories: true
+        )
+        try FileManager.default.createDirectory(
+            at: seedRuntimeRoot,
+            withIntermediateDirectories: true
+        )
+        let seedMetadata = try PropertyListSerialization.data(
+            fromPropertyList: ["IsSeed": true],
+            format: .binary,
+            options: 0
+        )
+        try seedMetadata.write(
+            to: seedRuntimeRoot.appendingPathComponent("RestoreVersion.plist")
+        )
+        let runner = CaptureOnlyCommandRunner { command, _, _ in
+            switch command {
+            case ["xcrun", "--find", "simctl"]:
+                return "/Applications/Xcode.app/Contents/Developer/usr/bin/simctl\n"
+            case ["xcrun", "simctl", "list", "runtimes", "-j"]:
+                return """
+                {"runtimes":[{"name":"watchOS 27.0","platform":"watchOS","version":"27.0","buildversion":"24R5325f","identifier":"watch-27","runtimeRoot":"\(seedRuntimeRoot.path)","isAvailable":true},{"name":"iOS 17.5","platform":"iOS","version":"17.5","buildversion":"21F79","identifier":"ios-17-5","runtimeRoot":"\(releaseRuntimeRoot.path)","isAvailable":true}]}
+                """
+            case ["/usr/bin/sw_vers", "-productVersion"]:
+                return "16.0\n"
+            case ["/usr/bin/sw_vers", "-buildVersion"]:
+                return "24A1\n"
+            default:
+                throw ToolingError.message("unexpected command: \(command)")
+            }
+        }
+
+        let sources = try await discoverPrivateHeaderKitInteractiveSources(
+            runner: runner,
+            releaseMetadataResolver: { systemRoot, layout in
+                switch layout {
+                case .simulator:
+                    return try resolvePrivateHeaderKitReleaseMetadata(
+                        systemRoot: systemRoot,
+                        layout: layout
+                    )
+                case .macOS:
+                    return false
+                }
+            }
+        )
+
+        #expect(sources == [
+            PrivateHeaderKitInteractiveSource(
+                platform: .iOS,
+                version: "17.5",
+                build: "21F79",
+                systemRoot: nil
+            ),
+            PrivateHeaderKitInteractiveSource(
+                platform: .watchOS,
+                version: "27.0",
+                build: "24R5325f",
+                metadataIsSeed: true,
+                systemRoot: nil
+            ),
+            PrivateHeaderKitInteractiveSource(
+                platform: .macOS,
+                version: "16.0",
+                build: "24A1",
+                systemRoot: "/"
+            ),
+        ])
     }
 
     @Test func sourceDiscoveryModelsSimulatorAvailabilityAndPropagatesListingFailures() async throws {

--- a/Tests/PrivateHeaderKitToolingTests/RuntimeReleaseMetadataTests.swift
+++ b/Tests/PrivateHeaderKitToolingTests/RuntimeReleaseMetadataTests.swift
@@ -34,6 +34,28 @@ struct RuntimeReleaseMetadataTests {
         #expect(try !RuntimeReleaseMetadata.isSeed(in: root, layout: .simulator))
     }
 
+    @Test func danglingSimulatorMetadataSymlinkFails() throws {
+        let root = try temporaryRuntimeRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        try FileManager.default.createSymbolicLink(
+            at: root.appendingPathComponent("RestoreVersion.plist"),
+            withDestinationURL: root.appendingPathComponent("MissingRestoreVersion.plist")
+        )
+
+        #expect(throws: ToolingError.self) {
+            _ = try RuntimeReleaseMetadata.isSeed(in: root, layout: .simulator)
+        }
+    }
+
+    @Test func missingSimulatorRuntimeRootFails() throws {
+        let root = try temporaryRuntimeRoot()
+        try FileManager.default.removeItem(at: root)
+
+        #expect(throws: ToolingError.self) {
+            _ = try RuntimeReleaseMetadata.isSeed(in: root, layout: .simulator)
+        }
+    }
+
     @Test func missingMacOSMetadataFails() throws {
         let root = try temporaryRuntimeRoot()
         defer { try? FileManager.default.removeItem(at: root) }

--- a/Tests/PrivateHeaderKitToolingTests/RuntimeReleaseMetadataTests.swift
+++ b/Tests/PrivateHeaderKitToolingTests/RuntimeReleaseMetadataTests.swift
@@ -27,16 +27,41 @@ struct RuntimeReleaseMetadataTests {
         #expect(try !RuntimeReleaseMetadata.isSeed(in: root, layout: .macOS))
     }
 
-    @Test func malformedOrMissingMetadataFailsWithItsPath() throws {
+    @Test func missingSimulatorMetadataRepresentsARelease() throws {
+        let root = try temporaryRuntimeRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        #expect(try !RuntimeReleaseMetadata.isSeed(in: root, layout: .simulator))
+    }
+
+    @Test func missingMacOSMetadataFails() throws {
+        let root = try temporaryRuntimeRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        #expect(throws: ToolingError.self) {
+            _ = try RuntimeReleaseMetadata.isSeed(in: root, layout: .macOS)
+        }
+    }
+
+    @Test func unreadableSimulatorMetadataFails() throws {
+        let root = try temporaryRuntimeRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        try FileManager.default.createDirectory(
+            at: root.appendingPathComponent("RestoreVersion.plist"),
+            withIntermediateDirectories: false
+        )
+
+        #expect(throws: ToolingError.self) {
+            _ = try RuntimeReleaseMetadata.isSeed(in: root, layout: .simulator)
+        }
+    }
+
+    @Test func malformedMetadataFails() throws {
         let root = try temporaryRuntimeRoot()
         defer { try? FileManager.default.removeItem(at: root) }
         let metadataURL = root.appendingPathComponent("RestoreVersion.plist")
         try writeRestoreVersion(["IsSeed": "true"], to: metadataURL)
 
-        #expect(throws: ToolingError.self) {
-            _ = try RuntimeReleaseMetadata.isSeed(in: root, layout: .simulator)
-        }
-        try FileManager.default.removeItem(at: metadataURL)
         #expect(throws: ToolingError.self) {
             _ = try RuntimeReleaseMetadata.isSeed(in: root, layout: .simulator)
         }


### PR DESCRIPTION
## Summary

- Treat a missing `RestoreVersion.plist` in Simulator runtime roots as non-seed release metadata.
- Preserve failures for unreadable or malformed metadata and for missing macOS metadata.
- Cover explicit Simulator resolution and no-argument interactive discovery, and document the updated contract.

## Testing

- `swift test` (539 tests, 42 suites)
- `git diff --check`
- `codex-review` (0 findings)

Closes #70
