### PR TITLE
Fix Objective-C runtime image identity resolution

### DIFF
--- a/Sources/PrivateHeaderKitRawDumpCore/PrivateHeaderKitRawDumpMain.swift
+++ b/Sources/PrivateHeaderKitRawDumpCore/PrivateHeaderKitRawDumpMain.swift
@@ -1319,6 +1319,121 @@ func withLoadedRuntimeImage<Result: Sendable>(
     return try inspect(handle)
 }
 
+struct ObjectiveCRuntimeImageIdentity: Equatable, Sendable {
+    let path: String
+
+    fileprivate init(path: String) {
+        self.path = path
+    }
+}
+
+func matchingLoadedRuntimeImageIdentity(
+    for targetImagePath: String,
+    loadedImageNames: [String],
+    environment: [String: String] = ProcessInfo.processInfo.environment
+) -> ObjectiveCRuntimeImageIdentity? {
+    let runtimeRoots = runtimeImageIdentityRoots(environment: environment)
+    let targetCandidates = Set(
+        normalizedCacheImagePaths(
+            for: targetImagePath,
+            environment: environment
+        )
+    )
+    var matchedName: String?
+    var visitedNames: Set<String> = []
+
+    for loadedImageName in loadedImageNames where visitedNames.insert(loadedImageName).inserted {
+        let matchesTarget = targetCandidates.contains(loadedImageName)
+            || runtimeRoots.contains { runtimeRoot in
+                guard let logicalPath = pathRemovingRuntimeRoot(
+                    loadedImageName,
+                    runtimeRoot: runtimeRoot
+                ) else {
+                    return false
+                }
+                return targetCandidates.contains(logicalPath)
+            }
+        guard matchesTarget else {
+            continue
+        }
+        guard matchedName == nil else {
+            return nil
+        }
+        matchedName = loadedImageName
+    }
+
+    return matchedName.map(ObjectiveCRuntimeImageIdentity.init(path:))
+}
+
+func runtimeRootedImageIdentity(
+    loadPath: String,
+    environment: [String: String] = ProcessInfo.processInfo.environment,
+    fileManager: FileExistenceChecking = FileManager.default
+) -> ObjectiveCRuntimeImageIdentity? {
+    guard fileManager.fileExists(atPath: loadPath) else { return nil }
+    if let runtimeRoot = runtimeRootPath(environment: environment),
+       URL(fileURLWithPath: runtimeRoot, isDirectory: true).standardizedFileURL.path == "/"
+    {
+        return ObjectiveCRuntimeImageIdentity(path: loadPath)
+    }
+    let runtimeRoots = runtimeImageIdentityRoots(environment: environment)
+    guard runtimeRoots.contains(where: { runtimeRoot in
+        pathRemovingRuntimeRoot(loadPath, runtimeRoot: runtimeRoot) != nil
+    }) else {
+        return nil
+    }
+    return ObjectiveCRuntimeImageIdentity(path: loadPath)
+}
+
+private func runtimeImageIdentityRoots(environment: [String: String]) -> [String] {
+    guard let runtimeRoot = runtimeRootPath(environment: environment) else {
+        return []
+    }
+    let lexicalRoot = URL(fileURLWithPath: runtimeRoot, isDirectory: true)
+        .standardizedFileURL
+        .path
+    let resolvedRoot = URL(fileURLWithPath: runtimeRoot, isDirectory: true)
+        .resolvingSymlinksInPath()
+        .standardizedFileURL
+        .path
+    var roots = lexicalRoot == "/" ? [] : [lexicalRoot]
+    if resolvedRoot != "/", resolvedRoot != lexicalRoot {
+        roots.append(resolvedRoot)
+    }
+    return roots
+}
+
+private func pathRemovingRuntimeRoot(_ path: String, runtimeRoot: String) -> String? {
+    guard runtimeRoot != "/" else { return nil }
+    let rootPrefix = runtimeRoot + "/"
+    guard path.hasPrefix(rootPrefix) else { return nil }
+    return "/" + path.dropFirst(rootPrefix.count)
+}
+
+@MainActor
+private func loadedRuntimeImageNames() -> [String] {
+    var count: UInt32 = 0
+    let names = objc_copyImageNames(&count)
+    defer { free(names) }
+    return UnsafeBufferPointer(start: names, count: Int(count)).map {
+        String(cString: $0)
+    }
+}
+
+@MainActor
+private func copyRuntimeClassNames(
+    for identity: ObjectiveCRuntimeImageIdentity
+) -> [String]? {
+    var count: UInt32 = 0
+    guard let names = objc_copyClassNamesForImage(identity.path, &count) else {
+        return nil
+    }
+    defer { free(names) }
+    return UnsafeBufferPointer(start: names, count: Int(count)).map {
+        String(cString: $0)
+    }
+}
+
 @MainActor
 private func runtimeClassInfos(
     for imagePath: String,
@@ -1326,15 +1441,35 @@ private func runtimeClassInfos(
     verbose: Bool
 ) -> [ObjCClassInfo] {
     let targetPaths = runtimeFallbackTargetImagePaths(for: imagePath)
-    let resolvedPath = resolveRuntimeURL(URL(fileURLWithPath: imagePath)).path
+    let loadPath = resolveRuntimeURL(URL(fileURLWithPath: imagePath)).path
     guard let infos = withLoadedRuntimeImage(
-        at: resolvedPath,
+        at: loadPath,
         inspect: { _ in
-            var count: UInt32 = 0
-            guard let namesPtr = objc_copyClassNamesForImage(resolvedPath, &count) else {
+            // Cache-only Simulator images can have no file at their registered runtime path.
+            var runtimeImageIdentity: ObjectiveCRuntimeImageIdentity?
+            var names: [String]?
+            if let rootedIdentity = runtimeRootedImageIdentity(loadPath: loadPath),
+               let rootedNames = copyRuntimeClassNames(for: rootedIdentity)
+            {
+                runtimeImageIdentity = rootedIdentity
+                names = rootedNames
+            }
+
+            if names == nil,
+               let inventoryIdentity = matchingLoadedRuntimeImageIdentity(
+                   for: imagePath,
+                   loadedImageNames: loadedRuntimeImageNames()
+               ),
+               let inventoryNames = copyRuntimeClassNames(for: inventoryIdentity)
+            {
+                runtimeImageIdentity = inventoryIdentity
+                names = inventoryNames
+            }
+
+            guard let runtimeImageIdentity, let names else {
                 if verbose {
                     fputs(
-                        "privateheaderkit __raw-dump: runtime fallback objc_copyClassNamesForImage returned nil for \(resolvedPath)\n",
+                        "privateheaderkit __raw-dump: runtime fallback could not query loaded image identity for \(imagePath)\n",
                         stderr
                     )
                 }
@@ -1345,12 +1480,10 @@ private func runtimeClassInfos(
                     verbose: verbose
                 )
             }
-            defer { free(namesPtr) }
-
-            if count == 0 {
+            if names.isEmpty {
                 if verbose {
                     fputs(
-                        "privateheaderkit __raw-dump: runtime fallback objc_copyClassNamesForImage returned 0 classes for \(resolvedPath)\n",
+                        "privateheaderkit __raw-dump: runtime fallback objc_copyClassNamesForImage returned 0 classes for \(runtimeImageIdentity.path)\n",
                         stderr
                     )
                 }
@@ -1362,12 +1495,10 @@ private func runtimeClassInfos(
                 )
             }
 
-            let names = UnsafeBufferPointer(start: namesPtr, count: Int(count))
             var infos: [ObjCClassInfo] = []
-            infos.reserveCapacity(Int(count))
+            infos.reserveCapacity(names.count)
 
-            for namePtr in names {
-                let name = String(cString: namePtr)
+            for name in names {
                 if let onlyOneClass, onlyOneClass != name { continue }
                 if let cls = NSClassFromString(name) ?? (objc_getClass(name) as? AnyClass) {
                     if let info = runtimeClassInfo(
@@ -1392,7 +1523,7 @@ private func runtimeClassInfos(
         }
     ) else {
         if verbose {
-            fputs("privateheaderkit __raw-dump: runtime dlopen failed for \(resolvedPath)\n", stderr)
+            fputs("privateheaderkit __raw-dump: runtime dlopen failed for \(loadPath)\n", stderr)
         }
         return []
     }

--- a/Tests/PrivateHeaderKitRawDumpTests/PrivateHeaderKitRawDumpTests.swift
+++ b/Tests/PrivateHeaderKitRawDumpTests/PrivateHeaderKitRawDumpTests.swift
@@ -356,6 +356,162 @@ struct PrivateHeaderKitRawDumpPathTests {
         #expect(targets.contains("/System/Library/Frameworks/Foo.framework/Versions/Current/Foo"))
         #expect(targets.contains("/System/Library/Frameworks/Foo.framework/Versions/A/Foo"))
     }
+
+    @Test func loadedRuntimeImageIdentityMatchesCacheOnlyRootedIdentity() {
+        let logicalPath = "/System/Library/Frameworks/Foo.framework/Foo"
+        let runtimePath = "/Runtime/System/Library/Frameworks/Foo.framework/Foo"
+
+        let matched = matchingLoadedRuntimeImageIdentity(
+            for: logicalPath,
+            loadedImageNames: [
+                "/Runtime/System/Library/Frameworks/Other.framework/Other",
+                runtimePath,
+            ],
+            environment: ["PH_RUNTIME_ROOT": "/Runtime"]
+        )
+
+        #expect(matched?.path == runtimePath)
+    }
+
+    @Test func loadedRuntimeImageIdentityMatchesVersionedFrameworkIdentity() {
+        let runtimePath = "/Runtime/System/Library/Frameworks/Foo.framework/Versions/A/Foo"
+
+        let matched = matchingLoadedRuntimeImageIdentity(
+            for: "/System/Library/Frameworks/Foo.framework/Foo",
+            loadedImageNames: [runtimePath],
+            environment: ["PH_RUNTIME_ROOT": "/Runtime"]
+        )
+
+        #expect(matched?.path == runtimePath)
+    }
+
+    @Test func loadedRuntimeImageIdentityDoesNotPromoteNestedChildToParent() {
+        let childPath = "/System/Library/Frameworks/Foo.framework/XPCServices/Child.xpc/Child"
+        let loadedChildPath = "/Runtime" + childPath
+
+        #expect(
+            matchingLoadedRuntimeImageIdentity(
+                for: childPath,
+                loadedImageNames: [
+                    "/Runtime/System/Library/Frameworks/Foo.framework/Foo",
+                    loadedChildPath,
+                ],
+                environment: ["PH_RUNTIME_ROOT": "/Runtime"]
+            )?.path == loadedChildPath
+        )
+        #expect(
+            matchingLoadedRuntimeImageIdentity(
+                for: childPath,
+                loadedImageNames: [
+                    "/Runtime/System/Library/Frameworks/Foo.framework/Foo"
+                ],
+                environment: ["PH_RUNTIME_ROOT": "/Runtime"]
+            ) == nil
+        )
+    }
+
+    @Test func loadedRuntimeImageIdentityRejectsAmbiguousRuntimeIdentities() {
+        let logicalPath = "/System/Library/Frameworks/Foo.framework/Foo"
+
+        let matched = matchingLoadedRuntimeImageIdentity(
+            for: logicalPath,
+            loadedImageNames: [
+                "/Runtime/System/Library/Frameworks/Foo.framework/Foo",
+                logicalPath,
+            ],
+            environment: ["PH_RUNTIME_ROOT": "/Runtime"]
+        )
+
+        #expect(matched == nil)
+    }
+
+    @Test func loadedRuntimeImageIdentityRequiresTheActiveRuntimeRootBoundary() {
+        let logicalPath = "/System/Library/Frameworks/Foo.framework/Foo"
+
+        #expect(
+            matchingLoadedRuntimeImageIdentity(
+                for: logicalPath,
+                loadedImageNames: [
+                    "/Runtime2/System/Library/Frameworks/Foo.framework/Foo",
+                    "/tmp/payload/System/Library/Frameworks/Foo.framework/Foo",
+                ],
+                environment: ["PH_RUNTIME_ROOT": "/Runtime"]
+            ) == nil
+        )
+    }
+
+    @Test func loadedRuntimeImageIdentityDeduplicatesIdenticalInventoryNames() {
+        let runtimePath = "/Runtime/System/Library/Frameworks/Foo.framework/Foo"
+
+        let matched = matchingLoadedRuntimeImageIdentity(
+            for: "/System/Library/Frameworks/Foo.framework/Foo",
+            loadedImageNames: [runtimePath, runtimePath],
+            environment: ["PH_RUNTIME_ROOT": "/Runtime"]
+        )
+
+        #expect(matched?.path == runtimePath)
+    }
+
+    @Test func loadedRuntimeImageIdentityAcceptsLexicalAndResolvedRuntimeRoots() throws {
+        let dirs = try makeTemporaryTestDirectories()
+        defer { try? FileManager.default.removeItem(at: dirs.root) }
+        let canonicalRoot = dirs.root.appendingPathComponent("CanonicalRuntime", isDirectory: true)
+        let aliasRoot = dirs.root.appendingPathComponent("RuntimeAlias", isDirectory: true)
+        try FileManager.default.createDirectory(at: canonicalRoot, withIntermediateDirectories: true)
+        try FileManager.default.createSymbolicLink(
+            at: aliasRoot,
+            withDestinationURL: canonicalRoot
+        )
+        let logicalPath = "/System/Library/Frameworks/Foo.framework/Foo"
+
+        let lexicalMatch = matchingLoadedRuntimeImageIdentity(
+            for: logicalPath,
+            loadedImageNames: [aliasRoot.path + logicalPath],
+            environment: ["PH_RUNTIME_ROOT": aliasRoot.path]
+        )
+        let resolvedMatch = matchingLoadedRuntimeImageIdentity(
+            for: logicalPath,
+            loadedImageNames: [canonicalRoot.path + logicalPath],
+            environment: ["PH_RUNTIME_ROOT": aliasRoot.path]
+        )
+
+        #expect(lexicalMatch?.path == aliasRoot.path + logicalPath)
+        #expect(resolvedMatch?.path == canonicalRoot.path + logicalPath)
+    }
+
+    @Test func runtimeRootedImageIdentityRejectsLogicalAndForeignLoadPaths() {
+        let logicalPath = "/System/Library/Frameworks/Foo.framework/Foo"
+        let onDiskPath = "/Runtime" + logicalPath
+        let onDiskFiles = FakeFileManager(existing: [onDiskPath])
+        let onDiskIdentity = runtimeRootedImageIdentity(
+            loadPath: onDiskPath,
+            environment: ["PH_RUNTIME_ROOT": "/Runtime"],
+            fileManager: onDiskFiles
+        )
+
+        #expect(onDiskIdentity?.path == onDiskPath)
+        #expect(
+            runtimeRootedImageIdentity(
+                loadPath: logicalPath,
+                environment: ["PH_RUNTIME_ROOT": "/Runtime"],
+                fileManager: onDiskFiles
+            ) == nil
+        )
+        #expect(
+            runtimeRootedImageIdentity(
+                loadPath: logicalPath,
+                environment: ["PH_RUNTIME_ROOT": "/"],
+                fileManager: FakeFileManager(existing: [logicalPath])
+            )?.path == logicalPath
+        )
+        #expect(
+            runtimeRootedImageIdentity(
+                loadPath: "/Runtime2" + logicalPath,
+                environment: ["PH_RUNTIME_ROOT": "/Runtime"],
+                fileManager: FakeFileManager(existing: ["/Runtime2" + logicalPath])
+            ) == nil
+        )
+    }
     #endif
 
 }


### PR DESCRIPTION
## Summary

- separate the path used by `dlopen` from the image identity used by the Objective-C runtime
- resolve cache-only Simulator identities from `objc_copyImageNames` and require a unique exact normalized match
- retain direct lookup for verified file-backed runtime paths without allowing logical or foreign paths to become identities
- preserve the existing global class-list fallback when direct image-specific lookup is unavailable or ambiguous
- add coverage for cache-only, versioned, nested, ambiguous, foreign-root, duplicate, and symlinked-runtime identities

## Root cause

watchOS 27 Simulator images are cache-only. The logical `/System/Library/...` path succeeds with `dlopen`, but the Objective-C runtime registers the image under a runtime-root-prefixed identity.

PrivateHeaderKit reused the load path as the argument to `objc_copyClassNamesForImage`. The image-specific query returned `nil`, forcing every target through a global scan of approximately 40,560 classes.

This change models the Objective-C runtime identity separately and passes the exact runtime-owned identity to the class query.

## Impact

On the same watchOS 27 runtime and WatchKit target:

- previous helper: 4.44s total, 4.036s in `dumpObjC`
- fixed helper: 1.38–1.50s total, about 1.01s in `dumpObjC`
- global class-list fallback is no longer entered
- all 255 generated headers are byte-for-byte identical

watchOS 26.5 remains unchanged:

- previous helper: 0.49s total, 0.128s in `dumpObjC`
- fixed helper: 0.45s total, 0.123s in `dumpObjC`
- all 255 generated headers are byte-for-byte identical

## Validation

- `swift test --filter PrivateHeaderKitRawDumpPathTests`
- `swift test`: 547 tests in 42 suites passed
- release cross-build of `privateheaderkit-sim-helper` for `arm64-apple-watchos-simulator`
- physical local validation against watchOS 26.5 `23T570` and watchOS 27.0 beta `24R5325f`
- `git diff --check`
- `codex-review`: 0 findings

`xcodebuild test -scheme PrivateHeaderKit-Package -destination 'platform=macOS,arch=arm64' -skipMacroValidation` remains blocked by the existing `PrivateHeaderKitToolingTestHelper/main.swift` `@main` / top-level-code configuration. The package's SwiftPM test path passes completely.

Fixes #72
