### PR TITLE
Fix renamed framework staging and target isolation

### DIFF
--- a/Sources/PrivateHeaderKitCore/PrivateHeaderGenerationExecutor.swift
+++ b/Sources/PrivateHeaderKitCore/PrivateHeaderGenerationExecutor.swift
@@ -1044,24 +1044,34 @@ extension PrivateHeaderGeneration.GenerationExecutor {
       )
     }
     let artifactRoot = try Self.artifactRoot(for: target, layout: plan.options.layout)
-    let staged = try Self.collectStagedArtifacts(
-      for: target,
-      in: stagingDirectory,
-      runtimeRoot: plan.options.systemRoot?.path ?? "",
-      artifactRoot: artifactRoot
-    )
-    try publisher.validateRawStaging(
-      root: stagingDirectory,
-      expectedSourceFiles: Set(staged.files.values)
-    )
-    guard !staged.files.isEmpty else {
+    let staged: StagedArtifacts
+    do {
+      staged = try Self.collectStagedArtifacts(
+        for: target,
+        in: stagingDirectory,
+        runtimeRoot: plan.options.systemRoot?.path ?? "",
+        artifactRoot: artifactRoot
+      )
+      guard !staged.files.isEmpty else {
+        return Self.failedExecution(
+          target: target,
+          status: .failed,
+          summary: rawResult.succeeded
+            ? "raw dump produced no header artifacts"
+            : rawResult.failureSummary
+              ?? "raw dump exited with status \(rawResult.terminationStatus)",
+          at: dateProvider()
+        )
+      }
+      try publisher.validateRawStaging(
+        root: stagingDirectory,
+        expectedSourceFiles: Set(staged.files.values)
+      )
+    } catch {
       return Self.failedExecution(
         target: target,
         status: .failed,
-        summary: rawResult.succeeded
-          ? "raw dump produced no header artifacts"
-          : rawResult.failureSummary
-            ?? "raw dump exited with status \(rawResult.terminationStatus)",
+        summary: String(describing: error),
         at: dateProvider()
       )
     }

--- a/Sources/PrivateHeaderKitCore/PrivateHeaderGenerationTargetDiscovery.swift
+++ b/Sources/PrivateHeaderKitCore/PrivateHeaderGenerationTargetDiscovery.swift
@@ -557,13 +557,11 @@ private extension PrivateHeaderGeneration.TargetDiscovery {
         sharedCacheImages: SharedCacheImageIndex,
         fileManager: FileManager
     ) throws -> DiscoveredTarget? {
-        guard
-            let executableURL = selectedBundleExecutableURL(
-                bundleURL: bundleURL,
-                fileManager: fileManager
-            ),
-            safeExecutableName(executableURL.lastPathComponent) != nil
-        else {
+        let executableURL = selectedBundleExecutableURL(
+            bundleURL: bundleURL,
+            fileManager: fileManager
+        )
+        guard safeExecutableName(executableURL.lastPathComponent) != nil else {
             return nil
         }
         let hasDiskExecutable = try isRegularFileOrSymlinkToRegularFile(
@@ -602,11 +600,11 @@ private extension PrivateHeaderGeneration.TargetDiscovery {
     static func selectedBundleExecutableURL(
         bundleURL: URL,
         fileManager: FileManager
-    ) -> URL? {
-        ExecutableResolution.resolveBundleExecutableURL(
+    ) -> URL {
+        ExecutableResolution.resolveBundle(
             bundleURL,
             fileExists: fileManager.fileExists(atPath:)
-        )
+        ).loadURL
     }
 
     static func isRegularFileOrSymlinkToRegularFile(

--- a/Sources/PrivateHeaderKitExecutableResolution/PrivateHeaderKitExecutableResolution.swift
+++ b/Sources/PrivateHeaderKitExecutableResolution/PrivateHeaderKitExecutableResolution.swift
@@ -1,39 +1,19 @@
 import Foundation
 
-package enum ExecutableResolution {
-    package static func resolveBundleExecutableURL(
+package struct ExecutableResolution {
+    package enum OutputIdentity {
+        case image(URL)
+        case bundle(URL)
+    }
+
+    package let loadURL: URL
+    package let outputIdentity: OutputIdentity
+
+    package static func resolveBundle(
         _ bundleURL: URL,
         fileExists: (String) -> Bool = { FileManager.default.fileExists(atPath: $0) },
-        bundleURLs: (URL) -> (bundleURL: URL, executableURL: URL)? = {
-            guard let bundle = Bundle(url: $0), let executableURL = bundle.executableURL else {
-                return nil
-            }
-            return (bundle.bundleURL, executableURL)
-        }
-    ) -> URL? {
-        if let resolved = bundleURLs(bundleURL) {
-            // `Bundle(url:)` may resolve the caller's URL to a renamed symlink target or a
-            // Cryptex path. Derive the suffix from the URLs owned by that same Bundle lookup so
-            // output identity remains rooted at the caller-supplied bundle URL.
-            let suffixComponents = Self.relativePathComponents(
-                of: resolved.executableURL,
-                inside: resolved.bundleURL
-            ) ?? Self.relativePathComponents(
-                of: resolved.executableURL.resolvingSymlinksInPath(),
-                inside: resolved.bundleURL.resolvingSymlinksInPath()
-            )
-            if let suffixComponents {
-                var rebased = bundleURL
-                for component in suffixComponents {
-                    rebased.appendPathComponent(component)
-                }
-                if fileExists(rebased.path) {
-                    return rebased
-                }
-            }
-            return resolved.executableURL
-        }
-
+        bundleExecutableURL: (URL) -> URL? = { Bundle(url: $0)?.executableURL }
+    ) -> Self {
         let baseName = bundleURL.deletingPathExtension().lastPathComponent
         let candidates = [
             bundleURL.appendingPathComponent(baseName),
@@ -42,26 +22,17 @@ package enum ExecutableResolution {
             bundleURL.appendingPathComponent("Versions/B/\(baseName)"),
             bundleURL.appendingPathComponent("Versions/C/\(baseName)"),
         ]
-        for candidate in candidates where fileExists(candidate.path) {
-            return candidate
-        }
-
-        // Some system bundles (especially on modern macOS) only expose a dyld shared-cache image
-        // path while the on-disk executable symlink is intentionally absent/broken. Return the
-        // canonical in-bundle executable path so shared-cache lookup can still resolve the image.
-        return bundleURL.appendingPathComponent(baseName)
+        let loadURL = bundleExecutableURL(bundleURL)
+            ?? candidates.first { fileExists($0.path) }
+            // Some system bundles expose only a dyld shared-cache image while their canonical
+            // on-disk executable is absent or broken. Loading may use a nonexistent URL, but
+            // output identity remains the caller's bundle and must never depend on file existence.
+            ?? bundleURL.appendingPathComponent(baseName)
+        return Self(loadURL: loadURL, outputIdentity: .bundle(bundleURL))
     }
 
-    private static func relativePathComponents(of url: URL, inside directoryURL: URL) -> [String]? {
-        let directoryComponents = directoryURL.standardizedFileURL.pathComponents
-        let pathComponents = url.standardizedFileURL.pathComponents
-        guard
-            pathComponents.count > directoryComponents.count,
-            pathComponents.starts(with: directoryComponents)
-        else {
-            return nil
-        }
-        return Array(pathComponents.dropFirst(directoryComponents.count))
+    package static func direct(_ url: URL) -> Self {
+        Self(loadURL: url, outputIdentity: .image(url))
     }
 
     package static func normalizedCacheImagePaths(

--- a/Sources/PrivateHeaderKitExecutableResolution/PrivateHeaderKitExecutableResolution.swift
+++ b/Sources/PrivateHeaderKitExecutableResolution/PrivateHeaderKitExecutableResolution.swift
@@ -4,18 +4,25 @@ package enum ExecutableResolution {
     package static func resolveBundleExecutableURL(
         _ bundleURL: URL,
         fileExists: (String) -> Bool = { FileManager.default.fileExists(atPath: $0) },
-        bundleExecutableURL: (URL) -> URL? = { Bundle(url: $0)?.executableURL }
+        bundleURLs: (URL) -> (bundleURL: URL, executableURL: URL)? = {
+            guard let bundle = Bundle(url: $0), let executableURL = bundle.executableURL else {
+                return nil
+            }
+            return (bundle.bundleURL, executableURL)
+        }
     ) -> URL? {
-        if let executableURL = bundleExecutableURL(bundleURL) {
-            // `Bundle(url:)` may resolve symlinks, returning an executable inside the real path
-            // (e.g. `/System/Cryptexes/OS/...`). Prefer rebasing back onto the original bundle URL
-            // so output paths remain stable under `/System/Library/...` when possible.
-            let bundleName = bundleURL.lastPathComponent
-            let components = executableURL.pathComponents
-            if let bundleIndex = components.lastIndex(of: bundleName),
-               bundleIndex + 1 < components.count
-            {
-                let suffixComponents = components[(bundleIndex + 1)...]
+        if let resolved = bundleURLs(bundleURL) {
+            // `Bundle(url:)` may resolve the caller's URL to a renamed symlink target or a
+            // Cryptex path. Derive the suffix from the URLs owned by that same Bundle lookup so
+            // output identity remains rooted at the caller-supplied bundle URL.
+            let suffixComponents = Self.relativePathComponents(
+                of: resolved.executableURL,
+                inside: resolved.bundleURL
+            ) ?? Self.relativePathComponents(
+                of: resolved.executableURL.resolvingSymlinksInPath(),
+                inside: resolved.bundleURL.resolvingSymlinksInPath()
+            )
+            if let suffixComponents {
                 var rebased = bundleURL
                 for component in suffixComponents {
                     rebased.appendPathComponent(component)
@@ -24,7 +31,7 @@ package enum ExecutableResolution {
                     return rebased
                 }
             }
-            return executableURL
+            return resolved.executableURL
         }
 
         let baseName = bundleURL.deletingPathExtension().lastPathComponent
@@ -43,6 +50,18 @@ package enum ExecutableResolution {
         // path while the on-disk executable symlink is intentionally absent/broken. Return the
         // canonical in-bundle executable path so shared-cache lookup can still resolve the image.
         return bundleURL.appendingPathComponent(baseName)
+    }
+
+    private static func relativePathComponents(of url: URL, inside directoryURL: URL) -> [String]? {
+        let directoryComponents = directoryURL.standardizedFileURL.pathComponents
+        let pathComponents = url.standardizedFileURL.pathComponents
+        guard
+            pathComponents.count > directoryComponents.count,
+            pathComponents.starts(with: directoryComponents)
+        else {
+            return nil
+        }
+        return Array(pathComponents.dropFirst(directoryComponents.count))
     }
 
     package static func normalizedCacheImagePaths(

--- a/Sources/PrivateHeaderKitRawDumpCore/PrivateHeaderKitRawDumpMain.swift
+++ b/Sources/PrivateHeaderKitRawDumpCore/PrivateHeaderKitRawDumpMain.swift
@@ -342,16 +342,12 @@ private func dumpRecursive(
     while let url = enumerator.nextObject() as? URL {
         if isBundleDirectory(url) {
             enumerator.skipDescendants()
-            if let executableURL = resolveBundleExecutableURL(url, fileManager: fileManager) {
-                let originalPath = stripRuntimeRoot(from: executableURL.path)
-                try await dumpImage(
-                    executableURL,
-                    originalPath: originalPath,
-                    options: options,
-                    fileManager: fileManager,
-                    machOLoader: machOLoader
-                )
-            }
+            try await dumpImage(
+                resolveBundleExecutable(url, fileManager: fileManager),
+                options: options,
+                fileManager: fileManager,
+                machOLoader: machOLoader
+            )
             continue
         }
 
@@ -360,10 +356,8 @@ private func dumpRecursive(
               values.isRegularFile == true
         else { continue }
 
-        let originalPath = stripRuntimeRoot(from: url.path)
         try await dumpImage(
-            url,
-            originalPath: originalPath,
+            .direct(url),
             options: options,
             fileManager: fileManager,
             machOLoader: machOLoader
@@ -379,30 +373,31 @@ private func dumpSingle(
 ) async throws {
     let originalURL = URL(fileURLWithPath: inputPath)
     let resolvedURL = resolveRuntimeURL(originalURL)
-    if isBundleDirectory(resolvedURL), let executableURL = resolveBundleExecutableURL(resolvedURL, fileManager: fileManager) {
-        let originalPath = stripRuntimeRoot(from: executableURL.path)
+    if isBundleDirectory(resolvedURL) {
         try await dumpImage(
-            executableURL,
-            originalPath: originalPath,
+            resolveBundleExecutable(resolvedURL, fileManager: fileManager),
             options: options,
             fileManager: fileManager,
             machOLoader: machOLoader
         )
         return
     }
-    let originalPath = stripRuntimeRoot(from: resolvedURL.path)
     try await dumpImage(
-        resolvedURL,
-        originalPath: originalPath,
+        .direct(resolvedURL),
         options: options,
         fileManager: fileManager,
         machOLoader: machOLoader
     )
 }
 
+private let supportedBundlePathExtensions: Set<String> = [
+    "framework", "app", "bundle", "xpc", "appex",
+]
+
 func isBundleDirectory(_ url: URL) -> Bool {
-    let ext = url.pathExtension.lowercased()
-    guard ext == "framework" || ext == "app" || ext == "bundle" || ext == "xpc" || ext == "appex" else { return false }
+    guard supportedBundlePathExtensions.contains(url.pathExtension.lowercased()) else {
+        return false
+    }
 
     // `URL.hasDirectoryPath` is unreliable for symlink-to-directory bundles (e.g. Cryptex-backed
     // system frameworks inside simulator runtimes). Fall back to a filesystem check so we can
@@ -418,58 +413,57 @@ func isBundleDirectory(_ url: URL) -> Bool {
     return false
 }
 
-func resolveBundleExecutableURL(
+func resolveBundleExecutable(
     _ bundleURL: URL,
     fileManager: FileExistenceChecking = FileManager.default,
-    bundleURLs: (URL) -> (bundleURL: URL, executableURL: URL)? = {
-        guard let bundle = Bundle(url: $0), let executableURL = bundle.executableURL else {
-            return nil
-        }
-        return (bundle.bundleURL, executableURL)
-    }
-) -> URL? {
-    ExecutableResolution.resolveBundleExecutableURL(
+    bundleExecutableURL: (URL) -> URL? = { Bundle(url: $0)?.executableURL }
+) -> ExecutableResolution {
+    ExecutableResolution.resolveBundle(
         bundleURL,
         fileExists: fileManager.fileExists(atPath:),
-        bundleURLs: bundleURLs
+        bundleExecutableURL: bundleExecutableURL
     )
 }
 
 private func dumpImage(
-    _ url: URL,
-    originalPath: String,
+    _ executable: ExecutableResolution,
     options: DumpOptions,
     fileManager: FileManager,
     machOLoader: RawMachOLoader
 ) async throws {
+    let imagePath = stripRuntimeRoot(from: executable.loadURL.path)
+    let placement = outputPlacement(
+        for: executable,
+        outputRoot: options.outputDir,
+        options: options
+    )
     let loadStart = profileNowNanoseconds(enabled: options.profile)
-    guard let machO = try machOLoader.load(url: url) else {
+    guard let machO = try machOLoader.load(url: executable.loadURL) else {
         return
     }
-    profileLogDuration(enabled: options.profile, imagePath: originalPath, name: "loadMachO", since: loadStart)
+    profileLogDuration(enabled: options.profile, imagePath: imagePath, name: "loadMachO", since: loadStart)
 
-    let outputDir = writeDirectory(for: originalPath, outputRoot: options.outputDir, options: options)
     if options.verbose {
-        print("Dumping: \(originalPath)")
+        print("Dumping: \(placement.identity.url.path)")
     }
 
     let objcStart = profileNowNanoseconds(enabled: options.profile)
     try await dumpObjC(
         machO: machO,
-        imagePath: originalPath,
-        outputDir: outputDir,
+        imagePath: imagePath,
+        outputDir: placement.directory,
         options: options,
         fileManager: fileManager
     )
-    profileLogDuration(enabled: options.profile, imagePath: originalPath, name: "dumpObjC", since: objcStart)
+    profileLogDuration(enabled: options.profile, imagePath: imagePath, name: "dumpObjC", since: objcStart)
 
     try await dumpSwift(
         machO: machO,
-        imagePath: originalPath,
-        outputDir: outputDir,
+        imagePath: imagePath,
+        outputDir: placement.directory,
         options: options,
         interfaceBuilderFactory: defaultSwiftInterfaceBuilderFactory(
-            imagePath: originalPath,
+            imagePath: imagePath,
             options: options
         ),
         fileManager: fileManager
@@ -608,15 +602,77 @@ func normalizedCacheImagePaths(
     )
 }
 
-func writeDirectory(for imagePath: String, outputRoot: URL, options: DumpOptions) -> URL {
+struct DumpOutputPlacement {
+    let identity: ExecutableResolution.OutputIdentity
+    let directory: URL
+}
+
+func outputPlacement(
+    for executable: ExecutableResolution,
+    outputRoot: URL,
+    options: DumpOptions,
+    environment: [String: String] = ProcessInfo.processInfo.environment
+) -> DumpOutputPlacement {
+    let identity = logicalOutputIdentity(
+        executable.outputIdentity,
+        environment: environment
+    )
+    return DumpOutputPlacement(
+        identity: identity,
+        directory: writeDirectory(for: identity, outputRoot: outputRoot, options: options)
+    )
+}
+
+private func logicalOutputIdentity(
+    _ outputIdentity: ExecutableResolution.OutputIdentity,
+    environment: [String: String]
+) -> ExecutableResolution.OutputIdentity {
+    switch outputIdentity {
+    case .image(let url):
+        .image(
+            URL(
+                fileURLWithPath: stripRuntimeRoot(from: url.path, environment: environment)
+            )
+        )
+    case .bundle(let url):
+        .bundle(
+            URL(
+                fileURLWithPath: stripRuntimeRoot(from: url.path, environment: environment),
+                isDirectory: true
+            )
+        )
+    }
+}
+
+private extension ExecutableResolution.OutputIdentity {
+    var url: URL {
+        switch self {
+        case .image(let url), .bundle(let url): url
+        }
+    }
+}
+
+func writeDirectory(
+    for outputIdentity: ExecutableResolution.OutputIdentity,
+    outputRoot: URL,
+    options: DumpOptions
+) -> URL {
     guard options.buildOriginalDirs else { return outputRoot }
 
-    let imageURL = URL(fileURLWithPath: imagePath)
-    let parentURL = imageURL.deletingLastPathComponent()
-    let isBundle = parentURL.lastPathComponent.contains(".")
-    let targetPath = isBundle ? parentURL.path : imageURL.path
-    var fullPath = outputRoot.path + targetPath
-    if isBundle && options.addHeadersFolder {
+    let target: (url: URL, isBundle: Bool)
+    switch outputIdentity {
+    case .bundle(let bundleURL):
+        target = (bundleURL, true)
+    case .image(let imageURL):
+        let parentURL = imageURL.deletingLastPathComponent()
+        if supportedBundlePathExtensions.contains(parentURL.pathExtension.lowercased()) {
+            target = (parentURL, true)
+        } else {
+            target = (imageURL, false)
+        }
+    }
+    var fullPath = outputRoot.path + target.url.path
+    if target.isBundle && options.addHeadersFolder {
         fullPath += "/Headers"
     }
     fullPath = normalizePath(fullPath)

--- a/Sources/PrivateHeaderKitRawDumpCore/PrivateHeaderKitRawDumpMain.swift
+++ b/Sources/PrivateHeaderKitRawDumpCore/PrivateHeaderKitRawDumpMain.swift
@@ -421,12 +421,17 @@ func isBundleDirectory(_ url: URL) -> Bool {
 func resolveBundleExecutableURL(
     _ bundleURL: URL,
     fileManager: FileExistenceChecking = FileManager.default,
-    bundleExecutableURL: (URL) -> URL? = { Bundle(url: $0)?.executableURL }
+    bundleURLs: (URL) -> (bundleURL: URL, executableURL: URL)? = {
+        guard let bundle = Bundle(url: $0), let executableURL = bundle.executableURL else {
+            return nil
+        }
+        return (bundle.bundleURL, executableURL)
+    }
 ) -> URL? {
     ExecutableResolution.resolveBundleExecutableURL(
         bundleURL,
         fileExists: fileManager.fileExists(atPath:),
-        bundleExecutableURL: bundleExecutableURL
+        bundleURLs: bundleURLs
     )
 }
 

--- a/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationExecutorTests.swift
+++ b/Tests/PrivateHeaderKitCoreTests/PrivateHeaderGenerationExecutorTests.swift
@@ -439,7 +439,7 @@ struct PrivateHeaderGenerationExecutorTests {
     #expect(persistedCount == 0)
   }
 
-  @Test func infrastructureFailureKeepsObjectiveCWarningPresentationBoundedAndAggregated()
+  @Test func targetFailureKeepsObjectiveCWarningPresentationBoundedAndAggregated()
     async throws
   {
     let fixture = try ExecutorFixture()
@@ -479,7 +479,7 @@ struct PrivateHeaderGenerationExecutorTests {
       )
       Issue.record("hidden raw payload unexpectedly completed")
       return
-    } catch let PrivateHeaderGeneration.GenerationError.infrastructureFailed(failure) {
+    } catch let PrivateHeaderGeneration.GenerationError.runFailed(failure) {
       summary = failure.summary
     }
 
@@ -539,35 +539,53 @@ struct PrivateHeaderGenerationExecutorTests {
     #expect(observation.errorDescription == nil)
   }
 
-  @Test func laterInfrastructureFailureKeepsCompletedTargetVisibleAndResumeSkipsIt()
+  @Test func stagingMismatchKeepsCompletedTargetsVisibleAndResumeRetriesOnlyFailure()
     async throws
   {
     let fixture = try ExecutorFixture()
     defer { fixture.cleanup() }
     try fixture.createFramework("Foo.framework")
     try fixture.createFramework("Bar.framework")
+    try fixture.createFramework("Baz.framework")
     let plan = try fixture.plan(
-      .identifiers(["framework:Foo.framework", "framework:Bar.framework"]),
+      .identifiers([
+        "framework:Foo.framework",
+        "framework:Bar.framework",
+        "framework:Baz.framework",
+      ]),
       resumeBehavior: .resume
+    )
+    let firstRunner = RecordingRunner(
+      contents: "first-run",
+      unexpectedHeaderFramework: "Bar.framework"
     )
 
     do {
       _ = try await fixture.executor(
-        runner: RecordingRunner(
-          contents: "first-run",
-          hiddenPayloadFramework: "Bar.framework"
-        ),
-        runID: "run-partial",
-        generationID: "generation-partial"
+        runner: firstRunner,
+        runID: "run-staging-mismatch",
+        generationID: "generation-staging-mismatch"
       ).run(plan: plan)
       Issue.record("invalid second target unexpectedly completed")
-    } catch let PrivateHeaderGeneration.GenerationError.infrastructureFailed(failure) {
-      #expect(failure.summary.targetCounts.completed == 1)
+    } catch let PrivateHeaderGeneration.GenerationError.runFailed(failure) {
+      #expect(failure.summary.targetCounts.completed == 2)
       #expect(failure.summary.targetCounts.failed == 1)
+      #expect(failure.summary.targetCounts.pending == 0)
+      #expect(failure.summary.targetCounts.running == 0)
+      #expect(failure.failedTargetIDs == ["framework:Bar.framework"])
       #expect(failure.summary.targetFailures.map(\.displayName) == ["Bar"])
+      #expect(
+        failure.summary.targetFailures.first?.message?.contains(
+          "generation inventory mismatch"
+        ) == true
+      )
     }
 
+    #expect(await firstRunner.invocationCount == 3)
     #expect(try fixture.readLiveHeader(framework: "Foo") == "first-run")
+    #expect(try fixture.readLiveHeader(framework: "Baz") == "first-run")
+    #expect(try fixture.readStableHeader(framework: "Foo") == "first-run")
+    #expect(try fixture.readStableHeader(framework: "Baz") == "first-run")
     #expect(!FileManager.default.fileExists(atPath: fixture.liveHeaderURL(framework: "Bar").path))
     let firstStore = try GenerationStore(
       databaseURL: fixture.databaseURL,
@@ -575,7 +593,7 @@ struct PrivateHeaderGenerationExecutorTests {
     )
     #expect(
       try await firstStore.targetSnapshot(targetID: "framework:Foo.framework")?
-        .lastSuccessfulRunID == .init(rawValue: "run-partial")
+        .lastSuccessfulRunID == .init(rawValue: "run-staging-mismatch")
     )
 
     let resumedRunner = RecordingRunner(contents: "resumed")
@@ -587,11 +605,13 @@ struct PrivateHeaderGenerationExecutorTests {
 
     #expect(await resumedRunner.invocationCount == 1)
     #expect(await resumedRunner.invocations.first?.inputPath.hasSuffix("/Bar.framework") == true)
-    #expect(result.targetCounts.skipped == 1)
+    #expect(result.targetCounts.skipped == 2)
     #expect(result.targetCounts.completed == 1)
     #expect(try fixture.readLiveHeader(framework: "Foo") == "first-run")
+    #expect(try fixture.readLiveHeader(framework: "Baz") == "first-run")
     #expect(try fixture.readLiveHeader(framework: "Bar") == "resumed")
     #expect(try fixture.readStableHeader(framework: "Foo") == "first-run")
+    #expect(try fixture.readStableHeader(framework: "Baz") == "first-run")
     #expect(try fixture.readStableHeader(framework: "Bar") == "resumed")
   }
 
@@ -2445,7 +2465,7 @@ struct PrivateHeaderGenerationExecutorTests {
     #expect(!FileManager.default.fileExists(atPath: crashed.path))
   }
 
-  @Test func hiddenRawPayloadFailsFastWithoutPublishing() async throws {
+  @Test func hiddenRawPayloadFailsTargetWithoutPublishing() async throws {
     let fixture = try ExecutorFixture()
     defer { fixture.cleanup() }
     try fixture.createFramework("Foo.framework")
@@ -2458,10 +2478,13 @@ struct PrivateHeaderGenerationExecutorTests {
         generationID: "generation-hidden"
       ).run(plan: try fixture.plan(.query("Foo")))
       Issue.record("hidden raw payload unexpectedly succeeded")
-    } catch let PrivateHeaderGeneration.GenerationError.infrastructureFailed(failure) {
+    } catch let PrivateHeaderGeneration.GenerationError.runFailed(failure) {
       #expect(failure.summary.status == .failed)
       #expect(failure.summary.targetCounts.failed == 1)
-      #expect(failure.message.contains("hidden staging payload"))
+      #expect(failure.failedTargetIDs == ["framework:Foo.framework"])
+      #expect(
+        failure.summary.targetFailures.first?.message?.contains("hidden staging payload") == true
+      )
     }
 
     #expect(try fixture.publisher().inspect().currentGenerationID == nil)
@@ -2744,6 +2767,7 @@ private actor RecordingRunner {
   let thrownError: (any Error & Sendable)?
   let writesHiddenPayload: Bool
   let hiddenPayloadFramework: String?
+  let unexpectedHeaderFramework: String?
   let primaryHeaderName: String
   let additionalHeaderName: String?
   let cancelsForFramework: String?
@@ -2755,6 +2779,7 @@ private actor RecordingRunner {
     thrownError: (any Error & Sendable)? = nil,
     writesHiddenPayload: Bool = false,
     hiddenPayloadFramework: String? = nil,
+    unexpectedHeaderFramework: String? = nil,
     primaryHeaderName: String = "Generated.h",
     additionalHeaderName: String? = nil,
     cancelsForFramework: String? = nil,
@@ -2765,6 +2790,7 @@ private actor RecordingRunner {
     self.thrownError = thrownError
     self.writesHiddenPayload = writesHiddenPayload
     self.hiddenPayloadFramework = hiddenPayloadFramework
+    self.unexpectedHeaderFramework = unexpectedHeaderFramework
     self.primaryHeaderName = primaryHeaderName
     self.additionalHeaderName = additionalHeaderName
     self.cancelsForFramework = cancelsForFramework
@@ -2793,6 +2819,11 @@ private actor RecordingRunner {
       {
         try Data("hidden".utf8).write(
           to: invocation.stagingOutputDirectory.appendingPathComponent(".unexpected")
+        )
+      }
+      if unexpectedHeaderFramework.map({ invocation.inputPath.hasSuffix("/\($0)") }) == true {
+        try Data("unexpected".utf8).write(
+          to: invocation.stagingOutputDirectory.appendingPathComponent("Unexpected.h")
         )
       }
     }

--- a/Tests/PrivateHeaderKitRawDumpTests/PrivateHeaderKitRawDumpTests.swift
+++ b/Tests/PrivateHeaderKitRawDumpTests/PrivateHeaderKitRawDumpTests.swift
@@ -825,7 +825,7 @@ struct PrivateHeaderKitRawDumpBundlePathTests {
         let resolved = resolveBundleExecutableURL(
             bundleURL,
             fileManager: fake,
-            bundleExecutableURL: { _ in nil }
+            bundleURLs: { _ in nil }
         )
         #expect(resolved?.path == candidate.path)
 
@@ -833,23 +833,91 @@ struct PrivateHeaderKitRawDumpBundlePathTests {
         let resolvedExplicit = resolveBundleExecutableURL(
             bundleURL,
             fileManager: fake,
-            bundleExecutableURL: { _ in explicit }
+            bundleURLs: { _ in (bundleURL, explicit) }
         )
         #expect(resolvedExplicit?.path == explicit.path)
     }
 
-    @Test func resolveBundleExecutableURLRebasesBundleExecutableWhenPossible() {
-        let bundleURL = URL(fileURLWithPath: "/System/Library/Frameworks/SafariServices.framework", isDirectory: true)
-        let resolvedExec = URL(fileURLWithPath: "/System/Cryptexes/OS/System/Library/Frameworks/SafariServices.framework/SafariServices")
-        let expectedRebased = bundleURL.appendingPathComponent("SafariServices")
-        let fake = FakeFileManager(existing: [expectedRebased.path])
+    @Test func resolveBundleExecutableURLPreservesCryptexAliasWithMixedBundleURLs() throws {
+        let dirs = try makeTemporaryTestDirectories()
+        let resolvedBundle = dirs.root.appendingPathComponent(
+            "System/Cryptexes/OS/System/Library/Frameworks/SafariServices.framework",
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(at: resolvedBundle, withIntermediateDirectories: true)
+        let resolvedExec = resolvedBundle.appendingPathComponent("Versions/A/SafariServices")
+        try FileManager.default.createDirectory(
+            at: resolvedExec.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try Data().write(to: resolvedExec)
+        let bundleURL = dirs.root.appendingPathComponent(
+            "System/Library/Frameworks/SafariServices.framework",
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(
+            at: bundleURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try FileManager.default.createSymbolicLink(
+            atPath: bundleURL.path,
+            withDestinationPath: resolvedBundle.path
+        )
+        let expectedRebased = bundleURL.appendingPathComponent("Versions/A/SafariServices")
+
+        let result = resolveBundleExecutableURL(
+            bundleURL,
+            bundleURLs: { _ in (bundleURL, resolvedExec) }
+        )
+        #expect(result?.path == expectedRebased.path)
+    }
+
+    @Test func resolveBundleExecutableURLPreservesRenamedSymlinkIdentity() throws {
+        let dirs = try makeTemporaryTestDirectories()
+        let resolvedBundle = dirs.root.appendingPathComponent(
+            "SpotlightIndex.framework",
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(at: resolvedBundle, withIntermediateDirectories: true)
+        let resolvedExec = resolvedBundle.appendingPathComponent("SpotlightIndex")
+        try Data().write(to: resolvedExec)
+        let bundleURL = dirs.root.appendingPathComponent(
+            "MobileSpotlightIndex.framework",
+            isDirectory: true
+        )
+        try FileManager.default.createSymbolicLink(
+            atPath: bundleURL.path,
+            withDestinationPath: resolvedBundle.lastPathComponent
+        )
+
+        let result = try #require(
+            resolveBundleExecutableURL(
+                bundleURL,
+                bundleURLs: { _ in (resolvedBundle, resolvedExec) }
+            )
+        )
+
+        #expect(result.path == bundleURL.appendingPathComponent("SpotlightIndex").path)
+        #expect(
+            result.resolvingSymlinksInPath().standardizedFileURL
+                == resolvedExec.resolvingSymlinksInPath().standardizedFileURL
+        )
+    }
+
+    @Test func resolveBundleExecutableURLDoesNotRebaseExecutableOutsideBundle() {
+        let bundleURL = URL(fileURLWithPath: "/tmp/Alias.framework", isDirectory: true)
+        let resolvedBundle = URL(fileURLWithPath: "/tmp/Real.framework", isDirectory: true)
+        let resolvedExec = URL(fileURLWithPath: "/tmp/Elsewhere/Real")
+        let aliasCandidate = bundleURL.appendingPathComponent("Real")
+        let fake = FakeFileManager(existing: [aliasCandidate.path])
 
         let result = resolveBundleExecutableURL(
             bundleURL,
             fileManager: fake,
-            bundleExecutableURL: { _ in resolvedExec }
+            bundleURLs: { _ in (resolvedBundle, resolvedExec) }
         )
-        #expect(result?.path == expectedRebased.path)
+
+        #expect(result == resolvedExec)
     }
 
     @Test func resolveBundleExecutableURLFallsBackToCanonicalPathForCacheOnlyBundles() {
@@ -859,7 +927,7 @@ struct PrivateHeaderKitRawDumpBundlePathTests {
         let resolved = resolveBundleExecutableURL(
             bundleURL,
             fileManager: fake,
-            bundleExecutableURL: { _ in nil }
+            bundleURLs: { _ in nil }
         )
 
         #expect(resolved?.path == "/tmp/Foo.framework/Foo")
@@ -875,7 +943,7 @@ struct PrivateHeaderKitRawDumpBundlePathTests {
         let xpcResolved = resolveBundleExecutableURL(
             xpcURL,
             fileManager: FileManager.default,
-            bundleExecutableURL: { _ in nil }
+            bundleURLs: { _ in nil }
         )
         #expect(xpcResolved?.path == xpcURL.appendingPathComponent("Foo").path)
 
@@ -886,7 +954,7 @@ struct PrivateHeaderKitRawDumpBundlePathTests {
         let appexResolved = resolveBundleExecutableURL(
             appexURL,
             fileManager: FileManager.default,
-            bundleExecutableURL: { _ in nil }
+            bundleURLs: { _ in nil }
         )
         #expect(appexResolved?.path == appexURL.appendingPathComponent("Bar").path)
     }

--- a/Tests/PrivateHeaderKitRawDumpTests/PrivateHeaderKitRawDumpTests.swift
+++ b/Tests/PrivateHeaderKitRawDumpTests/PrivateHeaderKitRawDumpTests.swift
@@ -761,14 +761,19 @@ struct PrivateHeaderKitRawDumpSharedCacheTests {
 
 @Suite
 struct PrivateHeaderKitRawDumpBundlePathTests {
-    @Test func writeDirectoryBuildsBundlePaths() {
+    @Test func writeDirectoryBuildsDeclaredBundleAndImagePaths() {
         let outputRoot = URL(fileURLWithPath: "/tmp/out")
         var options = DumpOptions(outputDir: outputRoot)
         options.buildOriginalDirs = true
         options.addHeadersFolder = true
 
         let result = writeDirectory(
-            for: "/System/Library/Frameworks/Foo.framework/Foo",
+            for: .bundle(
+                URL(
+                    fileURLWithPath: "/System/Library/Frameworks/Foo.framework",
+                    isDirectory: true
+                )
+            ),
             outputRoot: outputRoot,
             options: options
         )
@@ -776,11 +781,45 @@ struct PrivateHeaderKitRawDumpBundlePathTests {
 
         options.addHeadersFolder = false
         let resultNoHeaders = writeDirectory(
-            for: "/usr/lib/libobjc.A.dylib",
+            for: .image(URL(fileURLWithPath: "/usr/lib/libobjc.A.dylib")),
             outputRoot: outputRoot,
             options: options
         )
         #expect(resultNoHeaders.path == "/tmp/out/usr/lib/libobjc.A.dylib")
+    }
+
+    @Test func writeDirectoryOnlyInfersAnImmediateBundleParentForDirectImages() {
+        let outputRoot = URL(fileURLWithPath: "/tmp/out")
+        var options = DumpOptions(outputDir: outputRoot)
+        options.buildOriginalDirs = true
+        options.addHeadersFolder = true
+        let cases = [
+            (
+                "/System/Library/Frameworks/Foo.framework/Foo",
+                "/tmp/out/System/Library/Frameworks/Foo.framework/Headers"
+            ),
+            (
+                "/System/Library/Frameworks/CreateML.framework/Versions/A/CreateML",
+                "/tmp/out/System/Library/Frameworks/CreateML.framework/Versions/A/CreateML"
+            ),
+            (
+                "/System/Library/CoreServices/Finder.app/Contents/MacOS/Finder",
+                "/tmp/out/System/Library/CoreServices/Finder.app/Contents/MacOS/Finder"
+            ),
+            (
+                "/tmp/Version.1/Tool",
+                "/tmp/out/tmp/Version.1/Tool"
+            ),
+        ]
+
+        for (imagePath, expectedPath) in cases {
+            let result = writeDirectory(
+                for: .image(URL(fileURLWithPath: imagePath)),
+                outputRoot: outputRoot,
+                options: options
+            )
+            #expect(result.path == expectedPath)
+        }
     }
 
     @Test func writeDirectoryReturnsRootWhenDisabled() {
@@ -788,7 +827,12 @@ struct PrivateHeaderKitRawDumpBundlePathTests {
         var options = DumpOptions(outputDir: outputRoot)
         options.buildOriginalDirs = false
         let result = writeDirectory(
-            for: "/System/Library/Frameworks/Foo.framework/Foo",
+            for: .bundle(
+                URL(
+                    fileURLWithPath: "/System/Library/Frameworks/Foo.framework",
+                    isDirectory: true
+                )
+            ),
             outputRoot: outputRoot,
             options: options
         )
@@ -817,28 +861,38 @@ struct PrivateHeaderKitRawDumpBundlePathTests {
         #expect(isBundleDirectory(linkURL) == true)
     }
 
-    @Test func resolveBundleExecutableURLUsesInjectedFileManager() {
+    @Test func resolveBundleExecutableUsesLoadCandidateAndCallerBundleIdentity() {
         let bundleURL = URL(fileURLWithPath: "/tmp/Foo.framework", isDirectory: true)
         let candidate = bundleURL.appendingPathComponent("Versions/A/Foo")
         let fake = FakeFileManager(existing: [candidate.path])
 
-        let resolved = resolveBundleExecutableURL(
+        let resolved = resolveBundleExecutable(
             bundleURL,
             fileManager: fake,
-            bundleURLs: { _ in nil }
+            bundleExecutableURL: { _ in nil }
         )
-        #expect(resolved?.path == candidate.path)
+        #expect(resolved.loadURL == candidate)
+        guard case .bundle(let outputBundleURL) = resolved.outputIdentity else {
+            Issue.record("expected bundle output identity")
+            return
+        }
+        #expect(outputBundleURL == bundleURL)
 
-        let explicit = URL(fileURLWithPath: "/tmp/BundleExec")
-        let resolvedExplicit = resolveBundleExecutableURL(
+        let explicit = bundleURL.appendingPathComponent("Versions/A/CustomExecutable")
+        let resolvedExplicit = resolveBundleExecutable(
             bundleURL,
             fileManager: fake,
-            bundleURLs: { _ in (bundleURL, explicit) }
+            bundleExecutableURL: { _ in explicit }
         )
-        #expect(resolvedExplicit?.path == explicit.path)
+        #expect(resolvedExplicit.loadURL == explicit)
+        guard case .bundle(let explicitOutputBundleURL) = resolvedExplicit.outputIdentity else {
+            Issue.record("expected explicit bundle output identity")
+            return
+        }
+        #expect(explicitOutputBundleURL == bundleURL)
     }
 
-    @Test func resolveBundleExecutableURLPreservesCryptexAliasWithMixedBundleURLs() throws {
+    @Test func versionedBundleExecutableLoadsRealPathAndStagesAtCallerBundleRoot() throws {
         let dirs = try makeTemporaryTestDirectories()
         let resolvedBundle = dirs.root.appendingPathComponent(
             "System/Cryptexes/OS/System/Library/Frameworks/SafariServices.framework",
@@ -863,100 +917,145 @@ struct PrivateHeaderKitRawDumpBundlePathTests {
             atPath: bundleURL.path,
             withDestinationPath: resolvedBundle.path
         )
-        let expectedRebased = bundleURL.appendingPathComponent("Versions/A/SafariServices")
 
-        let result = resolveBundleExecutableURL(
+        let result = resolveBundleExecutable(
             bundleURL,
-            bundleURLs: { _ in (bundleURL, resolvedExec) }
+            bundleExecutableURL: { _ in resolvedExec }
         )
-        #expect(result?.path == expectedRebased.path)
+        #expect(result.loadURL == resolvedExec)
+        guard case .bundle(let outputBundleURL) = result.outputIdentity else {
+            Issue.record("expected caller bundle output identity")
+            return
+        }
+        #expect(outputBundleURL == bundleURL)
+        var options = DumpOptions(outputDir: dirs.outDir)
+        options.buildOriginalDirs = true
+        options.addHeadersFolder = true
+        let placement = outputPlacement(
+            for: result,
+            outputRoot: dirs.outDir,
+            options: options,
+            environment: ["PH_RUNTIME_ROOT": dirs.root.path]
+        )
+        #expect(
+            placement.directory.path == dirs.outDir.appendingPathComponent(
+                "System/Library/Frameworks/SafariServices.framework/Headers",
+                isDirectory: true
+            ).path
+        )
     }
 
-    @Test func resolveBundleExecutableURLPreservesRenamedSymlinkIdentity() throws {
+    @Test func cacheOnlyRenamedBundleKeepsCallerIdentityWithoutDiskExecutable() throws {
         let dirs = try makeTemporaryTestDirectories()
-        let resolvedBundle = dirs.root.appendingPathComponent(
+        let parent = dirs.root.appendingPathComponent(
+            "System/Library/PrivateFrameworks",
+            isDirectory: true
+        )
+        let resolvedBundle = parent.appendingPathComponent(
             "SpotlightIndex.framework",
             isDirectory: true
         )
-        try FileManager.default.createDirectory(at: resolvedBundle, withIntermediateDirectories: true)
-        let resolvedExec = resolvedBundle.appendingPathComponent("SpotlightIndex")
-        try Data().write(to: resolvedExec)
-        let bundleURL = dirs.root.appendingPathComponent(
+        let bundleURL = parent.appendingPathComponent(
             "MobileSpotlightIndex.framework",
             isDirectory: true
         )
+        try FileManager.default.createDirectory(at: resolvedBundle, withIntermediateDirectories: true)
         try FileManager.default.createSymbolicLink(
             atPath: bundleURL.path,
             withDestinationPath: resolvedBundle.lastPathComponent
         )
+        let resolvedExec = resolvedBundle.appendingPathComponent("SpotlightIndex")
+        let fake = FakeFileManager(existing: [])
 
-        let result = try #require(
-            resolveBundleExecutableURL(
-                bundleURL,
-                bundleURLs: { _ in (resolvedBundle, resolvedExec) }
-            )
-        )
-
-        #expect(result.path == bundleURL.appendingPathComponent("SpotlightIndex").path)
-        #expect(
-            result.resolvingSymlinksInPath().standardizedFileURL
-                == resolvedExec.resolvingSymlinksInPath().standardizedFileURL
-        )
-    }
-
-    @Test func resolveBundleExecutableURLDoesNotRebaseExecutableOutsideBundle() {
-        let bundleURL = URL(fileURLWithPath: "/tmp/Alias.framework", isDirectory: true)
-        let resolvedBundle = URL(fileURLWithPath: "/tmp/Real.framework", isDirectory: true)
-        let resolvedExec = URL(fileURLWithPath: "/tmp/Elsewhere/Real")
-        let aliasCandidate = bundleURL.appendingPathComponent("Real")
-        let fake = FakeFileManager(existing: [aliasCandidate.path])
-
-        let result = resolveBundleExecutableURL(
+        let result = resolveBundleExecutable(
             bundleURL,
             fileManager: fake,
-            bundleURLs: { _ in (resolvedBundle, resolvedExec) }
+            bundleExecutableURL: { _ in resolvedExec }
         )
-
-        #expect(result == resolvedExec)
+        #expect(result.loadURL == resolvedExec)
+        #expect(fake.fileExists(atPath: resolvedExec.path) == false)
+        #expect(
+            normalizedCacheImagePaths(
+                for: result.loadURL.path,
+                environment: ["PH_RUNTIME_ROOT": dirs.root.path]
+            ).contains(
+                "/System/Library/PrivateFrameworks/SpotlightIndex.framework/SpotlightIndex"
+            )
+        )
+        guard case .bundle(let outputBundleURL) = result.outputIdentity else {
+            Issue.record("expected renamed caller bundle output identity")
+            return
+        }
+        #expect(outputBundleURL == bundleURL)
+        var options = DumpOptions(outputDir: dirs.outDir)
+        options.buildOriginalDirs = true
+        options.addHeadersFolder = true
+        let placement = outputPlacement(
+            for: result,
+            outputRoot: dirs.outDir,
+            options: options,
+            environment: ["PH_RUNTIME_ROOT": dirs.root.path]
+        )
+        #expect(
+            placement.directory.path == dirs.outDir.appendingPathComponent(
+                "System/Library/PrivateFrameworks/MobileSpotlightIndex.framework/Headers",
+                isDirectory: true
+            ).path
+        )
     }
 
-    @Test func resolveBundleExecutableURLFallsBackToCanonicalPathForCacheOnlyBundles() {
+    @Test func resolveBundleExecutableFallsBackToCanonicalLoadPathForCacheOnlyBundles() {
         let bundleURL = URL(fileURLWithPath: "/tmp/Foo.framework", isDirectory: true)
         let fake = FakeFileManager(existing: [])
 
-        let resolved = resolveBundleExecutableURL(
+        let resolved = resolveBundleExecutable(
             bundleURL,
             fileManager: fake,
-            bundleURLs: { _ in nil }
+            bundleExecutableURL: { _ in nil }
         )
 
-        #expect(resolved?.path == "/tmp/Foo.framework/Foo")
+        #expect(resolved.loadURL.path == "/tmp/Foo.framework/Foo")
+        guard case .bundle(let outputBundleURL) = resolved.outputIdentity else {
+            Issue.record("expected fallback bundle output identity")
+            return
+        }
+        #expect(outputBundleURL == bundleURL)
     }
 
-    @Test func resolveBundleExecutableURLResolvesXPCAndAppExtensionCandidates() throws {
+    @Test func resolveBundleExecutableResolvesXPCAndAppExtensionCandidates() throws {
         let dirs = try makeTemporaryTestDirectories()
 
         let xpcURL = dirs.root.appendingPathComponent("Foo.xpc", isDirectory: true)
         try FileManager.default.createDirectory(at: xpcURL, withIntermediateDirectories: true)
         _ = FileManager.default.createFile(atPath: xpcURL.appendingPathComponent("Foo").path, contents: Data())
 
-        let xpcResolved = resolveBundleExecutableURL(
+        let xpcResolved = resolveBundleExecutable(
             xpcURL,
             fileManager: FileManager.default,
-            bundleURLs: { _ in nil }
+            bundleExecutableURL: { _ in nil }
         )
-        #expect(xpcResolved?.path == xpcURL.appendingPathComponent("Foo").path)
+        #expect(xpcResolved.loadURL == xpcURL.appendingPathComponent("Foo"))
+        guard case .bundle(let xpcOutputBundleURL) = xpcResolved.outputIdentity else {
+            Issue.record("expected XPC bundle output identity")
+            return
+        }
+        #expect(xpcOutputBundleURL == xpcURL)
 
         let appexURL = dirs.root.appendingPathComponent("Bar.appex", isDirectory: true)
         try FileManager.default.createDirectory(at: appexURL, withIntermediateDirectories: true)
         _ = FileManager.default.createFile(atPath: appexURL.appendingPathComponent("Bar").path, contents: Data())
 
-        let appexResolved = resolveBundleExecutableURL(
+        let appexResolved = resolveBundleExecutable(
             appexURL,
             fileManager: FileManager.default,
-            bundleURLs: { _ in nil }
+            bundleExecutableURL: { _ in nil }
         )
-        #expect(appexResolved?.path == appexURL.appendingPathComponent("Bar").path)
+        #expect(appexResolved.loadURL == appexURL.appendingPathComponent("Bar"))
+        guard case .bundle(let appexOutputBundleURL) = appexResolved.outputIdentity else {
+            Issue.record("expected app extension bundle output identity")
+            return
+        }
+        #expect(appexOutputBundleURL == appexURL)
     }
 }
 


### PR DESCRIPTION
## Summary

- separate executable load paths from typed output identities so renamed, versioned, Cryptex-backed, and cache-only bundles stage under the caller-selected bundle root
- classify target-local raw staging collection and validation anomalies as failed targets so later targets continue
- add regression coverage for versioned executables, cache-only renamed aliases, staging mismatch continuation, hidden payloads, and resume behavior

## Validation

- `swift test` — 549 tests in 42 suites
- iOS Simulator cross-compile — `PrivateHeaderKitCore` and `PrivateHeaderKitCoreTests`
- watchOS Simulator cross-compile — `PrivateHeaderKitCore`, `PrivateHeaderKitCoreTests`, and `privateheaderkit-sim-helper`
- watchOS 26.5 (23T570) runtime smoke — `MobileSpotlightIndex` and `SpotlightIndex` both generated successfully into distinct output roots, with five files each and no public `Versions` subtree
- `git diff --check`
- branch-wide `codex-review` against pinned `main` (`8a9d458`) — 0 findings

Closes #74
